### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,5 +1,8 @@
 name: Run PHPUnit Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:  # Manual only — does not run automatically
 


### PR DESCRIPTION
Potential fix for [https://github.com/InvoicePlane/InvoicePlane-v2/security/code-scanning/3](https://github.com/InvoicePlane/InvoicePlane-v2/security/code-scanning/3)

Generally, the fix is to explicitly declare a `permissions:` block that grants only the minimal required privileges to `GITHUB_TOKEN`. For this PHPUnit workflow, the steps only need to read repository contents (for `actions/checkout`) and run commands; they do not push commits, manage issues, or update pull requests, so `contents: read` is sufficient.

The best minimal, non‑breaking fix is to add a `permissions:` block at the workflow root (top level, alongside `name:` and `on:`), so it applies to all jobs in this workflow. Concretely, in `.github/workflows/phpunit.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` keys (e.g., after line 1). No imports or additional methods are needed, since this is just YAML configuration. No other lines in the file need to be touched.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions for improved security configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->