### PR TITLE
fix(forms): filter numbering selector by document type (#152)

### DIFF
--- a/Modules/Invoices/Filament/Company/Resources/Invoices/Schemas/InvoiceForm.php
+++ b/Modules/Invoices/Filament/Company/Resources/Invoices/Schemas/InvoiceForm.php
@@ -14,6 +14,7 @@ use Filament\Schemas;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Modules\Core\Enums\NumberingType;
 use Modules\Invoices\Enums\InvoiceStatus;
 use Modules\Invoices\Support\InvoiceCalculator;
 use Modules\Products\Models\Product;
@@ -91,7 +92,7 @@ class InvoiceForm
 
                                         Select::make('numbering_id')
                                             ->label(trans('ip.numbering'))
-                                            ->relationship('numbering', 'name')
+                                            ->relationship('numbering', 'name', fn ($query) => $query->where('type', NumberingType::INVOICE->value))
                                             ->required()
                                             ->searchable()
                                             ->preload()

--- a/Modules/Quotes/Filament/Company/Resources/Quotes/Schemas/QuoteForm.php
+++ b/Modules/Quotes/Filament/Company/Resources/Quotes/Schemas/QuoteForm.php
@@ -15,6 +15,7 @@ use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
+use Modules\Core\Enums\NumberingType;
 use Modules\Products\Models\Product;
 use Modules\Quotes\Enums\QuoteStatus;
 use Modules\Quotes\Support\QuoteCalculator;
@@ -98,7 +99,7 @@ class QuoteForm
 
                                         Select::make('numbering_id')
                                             ->label(trans('ip.numbering'))
-                                            ->relationship('numbering', 'name')
+                                            ->relationship('numbering', 'name', fn ($query) => $query->where('type', NumberingType::QUOTE->value))
                                             ->required()
                                             ->searchable()
                                             ->preload()


### PR DESCRIPTION
## Summary

- `QuoteForm`: numbering selector now filters to `type = Quote` only
- `InvoiceForm`: numbering selector now filters to `type = Invoice` only
- Previously both forms showed **all** numbering schemes, so an invoice could be accidentally assigned a Quote numbering scheme (wrong prefix/sequence) and vice versa

## Root cause

Both `Select::make('numbering_id')->relationship('numbering', 'name')` calls had no type constraint. The `Numbering` model's global `BelongsToCompany` scope already filters by company, but `NumberingType` (Invoice vs Quote) was not filtered at all.

## Test plan

- [ ] Open the Invoice create/edit form → numbering dropdown shows only Invoice-type schemes
- [ ] Open the Quote create/edit form → numbering dropdown shows only Quote-type schemes
- [ ] Numberings from another company do not appear (pre-existing BelongsToCompany scope)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice forms now display only invoice-type numbering options
  * Quote forms now display only quote-type numbering options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->