### PR TITLE
Remove duplicate it_lists_companies test to fix fatal redeclare

### DIFF
--- a/Modules/Core/Tests/Feature/CompaniesTest.php
+++ b/Modules/Core/Tests/Feature/CompaniesTest.php
@@ -151,32 +151,6 @@ class CompaniesTest extends AbstractAdminPanelTestCase
     }
     # endregion
 
-    # region crud
-    #[Test]
-    #[Group('crud')]
-    /**
-     * @payload {
-     *   "search_code": "IVPLV2",
-     *   "name": "InvoicePlane Corp"
-     * }
-     */
-    #[Group('crud')]
-    public function it_lists_companies(): void
-    {
-        /* arrange */
-        $company = Company::factory()->create(['name' => 'Acme LLC']);
-
-        /* act */
-        $component = Livewire::actingAs($this->superAdmin())
-            ->test(ListCompanies::class);
-
-        /* assert */
-        $component->assertSuccessful();
-
-        $this->assertDatabaseHas('companies', $company->toArray());
-    }
-    # endregion
-
     # region modals
     #[Test]
     #[Group('modals')]


### PR DESCRIPTION
### Motivation
- Prevent a PHPUnit fatal `Cannot redeclare` error caused by two methods named `it_lists_companies()` in the same test class. 
- Ensure the test class `Modules/Core/Tests/Feature/CompaniesTest.php` loads cleanly so CI/test runs do not abort during test discovery.

### Description
- Deleted the duplicated `it_lists_companies()` method block from `Modules/Core/Tests/Feature/CompaniesTest.php` so only a single implementation remains. 
- Kept the other related tests and regions intact and did not introduce behavioral changes to test logic. 
- The change is limited to the single test file and does not modify production code or other test files. 

### Testing
- Ran `php -l Modules/Core/Tests/Feature/CompaniesTest.php` and the file reported no syntax errors. (succeeded)
- Searched for duplicate definitions with `rg "function it_lists_companies" -n Modules/Core/Tests/Feature/CompaniesTest.php` and found a single occurrence. (succeeded)
- Ran `git diff --check` to ensure no whitespace/merge artifacts were introduced. (succeeded)
- Attempted to run `php artisan test Modules/Core/Tests/Feature/CompaniesTest.php --env=testing` but it could not be executed locally because `vendor/autoload.php` is missing in the workspace. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2184ca02848329ab9f9a01809c0cb8)