### PR TITLE
ci: remove develop from push trigger in smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - develop
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Running smoke tests on push to develop is redundant — the pull_request
trigger already covers every commit that touches develop via a PR. This
eliminates the duplicate run that fires on every merge into develop.

https://claude.ai/code/session_01X7cmUzpSuPt6onr8V8vQbH