### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -7,6 +7,8 @@ jobs:
   quickstart:
     name: Quickstart Bootstrap & Smoke Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     # MySQL service commented out - smoke tests should not require database setup
     # services:


### PR DESCRIPTION
Potential fix for [https://github.com/InvoicePlane/InvoicePlane-v2/security/code-scanning/4](https://github.com/InvoicePlane/InvoicePlane-v2/security/code-scanning/4)

In general, to fix this issue you should add a `permissions:` block that grants only the minimal scopes required by the workflow or job. If the workflow doesn’t need to modify repository contents, issues, or pull requests, you can usually set `contents: read` and omit other scopes.

For this specific workflow, the `quickstart` job only checks out code, installs dependencies, builds assets, runs migrations, and executes tests. None of these require write access to the repository or other GitHub resources. The best fix is to add a `permissions:` section under the `quickstart` job with `contents: read`. This limits the `GITHUB_TOKEN` while preserving all existing behavior. Concretely, edit `.github/workflows/quickstart.yml` and insert:

```yaml
    permissions:
      contents: read
```

immediately under `runs-on: ubuntu-latest` (line 9 in the provided snippet), keeping the same indentation level as `runs-on`. No imports or additional methods are required; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
