### PR TITLE
feat: restore DocumentGroup subsystem for further development

### DIFF
--- a/Modules/Core/Database/Factories/DocumentGroupFactory.php
+++ b/Modules/Core/Database/Factories/DocumentGroupFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\Core\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Modules\Core\Enums\DocumentGroupType;
+use Modules\Core\Models\Company;
+use Modules\Core\Models\DocumentGroup;
+
+/**
+ * @extends Factory<DocumentGroup>
+ */
+class DocumentGroupFactory extends Factory
+{
+    protected $model = DocumentGroup::class;
+
+    public function definition(): array
+    {
+        $company   = Company::query()->inRandomOrder()->first() ?? Company::factory()->create();
+        $groupType = $this->faker->randomElement(DocumentGroupType::cases());
+
+        return [
+            'company_id'              => $company->id,
+            'type'                    => $groupType->value,
+            'group_identifier_format' => $groupType->prefix() . '-' . $this->faker->numberBetween(100, 700),
+            'name'                    => $groupType->label(),
+            'left_pad'                => 1,
+            'format'                  => $this->faker->optional()->numerify($groupType->prefix() . '-#####'),
+            'next_id'                 => 1,
+            'reset_number'            => 1,
+            'last_id'                 => 1,
+            'last_year'               => 1,
+            'last_month'              => 1,
+            'last_week'               => 1,
+        ];
+    }
+}

--- a/Modules/Core/Database/Migrations/2009_01_01_000003_create_document_groups_table.php
+++ b/Modules/Core/Database/Migrations/2009_01_01_000003_create_document_groups_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('document_groups', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('company_id');
+            $table->string('type');
+            $table->string('name');
+            $table->string('group_identifier_format');
+            $table->unsignedBigInteger('next_id');
+            $table->unsignedBigInteger('left_pad')->default(0)->index();
+            $table->string('format')->nullable();
+            $table->unsignedBiginteger('reset_number');
+            $table->unsignedBiginteger('last_id');
+            $table->unsignedBiginteger('last_year');
+            $table->unsignedBiginteger('last_month');
+            $table->unsignedBiginteger('last_week');
+
+            $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('document_groups');
+    }
+};

--- a/Modules/Core/Database/Seeders/DocumentGroupsSeeder.php
+++ b/Modules/Core/Database/Seeders/DocumentGroupsSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Modules\Core\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Modules\Core\Models\Company;
+use Modules\Core\Models\DocumentGroup;
+
+class DocumentGroupsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Company::all()->each(function (Company $company): void {
+            DocumentGroup::factory(random_int(2, 3))->create([
+                'company_id' => $company->id,
+            ]);
+        });
+    }
+}

--- a/Modules/Core/Enums/DocumentGroupType.php
+++ b/Modules/Core/Enums/DocumentGroupType.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Modules\Core\Enums;
+
+use Modules\Core\Contracts\LabeledEnum;
+
+enum DocumentGroupType: string implements LabeledEnum
+{
+    case CREDIT_NOTES       = 'credit_notes';
+    case CUSTOMERS          = 'customers';
+    case DRAFTS             = 'drafts';
+    case EXPENSES           = 'expenses';
+    case PRO_FORMA_INVOICES = 'pro_forma_invoices';
+    case PROSPECTS          = 'prospects';
+    case QUOTES             = 'quotes';
+    case RECURRING_INVOICES = 'recurring_invoices';
+    case INVOICES           = 'invoices';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::CREDIT_NOTES       => 'Credit Notes',
+            self::CUSTOMERS          => 'Customers',
+            self::DRAFTS             => 'Drafts',
+            self::EXPENSES           => 'Expenses',
+            self::PRO_FORMA_INVOICES => 'Pro Forma Invoices',
+            self::PROSPECTS          => 'Prospects',
+            self::QUOTES             => 'Quotes',
+            self::RECURRING_INVOICES => 'Recurring Invoices',
+            self::INVOICES           => 'Invoices',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::CREDIT_NOTES       => 'maroon',
+            self::CUSTOMERS          => 'info',
+            self::DRAFTS             => 'gray',
+            self::EXPENSES           => 'secondary',
+            self::PRO_FORMA_INVOICES => 'secondary',
+            self::PROSPECTS          => 'emerald',
+            self::QUOTES             => 'primary',
+            self::RECURRING_INVOICES => 'success',
+            self::INVOICES           => 'green',
+        };
+    }
+
+    public function prefix(): string
+    {
+        return match ($this) {
+            self::CREDIT_NOTES       => 'CRE',
+            self::CUSTOMERS          => 'CST',
+            self::DRAFTS             => 'DRA',
+            self::EXPENSES           => 'EXP',
+            self::PRO_FORMA_INVOICES => 'PFI',
+            self::PROSPECTS          => 'PRP',
+            self::QUOTES             => 'QUO',
+            self::RECURRING_INVOICES => 'REC',
+            self::INVOICES           => 'INV',
+        };
+    }
+}

