### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,5 +1,8 @@
 name: Setup & Install with Error Handling
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/InvoicePlane/InvoicePlane-v2/security/code-scanning/5](https://github.com/InvoicePlane/InvoicePlane-v2/security/code-scanning/5)

In general, this problem is fixed by explicitly specifying the minimal required `permissions` for the `GITHUB_TOKEN` at the workflow root or per-job level. For this workflow, the job only needs to read repository contents (for `actions/checkout@v4`) and write to logs/summary, which do not require any additional GitHub API scopes beyond `contents: read`. It does not modify repository data, issues, or pull requests, so we can safely restrict permissions to `contents: read`.

The best fix with no functional change is to add a root‑level `permissions` block near the top of `.github/workflows/setup.yml`, just after the `name:` line and before the `on:` key. This will apply to all jobs (here, only `setup`) that don’t override permissions. Specifically: insert

```yaml
permissions:
  contents: read
```

so the file begins with `name: ...`, then `permissions:`, then the current `on:` block. No imports or other definitions are needed, since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
