### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: Docker Compose Check (Disabled)
 
+permissions:
+  contents: read
+
 # This workflow is DISABLED by default.
 # To enable it:
 # - Remove/comment out the line: `workflow_dispatch:`


### PR DESCRIPTION
Potential fix for [https://github.com/InvoicePlane/InvoicePlane-v2/security/code-scanning/1](https://github.com/InvoicePlane/InvoicePlane-v2/security/code-scanning/1)

To fix the problem, explicitly set minimal `GITHUB_TOKEN` permissions for this workflow or job. Since the job only checks out code and runs local Docker commands, it needs at most read access to repository contents. The simplest, least-privilege fix is to add `permissions: contents: read` at the workflow root so it applies to all jobs (current and future) in this file.

Concretely:
- Edit `.github/workflows/docker.yml`.
- Insert a `permissions:` block after the `name:` (line 1) and before `on:` (line 8).  
- Set `contents: read` as the only permission, which is sufficient for `actions/checkout@v4`.

No additional imports, methods, or other definitions are required, since this is a YAML workflow config change only and does not alter job behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance repository access permissions.

**Note:** This is an internal infrastructure update with no direct impact on user-facing features or functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->