--- a/Modules/Core/Filament/Admin/Resources/DocumentGroups/DocumentGroupResource.php
+++ b/Modules/Core/Filament/Admin/Resources/DocumentGroups/DocumentGroupResource.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Modules\Core\Filament\Admin\Resources\DocumentGroups;
+
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Modules\Core\Filament\Admin\Resources\DocumentGroups\Pages\ListDocumentGroups;
+use Modules\Core\Filament\Admin\Resources\DocumentGroups\Schemas\DocumentGroupForm;
+use Modules\Core\Filament\Admin\Resources\DocumentGroups\Tables\DocumentGroupsTable;
+use Modules\Core\Models\DocumentGroup;
+
+class DocumentGroupResource extends Resource
+{
+    protected static ?string $model = DocumentGroup::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::DocumentDuplicate;
+
+    public static function form(Schema $schema): Schema
+    {
+        return DocumentGroupForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return DocumentGroupsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListDocumentGroups::route('/'),
+        ];
+    }
+}

--- a/Modules/Core/Filament/Admin/Resources/DocumentGroups/Pages/CreateDocumentGroup.php
+++ b/Modules/Core/Filament/Admin/Resources/DocumentGroups/Pages/CreateDocumentGroup.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\Core\Filament\Admin\Resources\DocumentGroups\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Modules\Core\Filament\Admin\Resources\DocumentGroups\DocumentGroupResource;
+
+class CreateDocumentGroup extends CreateRecord
+{
+    protected static string $resource = DocumentGroupResource::class;
+}

--- a/Modules/Core/Filament/Admin/Resources/DocumentGroups/Pages/EditDocumentGroup.php
+++ b/Modules/Core/Filament/Admin/Resources/DocumentGroups/Pages/EditDocumentGroup.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Modules\Core\Filament\Admin\Resources\DocumentGroups\Pages;
+
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Modules\Core\Filament\Admin\Resources\DocumentGroups\DocumentGroupResource;
+
+class EditDocumentGroup extends EditRecord
+{
+    protected static string $resource = DocumentGroupResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/Modules/Core/Filament/Admin/Resources/DocumentGroups/Pages/ListDocumentGroups.php
+++ b/Modules/Core/Filament/Admin/Resources/DocumentGroups/Pages/ListDocumentGroups.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\Core\Filament\Admin\Resources\DocumentGroups\Pages;
+
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Modules\Core\Filament\Admin\Resources\DocumentGroups\DocumentGroupResource;
+use Modules\Core\Services\DocumentGroupService;
+
+class ListDocumentGroups extends ListRecords
+{
+    protected static string $resource = DocumentGroupResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make()
+                ->mutateDataUsing(function (array $data) {
+                    return $data;
+                })
+                ->action(function (array $data) {
+                    app(DocumentGroupService::class)->createDocumentGroup($data);
+                })
+                ->modalWidth('full'),
+        ];
+    }
+}

