### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -3,6 +3,10 @@ name: PHPStan Analysis
 on:
   workflow_dispatch:  # Manual only — does not run automatically
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   phpstan:
     name: Static Analysis with PHPStan


### PR DESCRIPTION
Potential fix for [https://github.com/InvoicePlane/InvoicePlane-v2/security/code-scanning/2](https://github.com/InvoicePlane/InvoicePlane-v2/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block and restrict the `GITHUB_TOKEN` to the minimum required scopes. Since this workflow only needs to read the repository contents (for checkout and running analysis) and write comments on pull requests, we can set `contents: read` and `pull-requests: write`. No job in this workflow needs broader write access.

The best fix with minimal impact is to add a `permissions` section at the workflow root (top level, alongside `name` and `on`). This will apply to the `phpstan` job automatically, because it has no job-level `permissions` block. Concretely, in `.github/workflows/phpstan.yml`, add:

```yaml
permissions:
  contents: read
  pull-requests: write
```

between the `on:` block and the `jobs:` block. No imports or additional code are required; this is purely a YAML configuration change inside the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to refine permissions settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->