--- a/Modules/Core/Filament/Admin/Resources/DocumentGroups/Schemas/DocumentGroupForm.php
+++ b/Modules/Core/Filament/Admin/Resources/DocumentGroups/Schemas/DocumentGroupForm.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Modules\Core\Filament\Admin\Resources\DocumentGroups\Schemas;
+
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Modules\Core\Models\DocumentGroup;
+
+class DocumentGroupForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                //
+                // Top: two-column split
+                //
+                Section::make()
+                    ->schema([
+                        Grid::make(2)
+                            ->schema([
+                                // ── LEFT: just the Name
+                                Schemas\Components\Group::make()
+                                    ->schema([
+                                        TextInput::make('name')
+                                            ->label(trans('ip.name'))
+                                            ->required(),
+                                        TextInput::make('group_identifier_format')
+                                            ->label(trans('ip.group_identifier_format'))
+                                            ->required(),
+                                    ])
+                                    ->columnSpan(1),
+
+                                // ── RIGHT: Next ID / Left Pad / Template Tags
+                                Grid::make()
+                                    ->schema([
+                                        TextInput::make('next_id')
+                                            ->label(trans('ip.next_id'))
+                                            ->numeric()
+                                            ->required(),
+
+                                        TextInput::make('left_pad')
+                                            ->label(trans('ip.left_pad'))
+                                            ->numeric(),
+                                    ])
+                                    ->columnSpan(1),
+                            ]),
+                    ])
+                    ->columnSpanFull(),  // Ensures the entire section spans full width
+
+                //
+                // Below: formatting + tag-picker + helper
+                //
+                Section::make()
+                    ->schema([
+                        Grid::make(2)
+                            ->columns(2)
+                            ->schema([
+                                Schemas\Components\Group::make()->schema([
+                                    TextInput::make('format')
+                                        ->label(trans('ip.identifier_formatting'))
+                                        ->placeholder('{{month}}-{{day}}-{{number}}')
+                                        ->required(),
+                                    Select::make('__tag_to_insert')
+                                        ->label(trans('ip.template_tags'))
+                                        ->options(DocumentGroup::availableTags())
+                                        ->placeholder(trans('ip.select_tag'))
+                                        ->dehydrated(false)
+                                        ->reactive()
+                                        ->afterStateUpdated(function (callable $set, callable $get, $state): void {
+                                            $current = $get('format') ?? '';
+                                            $set('format', $current . $state);
+                                            $set('__tag_to_insert', null);
+                                        }),
+                                ]),
+                                Schemas\Components\Group::make()->schema([
+                                    Placeholder::make('format_helper')
+                                        ->label('')
+                                        ->content(trans('ip.identifier_format_template_tags_instructions'))
+                                        ->columnSpanFull(),
+                                ]),
+                            ]),
+                    ])
+                    ->columnSpanFull(),  // Ensures the entire section spans full width
+            ]);
+    }
+}

--- a/Modules/Core/Filament/Admin/Resources/DocumentGroups/Tables/DocumentGroupsTable.php
+++ b/Modules/Core/Filament/Admin/Resources/DocumentGroups/Tables/DocumentGroupsTable.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Modules\Core\Filament\Admin\Resources\DocumentGroups\Tables;
+
+use Filament\Actions\ActionGroup;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Modules\Core\Enums\DocumentGroupType;
+use Modules\Core\Helpers\EnumHelper;
+use Modules\Core\Models\DocumentGroup;
+use Modules\Core\Services\DocumentGroupService;
+
+class DocumentGroupsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('type')
+                    ->limit(10)
+                    ->formatStateUsing(function ($state) {
+                        if ($state instanceof DocumentGroupType) {
+                            return $state->label();
+                        }
+
+                        $status = EnumHelper::safeEnum(DocumentGroupType::class, $state);
+
+                        return $status?->label() ?? '-';
+                    })
+                    ->color(function ($state) {
+                        if ($state instanceof DocumentGroupType) {
+                            return $state->color();
+                        }
+
+                        $status = EnumHelper::safeEnum(DocumentGroupType::class, $state);
+
+                        return $status?->color() ?? 'secondary';
+                    })
+                    ->badge()
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('name')
+                    ->limit(10)->searchable()->sortable()->toggleable(),
+                TextColumn::make('group_identifier_format')
+                    ->searchable()->sortable()->toggleable(),
+                TextColumn::make('left_pad')
+                    ->numeric()
+                    ->searchable()->sortable()->toggleable(),
+                TextColumn::make('format')
+                    ->limit(10)->searchable()->sortable()->toggleable(),
+                TextColumn::make('next_id')
+                    ->numeric()
+                    ->searchable()->sortable()->toggleable(),
+            ])
+            ->filters([
+            ])
+            ->actions([
+                ActionGroup::make([
+                    EditAction::make()
+                        ->mutateDataUsing(function (array $data, DocumentGroup $record) {
+                            $data['name'] = $record->name;
+
+                            return $data;
+                        })
+                        ->action(function (DocumentGroup $record, array $data) {
+                            app(DocumentGroupService::class)->update($record, $data);
+                        })
+                        ->modalWidth('full'),
+                ]),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/Modules/Core/Models/DocumentGroup.php
+++ b/Modules/Core/Models/DocumentGroup.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Modules\Core\Models;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Modules\Core\Database\Factories\DocumentGroupFactory;
+use Modules\Core\Enums\DocumentGroupType;
+use Modules\Core\Traits\BelongsToCompany;
+use Modules\Invoices\Models\Invoice;
+use Modules\Invoices\Models\RecurringInvoice;
+use Modules\Quotes\Models\Quote;
+
+/**
+ * @property int                           $id
+ * @property int                           $company_id
+ * @property string                        $type
+ * @property string                        $name
+ * @property string                        $group_identifier_format
+ * @property int                           $next_id
+ * @property int                           $left_pad
+ * @property string|null                   $format
+ * @property int                           $reset_number
+ * @property int                           $last_id
+ * @property int                           $last_year
+ * @property int                           $last_month
+ * @property int                           $last_week
+ * @property Company                       $company
+ * @property Collection|Invoice[]          $invoices
+ * @property Collection|Quote[]            $quotes
+ * @property Collection|RecurringInvoice[] $recurring_invoices
+ */
+class DocumentGroup extends Model
+{
+    use BelongsToCompany;
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $casts = [
+        'type' => DocumentGroupType::class,
+    ];
+
+    protected $guarded = [];
+
+    /*
+    |--------------------------------------------------------------------------
+    | Static Methods
+    |--------------------------------------------------------------------------
+    */
+    /**
+     * Return all the “template–insertion” tags you want
+     * to offer in your form dropdown.
+     */
+    public static function availableTags(): array
+    {
+        return [
+            '{{yy}}'    => trans('ip.year_short'),    // e.g. “23”
+            '{{year}}'  => trans('ip.year_full'),     // e.g. “2023”
+            '{{month}}' => trans('ip.month'),         // e.g. “04”
+            '{{day}}'   => trans('ip.day'),           // e.g. “27”
+            '{{id}}'    => trans('ip.id'),            // e.g. “42”
+        ];
+    }
+
+    public static function findIdByName($name)
+    {
+        if ($group = self::where('name', $name)->first()) {
+            return $group->id;
+        }
+    }
+
+    public static function generateNumber($id): array|string
+    {
+        $group = self::query()->find($id);
+
+        // Only check for resets if this group has been used.
+        if ($group->last_id != 0) {
+            // Check for yearly reset.
+            if ($group->reset_number == 1) {
+                if ($group->last_year != date('Y')) {
+                    $group->next_id = 1;
+                    $group->save();
+                }
+            } // Check for monthly reset.
+            elseif ($group->reset_number == 2) {
+                if ($group->last_month != date('m') || $group->last_year != date('Y')) {
+                    $group->next_id = 1;
+                    $group->save();
+                }
+            } // Check for weekly reset.
+            elseif ($group->reset_number == 3) {
+                if ($group->last_week != date('W') || $group->last_month != date('m') || $group->last_year != date('Y')) {
+                    $group->next_id = 1;
+                    $group->save();
+                }
+            }
+        }
+
+        $number = $group->format;
+
+        $number = str_replace('{NUMBER}', mb_str_pad($group->next_id, $group->left_pad, '0', STR_PAD_LEFT), $number);
+        $number = str_replace('{YEAR}', date('Y'), $number);
+        $number = str_replace('{MONTH}', date('m'), $number);
+        $number = str_replace('{WEEK}', date('W'), $number);
+        $number = str_replace('{MONTHSHORTNAME}', date('M'), $number);
+
+        $group->last_id    = $group->next_id;
+        $group->last_week  = date('W');
+        $group->last_month = date('m');
+        $group->last_year  = date('Y');
+        $group->save();
+
+        return $number;
+    }
+
+    public static function getList()
+    {
+        return self::orderBy('name')->pluck('name', 'id')->all();
+    }
+
+    public static function incrementNextId($document): void
+    {
+        $group          = self::query()->find($document->group_id);
+        $group->last_id = $group->next_id;  // Setting last_id to old nex_id before increment
+        $group->next_id = $group->next_id + 1;
+        $group->save();
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Relationships
+    |--------------------------------------------------------------------------
+    */
+    public function invoices(): HasMany
+    {
+        return $this->hasMany(Invoice::class, 'document_group_id');
+    }
+
+    public function quotes(): HasMany
+    {
+        return $this->hasMany(Quote::class, 'document_group_id');
+    }
+
+    public function recurringInvoices(): HasMany
+    {
+        return $this->hasMany(RecurringInvoice::class);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Factories
+    |--------------------------------------------------------------------------
+    */
+    protected static function newFactory(): Factory
+    {
+        return DocumentGroupFactory::new();
+    }
+}

--- a/Modules/Core/Observers/DocumentGroupObserver.php
+++ b/Modules/Core/Observers/DocumentGroupObserver.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Modules\Core\Observers;
+
+class DocumentGroupObserver extends AbstractObserver {}

--- a/Modules/Core/Repositories/DocumentGroupRepository.php
+++ b/Modules/Core/Repositories/DocumentGroupRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Modules\Core\Repositories;
+
+use Illuminate\Database\Eloquent\Builder;
+use Modules\Core\Models\DocumentGroup;
+
+class DocumentGroupRepository
+{
+    /**
+     * Find a document group by company ID, type, and optionally by name.
+     *
+     * @param int         $companyId
+     * @param string      $type
+     * @param string|null $name
+     *
+     * @return DocumentGroup|null
+     */
+    public function findByCompanyAndType(
+        int $companyId,
+        string $type,
+        ?string $name = null
+    ): ?DocumentGroup {
+        return DocumentGroup::query()
+            ->where('type', $type)
+            ->when($name, function (Builder $query) use ($name) {
+                return $query->where('name', $name);
+            })
+            ->first();
+    }
+}

--- a/Modules/Core/Services/DocumentGroupService.php
+++ b/Modules/Core/Services/DocumentGroupService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Modules\Core\Services;
+
+use Modules\Core\Enums\DocumentGroupType;
+use Modules\Core\Models\DocumentGroup;
+
+class DocumentGroupService extends BaseService
+{
+    public function model(): string
+    {
+        return DocumentGroup::class;
+    }
+
+    public function createDocumentGroup(array $data): DocumentGroup
+    {
+        return DocumentGroup::query()->create([
+            'company_id'              => $this->getCompanyId() ?? 1,
+            'type'                    => $data['type'] ?? DocumentGroupType::CUSTOMERS->value,
+            'group_identifier_format' => $data['group_identifier_format'],
+            'name'                    => $data['name'],
+            'left_pad'                => $data['left_pad'],
+            'format'                  => $data['format'] ?? null,
+            'next_id'                 => $data['next_id'] ?? 43748,
+            'reset_number'            => $data['reset_number'] ?? 34343,
+            'last_id'                 => $data['last_id'] ?? 437843,
+            'last_year'               => $data['last_year'] ?? 2025,
+            'last_month'              => $data['last_month'] ?? 6,
+            'last_week'               => $data['last_week'] ?? 23,
+        ]);
+    }
+
+    public function updateDocumentGroup(DocumentGroup $documentGroup, $data): DocumentGroup
+    {
+        $documentGroup->update([
+            'company_id'              => $data['company_id'],
+            'type'                    => $data['type'],
+            'group_identifier_format' => $data['group_identifier_format'],
+            'name'                    => $data['name'],
+            'left_pad'                => $data['left_pad'],
+            'format'                  => $data['format'] ?? null,
+            'next_id'                 => $data['next_id'],
+            'reset_number'            => $data['reset_number'],
+            'last_id'                 => $data['last_id'],
+            'last_year'               => $data['last_year'],
+            'last_month'              => $data['last_month'],
+            'last_week'               => $data['last_week'],
+        ]);
+
+        return $documentGroup;
+    }
+}

--- a/Modules/Core/Tests/Feature/DocumentGroupsTest.php
+++ b/Modules/Core/Tests/Feature/DocumentGroupsTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Modules\Core\Tests\Feature;
+
+use Livewire\Livewire;
+use Modules\Core\Enums\DocumentGroupType;
+use Modules\Core\Filament\Admin\Resources\DocumentGroups\DocumentGroupResource;
+use Modules\Core\Filament\Admin\Resources\DocumentGroups\Pages\CreateDocumentGroup;
+use Modules\Core\Filament\Admin\Resources\DocumentGroups\Pages\EditDocumentGroup;
+use Modules\Core\Filament\Admin\Resources\DocumentGroups\Pages\ListDocumentGroups;
+use Modules\Core\Models\DocumentGroup;
+use Modules\Core\Tests\AbstractAdminPanelTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(DocumentGroupResource::class)]
+class DocumentGroupsTest extends AbstractAdminPanelTestCase
+{
+    # region smoke
+    #[Test]
+    #[Group('smoke')]
+    /**
+     * @payload ['name' => 'Policies']
+     */
+    #[Group('crud')]
+    public function it_lists_document_groups(): void
+    {
+        /* arrange */
+        $group = DocumentGroup::factory()->create(['name' => 'Policies']);
+
+        /* act */
+        $component = Livewire::actingAs($this->superAdmin())
+            ->test(ListDocumentGroups::class);
+
+        /* assert */
+        $component->assertSuccessful();
+
+        $this->assertDatabaseHas('document_groups', $group->toArray());
+    }
+    # endregion
+
+    # region modals
+    #[Test]
+    #[Group('crud')]
+    public function it_creates_a_document_group_trough_a_modal(): void
+    {
+        $groupType = DocumentGroupType::CUSTOMERS;
+
+        /* arrange */
+        $payload = [
+            'type'                    => $groupType,
+            'group_identifier_format' => $groupType->prefix() . '-656',
+            'name'                    => $groupType->label(),
+            'left_pad'                => 1,
+            'format'                  => $groupType->prefix() . '-4376656',
+            'next_id'                 => 1,
+            'reset_number'            => 34343,
+            'last_id'                 => 437843,
+            'last_year'               => 2025,
+            'last_month'              => 6,
+            'last_week'               => 23,
+        ];
+
+        /* act */
+        $component = Livewire::actingAs($this->superAdmin())
+            ->test(ListDocumentGroups::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* assert */
+        $component->assertSuccessful();
+        $component->assertHasNoFormErrors();
+        $this->assertDatabaseHas('document_groups', $payload);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_fails_to_create_a_document_group_trough_a_modal_when_group_identifier_format_missing(): void
+    {
+        $groupType = DocumentGroupType::CUSTOMERS;
+
+        /* arrange */
+        $payload = [
+            'type'         => $groupType,
+            'name'         => $groupType->label(),
+            'left_pad'     => 1,
+            'format'       => $groupType->prefix() . '-4376656',
+            'next_id'      => 1,
+            'reset_number' => 34343,
+            'last_id'      => 437843,
+            'last_year'    => 2025,
+            'last_month'   => 6,
+            'last_week'    => 23,
+        ];
+
+        /* act */
+        $component = Livewire::actingAs($this->superAdmin())
+            ->test(ListDocumentGroups::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* assert */
+        $component->assertHasFormErrors();
+
+        $this->assertDatabaseMissing('document_groups', $payload);
+    }
+    # endregion
+
+    # region crud
+    #[Test]
+    #[Group('crud')]
+    public function it_creates_a_document_group(): void
+    {
+        $this->markTestIncomplete();
+
+        /* arrange */
+
+        $payload = ['name' => 'Forms'];
+
+        /* act */
+        $component = Livewire::actingAs($this->superAdmin())->test(CreateDocumentGroup::class)->fillForm($payload)->call('create');
+
+        /* assert */
+        $component
+            ->assertSuccessful()
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('document_groups', $payload);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_fails_to_create_document_group_when_name_missing(): void
+    {
+        $this->markTestIncomplete();
+
+        /* arrange */
+
+        $payload = [];
+
+        /* act */
+        $component = Livewire::actingAs($this->superAdmin())->test(CreateDocumentGroup::class)->fillForm($payload)->call('create');
+
+        /* assert */
+        $component->assertHasFormErrors(['name']);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_updates_a_document_group(): void
+    {
+        $this->markTestIncomplete();
+
+        /* arrange */
+
+        $group = DocumentGroup::factory()->create(['name' => 'Old Group']);
+
+        $payload = ['name' => 'Updated Group'];
+
+        /* act */
+        $component = Livewire::actingAs($this->superAdmin())->test(EditDocumentGroup::class, ['record' => $group->id])->fillForm($payload)->call('save');
+
+        /* assert */
+        $component
+            ->assertSuccessful()
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('document_groups', $payload);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_deletes_a_document_group(): void
+    {
+        $this->markTestIncomplete();
+
+        /* arrange */
+
+        $group = DocumentGroup::factory()->create();
+
+        /* act */
+        $component = Livewire::actingAs($this->superAdmin())->test(ListDocumentGroups::class)->callTableAction('delete', $group);
+
+        $this->assertDatabaseMissing('document_groups', ['id' => $group->id]);
+    }
+    # endregion
+}


### PR DESCRIPTION
The DocumentGroup resource (model, migration, service, factory, seeder, observer, Filament resource, tests) was removed from develop during a code review cleanup. It is preserved here for future work — it may be adapted, renamed, or replaced by the Numbering system.