### PR TITLE
Add CLAUDE.md with full project knowledge map

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,444 +1,287 @@
-# GitHub Copilot Context
-
-This is the default Copilot prompt for this project.
+# GitHub Copilot Instructions — InvoicePlane v2
 
 ## How to Use These Instructions
 
-**IMPORTANT:** These instructions contain comprehensive information about the InvoicePlane v2 codebase, architecture, and development workflow. **Trust these instructions** and use them as your primary reference. Only perform additional searches if:
-- The information you need is not covered here
-- You encounter an error that contradicts these instructions
-- You need to locate specific files or code not referenced here
+These instructions contain verified facts about the InvoicePlane v2 codebase. **Trust them** — only search the repo when something is not covered here or contradicts what you find.
 
-Following these guidelines will significantly reduce exploration time and prevent common mistakes.
+---
 
-## Project Description
+## Verified Tech Stack
 
-This project is **InvoicePlane v2**, a **multi-tenant Laravel application** with a **modular architecture**.
-
-- The application uses **Laravel Filament** for Admin Panel, Company Panel, and InvoicePanel interfaces.
-- Code is structured into **Modules**, each module encapsulating its own logic (models, services, repositories, DTOs,
- transformers, tests, etc.).
-- Tests for each module are located in:
- `/Modules/(ModuleName)/Tests`
-
-## Tech Stack
-
-- **Backend:** Laravel 12+ (PHP 8.2+)
-- **UI Framework:** Filament 4.0
-- **Frontend:** Livewire, Tailwind CSS
-- **Testing:** PHPUnit 11+
-- **Code Quality:** Laravel Pint (PSR-12), PHPStan, Rector
-- **Module System:** nwidart/laravel-modules
-- **Permissions:** spatie/laravel-permission
+- **Framework:** Laravel **11** (PHP **8.1**+) — not 12/8.2
+- **UI:** Filament **4.0** + Livewire **3**
+- **Modules:** `nwidart/laravel-modules`
+- **Permissions:** `spatie/laravel-permission`
 - **Multi-tenancy:** Filament Companies with `BelongsToCompany` trait
-- **Queue System:** Required for export functionality (Redis, database, or sync for local development)
+- **DB (production):** MariaDB 11
+- **DB (tests):** SQLite `:memory:` or MariaDB 11 (CI)
+- **Code quality:** Laravel Pint (PSR-12), PHPStan, Rector
 
-## Development Commands
-
-### Testing
-```bash
-# Run all tests (typically 30-60 seconds)
-php artisan test
-
-# Run tests with coverage (typically 60-120 seconds)
-php artisan test --coverage
-
-# Run specific test suite (faster - 10-30 seconds each)
-php artisan test --testsuite=Unit
-php artisan test --testsuite=Feature
-```
-
-**Important:** Always run tests before finalizing changes. All tests must pass.
-
-### Code Quality
-```bash
-# Format code with Laravel Pint (auto-fixes PSR-12 violations)
-vendor/bin/pint
-
-# Run static analysis (typically 20-40 seconds)
-vendor/bin/phpstan analyse
-
-# Run Rector for automated refactoring
-vendor/bin/rector process --dry-run
-```
-
-**Validation Pipeline:** Before submitting code, you MUST run:
-1. `vendor/bin/pint` - Format code
-2. `vendor/bin/phpstan analyse` - Check for type errors
-3. `php artisan test` - Run all tests
-
-### Setup & Installation
-```bash
-# See .github/INSTALLATION.md for detailed setup
-composer install
-cp .env.example .env
-php artisan key:generate
-php artisan migrate --seed
-
-# Start queue worker for export functionality
-php artisan queue:work
-```
-
-**Queue Configuration:**
-- Export functionality requires a queue worker to be running
-- For local development, you can use `QUEUE_CONNECTION=sync` in `.env`
-- For production, use Redis or database queue driver with Supervisor
-
-**GitHub Actions CI/CD:**
-The following automated checks run on every pull request and MUST pass:
-- **PHPUnit** - All tests must pass (`php artisan test`)
-- **PHPStan** - Static analysis must pass with no errors (`vendor/bin/phpstan analyse`)
-- **Pint** - Code must follow PSR-12 standards (`vendor/bin/pint`)
-- **Docker Build** - Docker images must build successfully
-
-See `.github/workflows/` for workflow configurations. Reference `.github/workflows/README.md` for setup details.
-
-## Related Documentation
-
-- **Installation:** `.github/INSTALLATION.md`
-- **Contributing:** `.github/CONTRIBUTING.md`
-- **Seeding:** `.github/SEEDING.md`
-- **Testing:** See test examples in `Modules/*/Tests/`
-- **Commit Conventions:** `.github/git-commit-instructions.md`
+---
 
 ## Project Layout
 
-### Repository Structure
-
 ```
-├── .github/               # Workflows, docs, issue/PR templates, Copilot instructions
-├── Modules/               # All application logic lives here
-│   ├── Clients/           # Client/customer management
-│   ├── Core/              # Shared infrastructure, panels, base test cases
-│   ├── Expenses/          # Expense tracking
-│   ├── Invoices/          # Invoice management + Peppol e-invoicing
-│   ├── Payments/          # Payment processing
-│   ├── Products/          # Product/item catalog
-│   ├── Projects/          # Project management
-│   └── Quotes/            # Quote/estimate management
-├── app/                   # Laravel bootstrap only — business logic is in Modules/
-├── config/                # Laravel configuration files
-├── database/seeders/      # Database seeders
-└── routes/                # web.php, console.php
+app/                    # Thin root — Providers/AppServiceProvider.php only
+Modules/                # ALL business logic lives here
+Modules/Core/Providers/ # All three Filament panel providers
+config/                 # modules.php, ip.php, filament.php, database.php
+database/migrations/    # Only the exports table; all others are per-module
+database/seeders/       # DatabaseSeeder — seeds ivplv2 company + roles + users
+resources/css/filament/ # Per-panel Vite themes
+routes/                 # Empty — all routing is done by Filament panel providers
 ```
 
-### Module Directory Conventions
+### Modules
 
-Every module follows the same internal structure:
+| Module | Key models |
+|--------|-----------|
+| Core | User, Company, CompanyUser, TaxRate, Numbering, EmailTemplate, CustomField, Upload, Note, AuditLog, Setting, MailQueue |
+| Clients | Relation (table: `relations`), Contact, Address, Communication, ClientCustom (PK: `client_custom_id`) |
+| Invoices | Invoice, InvoiceItem, RecurringInvoice |
+| Quotes | Quote, QuoteItem |
+| Payments | Payment |
+| Products | Product, ProductUnit, ProductCategory |
+| Projects | Project, Task |
+| Expenses | Expense, ExpenseCategory, ExpenseItem |
+
+### Module internal layout
 
 ```
-Modules/{Name}/
-├── Database/              # Migrations and model factories
-├── Enums/                 # PHP 8.1+ enums (used in $casts)
-├── Events/ & Listeners/   # Domain events and their listeners
-├── Filament/              # Filament UI resources, pages, and components
-│   ├── Admin/             # Admin panel resources (Core module only)
-│   └── Company/           # Company panel resources
-├── Models/                # Eloquent models (no $fillable, no timestamps unless specified)
-├── Observers/             # Eloquent observers
-├── Providers/             # Module service providers
-├── Services/              # Business logic (use Transformers, not raw DTOs)
-├── Support/               # DTOs, Transformers, value objects
-├── Tests/
-│   ├── Unit/              # Unit tests (extend AbstractTestCase)
-│   └── Feature/           # Feature tests (extend AbstractAdminPanelTestCase or AbstractCompanyPanelTestCase)
-└── Traits/                # Shared traits
+Modules/<Name>/
+  Models/
+  Services/               # extend Modules\Core\Services\BaseService
+  Enums/                  # PHP 8.1+ backed string enums
+  Filament/
+    Admin/Resources/      # Admin panel resources
+    Company/Resources/    # Company panel resources — Pages/, Tables/, Schemas/
+  Database/
+    Factories/            # extend AbstractFactory
+    Migrations/           # auto-discovered
+    Seeders/
+  Events/ Listeners/ Observers/
+  Traits/ Helpers/ Http/ Providers/
+  Tests/Feature/ Tests/Unit/
 ```
 
-### Filament Panel Providers
+---
 
-All panel providers are in `Modules/Core/Providers/`:
+## Filament Panels (verified)
 
-| Provider | File | Path | Roles |
-|---|---|---|---|
-| Admin | `AdminPanelProvider.php` | `/admin` | `admin`, `superadmin` |
-| Company | `CompanyPanelProvider.php` | `/company` | authenticated company users |
-| User | `UserPanelProvider.php` | `/user` | end users |
+| Provider | Panel ID | URL path | Tenant | Access |
+|----------|----------|----------|--------|--------|
+| AdminPanelProvider | `admin` | `/admin` | No | super_admin, admin, assist |
+| CompanyPanelProvider | `company` | `` **(root, default)** | Yes — Company by `search_code` | client_admin, client |
+| UserPanelProvider | `user` | `/user` | No | (future) |
 
-### Configuration Files
+> **The company panel path is an empty string** — URLs look like `/ivplv2/dashboard`, not `/company/...`.
 
-| File | Purpose |
-|---|---|
-| `phpunit.xml` | PHPUnit config — Unit suite: `Modules/*/Tests/Unit`, Feature suite: `Modules/*/Tests/Feature` |
-| `phpstan.neon` | PHPStan config (imports `phpstan-baseline.neon` for known suppressions) |
-| `pint.json` | Laravel Pint (PSR-12) code style rules |
-| `rector.php` | Rector automated refactoring rules |
-| `modules_statuses.json` | Which nwidart modules are enabled |
+Panel route naming: `filament.<panel-id>.pages.<slug>` and `filament.<panel-id>.resources.<resource>.<action>`
 
-### Abstract Test Cases (always extend one of these)
+Tenant middleware stack (company panel, persistent):
+1. `SetTenantFromQueryString` — reads `?tenant=<search_code>`, sets session + Filament tenant
+2. `ConfigureTenant` — resolves from route/query/session/user fallback
+3. `EnsureUserCanAccessCompany` — 403 if regular user not in `company_user` pivot
 
-Located in `Modules/Core/Tests/`:
+---
 
-- `AbstractTestCase` — application bootstrap only
-- `AbstractAdminPanelTestCase` — admin panel + `RefreshDatabase`
-- `AbstractCompanyPanelTestCase` — company panel + multi-tenancy + `RefreshDatabase`
+## Roles (verified Spatie values)
 
-## Guidelines
-
-- **SOLID Principles** must be followed at all times.
-- **Early returns** are preferred for readability.
-- **Dynamic programming practices** must be applied where relevant.
-- **Code must be modular and refactored**; avoid inline data setups.
-- **No JSON columns** in Laravel migrations.
-- **No ENUM columns** in Laravel migrations.
-- **Abstractions must reduce dependencies** while ensuring single responsibility.
-- **Centralize shared functionality in Traits** (avoid duplication).
-- **Catch `Error`, `ErrorException`, and `Throwable` separately.**
-- **Class names must always be provided in Markdown code blocks** for approval.
-
-### DTO & Transformer Rules
-
-- **All DTOs must avoid constructors.**
-- DTOs use static named constructors when necessary.
-- DTOs rely on getters and setters for data access.
-- **All DTOs get transformed using Transformers.**
-- **Services must not build DTOs manually**; instead, they must use Transformers directly.
-- **EntityExtractionService must use Transformers** for the entire transformation process.
-- Transformers use `toDto()` and `toModel()` methods.
-
-### API & Service Integration
-
-- **All API requests must go through the Advanced API Client.**
-- No direct API calls in controllers, services, or jobs.
-- Use Laravel’s HTTP client instead of curl or Guzzle.
-- **All transformations must go through Transformers.**
-- **API responses and errors must be logged separately** for debugging.
-- **Upserts must use repository methods** instead of `updateOrCreate`.
-
-### Filament Rules
-
-- **Filament resources must respect proper panel separation and namespaces.**
-- **Resource Generation (via commands):**
- - Must use Filament internal traits (`CanReadModelSchemas`, etc.).
- - No reflection for relationship detection.
- - Separate form and table generators by field type.
- - Keep a configurable `$excludedFields` array.
- - Enums detected via `$casts` and `enum_exists()`.
- - Add docblocks above `form()`, `table()`, `getRelations()` with relationships/fields.
- - Use `copyStubToApp()` instead of inline string replacements.
- - **Preserve the exact method signatures** for Filament resource methods.
- - **Use the correct `Action::make()` syntax** with fluent methods.
- - **Do not display raw `created_at` or `updated_at`** in tables/infolists; use dedicated timestamp columns.
-
-### Testing Rules
-
-- **Unit Tests must follow these rules:**
- - Test functions must be prefixed with `it_` and make grammatical sense (e.g., `it_creates_payment`, `it_validates_invoice_has_customer`).
- - Use `#[Test]` attribute instead of `@test` annotations.
- - Prefer Fakes and Fixtures over Mocks.
- - Place happy paths last in test cases.
- - Reusable logic (e.g., fixtures, setup) must live in abstract test cases, not inline.
- - Tests have inline comment blocks above sections (/* Arrange */, /* Act */, /* Assert */).
- - **CRITICAL:** All tests MUST have an "act" section where variables are defined BEFORE assertions.
- - Tests must be meaningful - avoid simple "ok" checks; validate actual behavior and data.
- - Use data providers for testing multiple scenarios with the same logic.
- - **NEVER extend `Tests\TestCase`** - all tests must extend one of the abstract test cases from `Modules/Core/Tests/`:
-   - `AbstractTestCase` - Basic test case with application bootstrap
-   - `AbstractAdminPanelTestCase` - For admin panel tests with RefreshDatabase
-   - `AbstractCompanyPanelTestCase` - For company panel tests with multi-tenancy
-
-**Test Structure Example:**
 ```php
-#[Test]
-public function it_creates_invoice(): void
-{
-    /* Arrange */
-    $data = ['number' => 'INV-001', 'total' => 100.00];
-    
-    /* Act */
-    $invoice = $this->service->createInvoice($data);  // ❗ Define variable here
-    
-    /* Assert */
-    $this->assertInstanceOf(Invoice::class, $invoice);  // Use it here
+// Modules/Core/Enums/UserRole.php
+UserRole::SUPER_ADMIN    = 'super_admin'    // full access, any panel
+UserRole::ADMIN          = 'admin'
+UserRole::ASSIST         = 'assist'
+UserRole::CUSTOMER_ADMIN = 'client_admin'   // company panel only
+UserRole::CUSTOMER       = 'client'         // company panel only
+
+UserRole::elevated()   // ['super_admin', 'admin', 'assist']
+UserRole::nonAdmin()   // ['client_admin', 'client']
+```
+
+Seeder seeds exactly these five roles. Create DB records before assigning in tests:
+```php
+Role::query()->firstOrCreate(['name' => UserRole::SUPER_ADMIN->value, 'guard_name' => 'web']);
+$user->assignRole(UserRole::SUPER_ADMIN->value);
+```
+
+---
+
+## Key Model Facts
+
+- `User::$timestamps = false` — no created_at/updated_at on users
+- `ClientCustom::$primaryKey = 'client_custom_id'` — non-standard PK
+- `Import::$primaryKey = 'import_id'` — non-standard PK
+- `Relation` model → table `relations` (not `customers`, not `clients`)
+- `Company::search_code` — 10-char unique slug used in URLs (e.g. `ivplv2`)
+- Soft deletes on Invoice, Quote (and their items)
+- `company_user` pivot: columns `id, company_id, user_id` (no timestamps)
+- Default company: `search_code='ivplv2'`, `id=22` (hard-coded in seeder)
+
+`BelongsToCompany` trait (used on every business model):
+- Adds `company()` BelongsTo relationship
+- Adds global scope filtering by `company_id`
+- Auto-injects `company_id` on create from Filament tenant / session / user
+
+---
+
+## Service Layer
+
+All services extend `Modules\Core\Services\BaseService`. **No DTO or Repository layer** — services accept plain arrays and return Eloquent models.
+
+```php
+$service->create(array $data): Model
+$service->find($id): Model
+$service->update(array $input, Model $model): Model
+$service->delete($id): bool
+$service->paginate(int $perPage): LengthAwarePaginator
+$service->getCompanyId(): ?int   // resolves Filament tenant → session → user's company
+```
+
+---
+
+## Testing
+
+### Base classes (Modules/Core/Tests/)
+
+```
+AbstractTestCase               — no RefreshDatabase; pure unit tests
+AbstractAdminPanelTestCase     — RefreshDatabase; panel='admin'; $this->company; $this->superAdmin()
+AbstractCompanyPanelTestCase   — RefreshDatabase; panel='company'; $this->user; $this->company
+```
+
+**NEVER extend `Tests\TestCase`** — always extend one of the three above.
+
+### Test patterns
+
+```php
+// Company panel (most tests):
+class InvoicesTest extends AbstractCompanyPanelTestCase {
+    #[Test]
+    #[Group('smoke')]
+    public function it_lists_invoices(): void {
+        /* Arrange */
+        $invoice = Invoice::factory()->for($this->company)->create();
+
+        /* Act */
+        $component = $this->testLivewire(ListInvoices::class);
+
+        /* Assert */
+        $component->assertSuccessful()->assertSee($invoice->number);
+    }
+}
+
+// Admin panel:
+class UsersTest extends AbstractAdminPanelTestCase {
+    #[Test]
+    public function it_lists_users(): void {
+        Livewire::actingAs($this->superAdmin())->test(ListUsers::class)->assertSuccessful();
+    }
 }
 ```
 
-### Export System Rules
-
-- **Exports use Filament's asynchronous export system** which requires queue workers.
-- **Export tests must use fakes:** `Queue::fake()`, `Storage::fake()`, and verify job dispatching with `Bus::assertChained()`.
-- **The `exports` table is temporary** and managed by Filament for job coordination only.
-- **No export history feature** - export records are ephemeral and auto-prunable.
-- **Queue configuration is required** for export functionality to work in production.
-- See `Modules/Core/Filament/Exporters/README.md` for export architecture details.
-
-### Database & Models
-
-- **No `$fillable` array in Models.**
-- **No `timestamps()` or `softDeletes()` in Migrations** unless explicitly specified.
-- **No `timestamps` or `softDeletes` properties/traits in Models** unless explicitly specified.
-- **Use native PHP type hints** and utilize `$casts` for Enum fields.
-
-### Peppol Integration Rules
-
-- **Peppol service follows Strategy Pattern** for format handlers with 11 supported formats.
-- **PeppolService coordinates** invoice transformation and transmission.
-- **PeppolManagementService handles** integration lifecycle (create, test, validate, send).
-- **Format handlers** must implement validation, transformation, and format-specific logic.
-- **Provider Factory** creates provider-specific clients (e.g., EInvoiceBe).
-- **All API calls** must go through the ApiClient with exception handling.
-- **Logging** is done via LogsApiRequests and LogsPeppolActivity traits.
-- **Events** are dispatched for all major Peppol operations (transmission, validation, etc.).
-
-**All 11 Supported Peppol Format Handlers:**
-1. **CII** - Cross Industry Invoice (UN/CEFACT standard for Germany/France/Austria)
-2. **EHF 3.0** - Norwegian e-invoice format (Elektronisk Handelsformat)
-3. **Factur-X** - French/German hybrid (PDF with embedded XML)
-4. **Facturae 3.2** - Spanish format (mandatory for public administration)
-5. **FatturaPA 1.2** - Italian format (mandatory for all invoices)
-6. **OIOUBL** - Danish e-invoice format
-7. **PEPPOL BIS 3.0** - Default Peppol format (pan-European)
-8. **UBL 2.1** - Universal Business Language (most common)
-9. **UBL 2.4** - Updated UBL with enhanced features
-10. **ZUGFeRD 1.0** - German format (PDF with embedded XML)
-11. **ZUGFeRD 2.0** - Updated German format (compatible with Factur-X)
-
-Each handler is registered in `FormatHandlerFactory` with comprehensive PHPUnit test coverage.
-The factory automatically selects handlers with fallback logic and proper logging.
-
-### Seeding Rules
-
-- Seed 5 default roles (`superadmin`, `admin`, `assistance`, `useradmin`, `user`).
-- Ensure users can belong to accounts when relevant.
-- Admin Panel access restricted to `admin` and `superadmin`.
-
-### Code Refactoring Principles
-
-- **Extract duplicate code** into private/protected methods following Single Responsibility Principle.
-- **Use early returns** to reduce nesting and improve readability.
-- **Validate inputs** at the start of methods and abort/throw exceptions early.
-- **Extract complex conditions** into well-named methods.
-- **Use meaningful method names** that describe what they do.
-
-### Internationalization & Translations
-
-**CRITICAL:** InvoicePlane v2 uses `trans()` for all translations, NOT `__()`.
+### Factory patterns
 
 ```php
-// ❌ WRONG - Do not use __()
+User::factory()->withCompany(['search_code' => 'IVPLV2'])->create()
+User::factory()->create(['is_active' => true, 'email_verified_at' => now()])
+Invoice::factory()->for($this->company)->create()   // always ->for($company) on scoped models
+Company::factory()->create(['search_code' => 'acme'])
+```
+
+### Test conventions
+
+- Method names: `it_<verb>_<subject>` (snake_case)
+- Use `#[Test]` attribute (not `@test`)
+- Use `#[Group('smoke|crud|security|authentication|...')]`
+- Structure with `/* Arrange */`, `/* Act */`, `/* Assert */` blocks
+- Define all variables in the "act" section before asserting on them
+- Prefer fakes over mocks (`Queue::fake()`, `Storage::fake()`)
+
+### PHPUnit discovery
+
+```xml
+<testsuite name="Unit">   <directory>Modules/*/Tests/Unit</directory>   </testsuite>
+<testsuite name="Feature"><directory>Modules/*/Tests/Feature</directory></testsuite>
+```
+
+---
+
+## Development Commands
+
+```bash
+# Tests
+php artisan test                        # all tests (~30-60s)
+php artisan test --testsuite=Unit       # unit only
+php artisan test --testsuite=Feature    # feature only
+php artisan test --group smoke          # by group
+
+# Code quality (run in this order before committing)
+vendor/bin/pint                         # format PSR-12
+vendor/bin/phpstan analyse              # static analysis
+php artisan test                        # all tests must pass
+```
+
+---
+
+## Database & Model Conventions
+
+- **No `$fillable` in models** — use `$guarded = []`
+- **No JSON or ENUM columns** in migrations
+- **No `timestamps()` or `softDeletes()`** in migrations unless explicitly needed
+- **Use `$casts`** for enum fields: `'status' => InvoiceStatus::class`
+- Use native PHP type hints throughout
+
+---
+
+## Filament Resource Conventions
+
+Each resource is split across focused files:
+```
+InvoiceResource.php         — getModel(), navigationIcon(), getPages()
+Pages/ListInvoices.php      — extends ListRecords
+Pages/CreateInvoice.php     — extends CreateRecord
+Pages/EditInvoice.php       — extends EditRecord
+Tables/InvoicesTable.php    — static table(Table $table): Table
+Schemas/InvoiceForm.php     — static form(Schema $schema): Schema
+```
+
+Rules:
+- Respect panel namespace separation (Admin/ vs Company/)
+- Use `Action::make()` with fluent methods
+- Do not display raw `created_at`/`updated_at` in tables
+
+---
+
+## Internationalization
+
+**Always use `trans()`, never `__()`:**
+
+```php
+// ❌ WRONG
 $label = __('ip.invoice_total');
 
-// ✅ CORRECT - Always use trans()
+// ✅ CORRECT
 $label = trans('ip.invoice_total');
 ```
 
-**Translation Key Conventions:**
-- Main translation file: `resources/lang/en/ip.php`
-- Prefix keys with `ip.` (e.g., `ip.invoice_total`, `ip.payment_method`)
-- Use snake_case for key names
-- In Blade: Use `{{ trans('ip.key') }}` or `@lang('ip.key')`
+Translation keys: `resources/lang/en/ip.php`, prefixed `ip.`, snake_case.
 
-**UI Text Translation Requirements:**
-ALL user-facing text must use trans():
-- Form field labels: `->label(trans('ip.field_label'))`
-- Placeholders: `->placeholder(trans('ip.placeholder'))`
-- Helper text: `->helperText(trans('ip.help_text'))`
-- Section titles: `Section::make(trans('ip.section_title'))`
-- Button labels: `trans('ip.button_text')`
-- Table headers: `trans('ip.column_name')`
-- Tooltips & hints: `trans('ip.tooltip')`
-- Success/error messages: `trans('ip.message')`
+---
 
-**Example:**
-```php
-TextInput::make('name')
-    ->label(trans('ip.report_block_name'))
-    ->placeholder(trans('ip.report_block_name_placeholder'))
-    ->helperText(trans('ip.report_block_name_help'));
+## Coding Rules Summary
 
-Section::make(trans('ip.section_general'))
-    ->schema([...]);
-```
+- Business logic lives in `Modules/` — never in `app/`
+- No routes in `routes/` — panels handle all routing
+- No DTO or Repository layer — services use plain arrays
+- `$user->companies()` BelongsToMany — use `.first()`, `.attach()`, `.detach()`
+- `Str::lower($company->search_code)` is always the URL tenant parameter
+- `$user->isSuperAdmin()` shorthand for role check
 
-## PHPStan Type Safety Guidelines
+---
 
-### Float Array Keys (CRITICAL)
-**Never use floats directly as array keys** - they cause PHPStan errors and precision issues:
+## CI/CD (must pass before merge)
 
-```php
-// ❌ WRONG
-$rate = 21.0;
-$taxGroups[$rate] = ['base' => 0];
-
-// ✅ CORRECT
-$rate = 21.0;
-$rateKey = (string) $rate;
-$taxGroups[$rateKey] = ['base' => 0];
-
-// When iterating, cast back to float
-foreach ($taxGroups as $rateKey => $group) {
-    $rate = (float) $rateKey;
-    // Use $rate for calculations
-}
-```
-
-### DTO Constructor Usage
-**Always use static factory methods**, never call DTO constructors with parameters:
-
-```php
-// ❌ WRONG
-$dto = new GridPositionDTO(0, 0, 6, 4);
-
-// ✅ CORRECT
-$dto = GridPositionDTO::create(0, 0, 6, 4);
-```
-
-### Property Type Consistency
-**Match parent class property types exactly**:
-
-```php
-// ❌ WRONG - Parent expects string
-protected static ?string $navigationGroup = 'Reports';
-
-// ✅ CORRECT
-protected static string $navigationGroup = 'Reports';
-```
-
-### Import Statements
-**Always use full namespace imports**:
-
-```php
-// ❌ WRONG
-use Log;
-
-// ✅ CORRECT
-use Illuminate\Support\Facades\Log;
-```
-
-### Test Mocks
-**Use PHPStan suppressions for test mocks with type mismatches**:
-
-```php
-$customer = new stdClass();
-/** @phpstan-ignore-next-line */
-$invoice->customer = $customer;
-```
-
-### Factory Return Types
-**Add type hints when factories return Collection but method expects Model**:
-
-```php
-protected function createCompany(): Company
-{
-    /** @var Company $company */
-    $company = Company::factory()->create();
-    return $company;
-}
-```
-
-## Development Workflow
-
-When making code changes, follow this workflow:
-
-1. **Understand the Task** - Read the requirements carefully
-2. **Locate Files** - Use the module structure (`Modules/{ModuleName}/{Type}/`)
-3. **Make Changes** - Follow all guidelines above (SOLID, DTOs, Transformers, etc.)
-4. **Write/Update Tests** - Use `#[Test]`, `it_` prefix, Arrange/Act/Assert structure
-5. **Validate Locally**:
-   - Run `vendor/bin/pint` to format code
-   - Run `vendor/bin/phpstan analyse` to check types
-   - Run `php artisan test` to verify tests pass
-6. **Review Changes** - Ensure minimal, surgical changes only
-7. **Commit** - Follow `.github/git-commit-instructions.md`
-
-**Remember:** All CI checks (PHPUnit, PHPStan, Pint) must pass before code can be merged.
+- `php artisan test` — all tests green
+- `vendor/bin/phpstan analyse` — no type errors
+- `vendor/bin/pint` — PSR-12 compliant

--- a/.junie/architecture.md
+++ b/.junie/architecture.md
@@ -1,0 +1,139 @@
+# Architecture — InvoicePlane v2
+
+## Auth & login flow
+
+```
+POST /login (Filament Livewire Login component)
+  Modules/Core/Filament/Pages/Auth/Login.php
+    → rate-limit (5/min), check is_active, regenerate session
+    → return app(LoginResponse::class)
+
+  Modules/Core/Filament/Responses/LoginResponse.php
+    → elevated user? (super_admin / admin / assist)
+        Company::whereRaw('LOWER(search_code) = ?', ['ivplv2'])->first()
+        ?? Company::query()->first()
+        filament()->setTenant($company)
+    → regular user? (client_admin / client)
+        $user->companies()->whereRaw('LOWER(search_code) = ?', ['ivplv2'])->first()
+        ?? $user->companies()->first()
+        session(['current_company_id' => $company->id])
+        filament()->setTenant($company)
+    → redirect to filament.company.pages.dashboard [tenant=<search_code>]
+
+Logout: Modules/Core/Filament/Responses/LogoutResponse.php
+    → redirect to filament.company.auth.login
+```
+
+---
+
+## Tenant resolution middleware (company panel, every request)
+
+```
+1. SetTenantFromQueryString   (Modules/Core/Http/Middleware/)
+     reads request('tenant') — the search_code from the URL segment
+     queries Company where LOWER(search_code) = lower(tenant)
+     sets session('current_company_id') + filament()->setTenant()
+
+2. ConfigureTenant
+     resolves tenant: route param → query string → session → user's first company
+     shares $currentCompany to all views
+
+3. EnsureUserCanAccessCompany
+     elevated users: pass unconditionally
+     regular users: must exist in company_user pivot — otherwise abort(403)
+     updates session('current_company_id')
+```
+
+---
+
+## Company scoping (BelongsToCompany trait)
+
+Every business model applies this trait. It:
+
+1. Registers a **global scope** that appends `WHERE company_id = <current>` to all queries
+2. On model `creating`, auto-injects `company_id` from:
+   - `Filament::getTenant()->id`
+   - `session('current_company_id')`
+   - `auth()->user()->companies()->first()->id`
+3. Adds `company()` BelongsTo relationship
+4. Adds `scopeForCompany(int $companyId)` named scope
+
+**Consequence:** Never do raw `Invoice::all()` inside tenant context — the global scope filters automatically. In tests, set the tenant before creating company-scoped factories.
+
+---
+
+## Filament resource anatomy
+
+Each resource is split into focused files:
+
+```
+InvoiceResource.php      — getModel(), navigationIcon(), navigationGroup(), getPages()
+Pages/
+  ListInvoices.php       — extends ListRecords; table configuration via InvoicesTable
+  CreateInvoice.php      — extends CreateRecord; form via InvoiceForm
+  EditInvoice.php        — extends EditRecord; form via InvoiceForm
+Tables/
+  InvoicesTable.php      — static table(Table $table): Table — columns, filters, actions
+Schemas/
+  InvoiceForm.php        — static form(Schema $schema): Schema — fields, sections, repeaters
+```
+
+---
+
+## Seeder (database/seeders/DatabaseSeeder.php)
+
+```
+Companies:
+  id=22, search_code='ivplv2', name='InvoicePlane Corporation'  ← hard-coded default
+  5 additional random companies
+
+Roles (Spatie):
+  super_admin, admin, assist, client_admin, client
+
+Users (one per role, all attached to ivplv2 company):
+  super_admin@example.com  / password
+  admin@example.com        / password
+  assist@example.com       / password
+  client_admin@example.com / password
+  client@example.com       / password
+```
+
+---
+
+## Key relationships
+
+```php
+// User ↔ Company (pivot: company_user — id, company_id, user_id, no timestamps)
+$user->companies()            // BelongsToMany<Company>
+$company->users()             // BelongsToMany<User>
+$user->companies()->attach($company->id)
+$user->companies()->detach($company->id)
+
+// Business models → Company (via BelongsToCompany trait)
+$invoice->company()           // BelongsTo<Company>
+$company->invoices()          // HasMany<Invoice>
+
+// Relations (customers) → Contacts, Addresses
+$relation->contacts()         // HasMany<Contact>
+$relation->primaryContact()   // BelongsTo<Contact>
+$relation->addresses()        // MorphMany<Address>
+```
+
+---
+
+## Config files
+
+| File | Purpose |
+|------|---------|
+| `config/modules.php` | nwidart module settings; migration auto-discovery |
+| `config/ip.php` | InvoicePlane custom settings |
+| `config/filament.php` | Filament framework config |
+| `config/database.php` | DB connections (mysql as `mariadb` driver in prod) |
+
+## Environment variables worth knowing
+
+```
+APP_EXTREME_LOGGING=true   # verbose company-scope debug output
+DB_CONNECTION=sqlite       # use for local dev / tests without MySQL
+DB_DATABASE=:memory:       # paired with sqlite for in-memory test DB
+```

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,912 +1,266 @@
-# Junie AI Agent Guidelines for InvoicePlane v2
-
-This document provides comprehensive guidelines for AI agents (like Junie) working on the InvoicePlane v2 codebase to ensure maximum information accuracy and performance.
-
----
+# Junie Guidelines — InvoicePlane v2
 
 ## How to Use These Guidelines
 
-**IMPORTANT:** These guidelines contain comprehensive information about the InvoicePlane v2 codebase, architecture, and development workflow. **Trust these guidelines** and use them as your primary reference. Only perform additional searches if:
-- The information you need is not covered here
-- You encounter an error that contradicts these guidelines
-- You need to locate specific files or code not referenced here
-
-Following these guidelines will significantly reduce exploration time and prevent common mistakes.
+These guidelines contain verified facts about the InvoicePlane v2 codebase. **Trust them** and use them as the primary reference. Only search the repository when something is not covered here or contradicts what you find.
 
 ---
 
-## Project Overview
+## Verified Tech Stack
 
-**InvoicePlane v2** is a multi-tenant invoicing and billing application built with modern PHP/Laravel technologies.
-
-### Core Architecture
-- **Framework:** Laravel 12+ (PHP 8.2+)
-- **UI:** Filament 4.0 (Admin/Company/Invoice panels)
-- **Frontend:** Livewire + Tailwind CSS
-- **Module System:** nwidart/laravel-modules (modular monolith)
+- **Framework:** Laravel **11** (PHP **8.1**+)
+- **UI:** Filament **4.0** + Livewire **3**
+- **Modules:** `nwidart/laravel-modules`
+- **Permissions:** `spatie/laravel-permission`
 - **Multi-tenancy:** Filament Companies with `BelongsToCompany` trait
-- **Permissions:** spatie/laravel-permission
-- **Queue System:** Required for export functionality
+- **DB (prod):** MariaDB 11 | **DB (tests):** SQLite `:memory:` or MariaDB 11 (CI)
+- **Code quality:** Laravel Pint (PSR-12), PHPStan, Rector
 
-### Module Structure
+---
+
+## Project Architecture
+
+All business logic lives in `Modules/`. The `app/` directory is intentionally thin.
+
+### Module inventory
+
+| Module | Key models |
+|--------|-----------|
+| Core | User, Company, CompanyUser, TaxRate, Numbering, EmailTemplate, CustomField, Upload, Note, AuditLog, Setting, MailQueue |
+| Clients | Relation (table: `relations`), Contact, Address, Communication, ClientCustom (PK: `client_custom_id`) |
+| Invoices | Invoice, InvoiceItem, RecurringInvoice |
+| Quotes | Quote, QuoteItem |
+| Payments | Payment |
+| Products | Product, ProductUnit, ProductCategory |
+| Projects | Project, Task |
+| Expenses | Expense, ExpenseCategory, ExpenseItem |
+
+### Module directory layout
+
 ```
-Modules/
- ModuleName/
- Models/ # Eloquent models
- Services/ # Business logic layer
- Repositories/ # Data access layer
- DTOs/ # Data Transfer Objects
- Transformers/ # DTO ↔ Model transformations
- Filament/ # Filament resources (Admin/Company panels)
- Tests/ # PHPUnit tests
- Database/ # Migrations, seeders, factories
+Modules/<Name>/
+  Models/
+  Services/               # extend BaseService; no DTO/Repository layer
+  Enums/                  # PHP 8.1+ backed string enums
+  Filament/
+    Admin/Resources/      # Admin panel CRUD
+    Company/Resources/
+      <Resource>/
+        Pages/   CreateX, EditX, ListX
+        Tables/  XTable (columns, filters, actions)
+        Schemas/ XForm (form schema)
+  Database/
+    Factories/            # extend AbstractFactory
+    Migrations/           # auto-discovered
+    Seeders/
+  Events/ Listeners/ Observers/
+  Traits/ Helpers/ Http/ Providers/
+  Tests/Feature/ Tests/Unit/
 ```
 
 ---
 
-## Critical Principles (MUST FOLLOW)
+## Filament Panels (verified)
 
-### 1. SOLID Principles
-- **Single Responsibility:** Each class has one clear purpose
-- **Open/Closed:** Extend behavior without modifying existing code
-- **Liskov Substitution:** Subtypes must be substitutable for base types
-- **Interface Segregation:** No fat interfaces; clients shouldn't depend on unused methods
-- **Dependency Inversion:** Depend on abstractions, not concretions
+| ID | Path | Tenant | Roles |
+|----|------|--------|-------|
+| `admin` | `/admin` | No | super_admin, admin, assist |
+| `company` | `` **(root, empty)** | Yes — Company by `search_code` | client_admin, client |
+| `user` | `/user` | No | (future) |
 
-### 2. Code Quality Standards
-- **Early Returns:** Prefer early returns over nested conditions
-- **No Inline Logic:** Business logic must be in services, not controllers/resources
-- **Dynamic Programming:** Apply where relevant (memoization, tabulation)
-- **Centralize Shared Logic:** Use traits to avoid duplication
-- **Type Safety:** Use native PHP type hints throughout
+> Company panel path is **empty string** — URLs are `/{search_code}/{page}`, e.g. `/ivplv2/dashboard`.
 
-### 3. Error Handling
+Panel providers all live at `Modules/Core/Providers/`.
+
+Route names: `filament.<panel-id>.pages.<slug>` and `filament.<panel-id>.resources.<resource>.<action>`
+
+---
+
+## Multi-Tenancy
+
 ```php
-// Catch specific exceptions separately
-try {
- // code
-} catch (Error $e) {
- // Handle Error
-} catch (ErrorException $e) {
- // Handle ErrorException
-} catch (Throwable $e) {
- // Handle other throwables
+// URL tenant param — always lowercase search_code
+Str::lower($company->search_code)   // e.g. 'ivplv2'
+
+// Pivot: company_user (id, company_id, user_id — no timestamps)
+$user->companies()          // BelongsToMany<Company>
+$company->users()           // BelongsToMany<Company>
+
+// Current tenant resolution (in order):
+// 1. Filament::getTenant()
+// 2. session('current_company_id')
+// 3. auth()->user()->companies()->first()
+```
+
+Tenant middleware chain (company panel, persistent):
+1. `SetTenantFromQueryString` → reads `?tenant=`, sets session + Filament tenant
+2. `ConfigureTenant` → resolves from route/query/session/user
+3. `EnsureUserCanAccessCompany` → 403 if user not in `company_user` for that company
+
+`BelongsToCompany` trait (on every business model):
+- Adds `company()` BelongsTo relationship
+- Adds global scope filtering by `company_id` — queries are always tenant-scoped
+- Auto-injects `company_id` on model creation
+
+---
+
+## Roles (verified Spatie values)
+
+```php
+UserRole::SUPER_ADMIN    = 'super_admin'    // full access, any panel
+UserRole::ADMIN          = 'admin'
+UserRole::ASSIST         = 'assist'
+UserRole::CUSTOMER_ADMIN = 'client_admin'   // company panel only
+UserRole::CUSTOMER       = 'client'
+
+UserRole::elevated()   // ['super_admin', 'admin', 'assist']
+UserRole::nonAdmin()   // ['client_admin', 'client']
+```
+
+Spatie roles require a DB record in tests:
+```php
+Role::query()->firstOrCreate(['name' => UserRole::SUPER_ADMIN->value, 'guard_name' => 'web']);
+$user->assignRole(UserRole::SUPER_ADMIN->value);
+```
+
+---
+
+## Key Model Facts
+
+- `User::$timestamps = false` — no created_at/updated_at
+- `ClientCustom::$primaryKey = 'client_custom_id'`
+- `Import::$primaryKey = 'import_id'`
+- `Relation` → table `relations` (not `customers`, not `clients`)
+- `Company::search_code` — 10-char unique string; URL slug
+- Soft deletes on Invoice, Quote (and their items)
+- Default company: `search_code='ivplv2'`, `id=22`, name `'InvoicePlane Corporation'` (seeder)
+
+---
+
+## Service Layer
+
+**No DTO, Transformer, or Repository layer.** Services accept plain arrays, return Eloquent models.
+
+```php
+class InvoiceService extends BaseService {
+    public function model(): string { return Invoice::class; }
+    // Inherited from BaseService:
+    // create(array $data): Model
+    // find($id): Model
+    // update(array $input, Model $model): Model
+    // delete($id): bool
+    // paginate(int $perPage): LengthAwarePaginator
+    // getCompanyId(): ?int
 }
 ```
 
 ---
 
-## Architecture Patterns
+## SOLID & Code Quality Principles
 
-### DTO & Transformer Rules
-
-**DTOs (Data Transfer Objects):**
-- NO constructors in DTOs
-- Use static named constructors when necessary
-- Rely on getters and setters for data access
-- DTOs are transformed using Transformers
-
-**Transformers:**
-- Must implement `toDto()` and `toModel()` methods
-- Services must use Transformers directly (not build DTOs manually)
-- EntityExtractionService must use Transformers for entire transformation process
-
-**Example:**
-```php
-// DTO
-class InvoiceDTO
-{
- private string $number;
- private float $total;
-
- // No constructor!
-
- public static function fromArray(array $data): self
- {
- $dto = new self();
- $dto->setNumber($data['number']);
- $dto->setTotal($data['total']);
- return $dto;
- }
-
- public function getNumber(): string { return $this->number; }
- public function setNumber(string $number): void { $this->number = $number; }
-}
-
-// Transformer
-class InvoiceTransformer
-{
- public function toDto(Invoice $model): InvoiceDTO
- {
- return InvoiceDTO::fromArray([
- 'number' => $model->number,
- 'total' => $model->total,
- ]);
- }
-
- public function toModel(InvoiceDTO $dto): Invoice
- {
- $model = new Invoice();
- $model->number = $dto->getNumber();
- $model->total = $dto->getTotal();
- return $model;
- }
-}
-```
-
-### Service Layer
-- All business logic must be in services
-- Services coordinate between repositories, transformers, and external systems
-- Services must not build DTOs manually—use Transformers
-- Services return DTOs or collections of DTOs
-
-### Repository Layer
-- Repositories handle data access only
-- Use repository methods for upserts (not `updateOrCreate`)
-- Repositories return models or collections of models
-
-### API Integration
-- All API requests must go through the Advanced API Client
-- No direct API calls in controllers, services, or jobs
-- Use Laravel's HTTP client (not curl or Guzzle)
-- All transformations must go through Transformers
-- API responses and errors must be logged separately
+- **Single Responsibility:** one clear purpose per class
+- **Early returns:** reduce nesting; validate inputs at the top of methods
+- **No inline business logic:** logic in services, not resources/controllers
+- **Centralize shared logic:** traits over copy-paste
+- **Type hints everywhere:** native PHP types throughout
 
 ---
 
-## Testing Standards
+## Database & Model Rules
 
-### Test Structure
-```php
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\Group;
-
-class InvoiceServiceTest extends AbstractCompanyPanelTestCase
-{
- use RefreshDatabase;
-
- #[Test]
- #[Group('invoices')]
- public function it_creates_invoice_with_valid_data(): void
- {
- /* Arrange */
- $data = ['number' => 'INV-001', 'total' => 100.00];
-
- /* Act */
- $result = $this->service->createInvoice($data);
-
- /* Assert */
- $this->assertInstanceOf(InvoiceDTO::class, $result);
- $this->assertEquals('INV-001', $result->getNumber());
- }
-}
-```
-
-### Testing Rules (MANDATORY)
-1. **Test Naming:** Functions prefixed with `it_` (e.g., `it_creates_invoice`)
-2. **No `@test` Annotations:** Use `#[Test]` attribute instead
-3. **Prefer Fakes over Mocks:**
- ```php
- Queue::fake();
- Storage::fake('local');
- Notification::fake();
- ```
-4. **Happy Paths Last:** Place success scenarios at the end
-5. **Reusable Setup:** Abstract test cases for fixtures, not inline
-6. **Comment Blocks:** Use `/* Arrange */`, `/* Act */`, `/* Assert */`
-7. **NEVER extend `Tests\TestCase`:** All tests must extend one of the abstract test cases from `Modules/Core/Tests/`:
-   - `AbstractTestCase` - Basic test case with application bootstrap
-   - `AbstractAdminPanelTestCase` - For admin panel tests with RefreshDatabase
-   - `AbstractCompanyPanelTestCase` - For company panel tests with multi-tenancy
-
-### Export Testing
-```php
-#[Test]
-#[Group('export')]
-public function it_dispatches_csv_export_job(): void
-{
- /* Arrange */
- Queue::fake();
- Storage::fake('local');
- $records = Model::factory()->count(3)->create();
-
- /* Act */
- Livewire::actingAs($this->user)
- ->test(ListPage::class)
- ->callAction('exportCsv', data: [
- 'columnMap' => [
- 'field' => ['isEnabled' => true, 'label' => 'Label'],
- ],
- ]);
-
- /* Assert */
- Bus::assertChained([
- fn($batch) => $batch instanceof \Illuminate\Bus\PendingBatch
- ]);
-}
-```
+- **No `$fillable`** — use `$guarded = []`
+- **No JSON or ENUM columns** in migrations
+- **No `timestamps()` or `softDeletes()`** unless explicitly needed
+- **Use `$casts`** for enum fields: `'status' => InvoiceStatus::class`
+- Native PHP type hints on all properties and return types
 
 ---
 
-## Database & Models
+## Internationalization
 
-### Migration Rules
-- NO JSON columns in migrations
-- NO ENUM columns in migrations
-- NO `timestamps()` unless explicitly specified
-- NO `softDeletes()` unless explicitly specified
-
-### Model Rules
-- NO `$fillable` array in models
-- NO `timestamps` or `softDeletes` properties unless needed
-- Use native PHP type hints
-- Use `$casts` for Enum fields
+**Always `trans()`, never `__()`:**
 
 ```php
-class Invoice extends Model
-{
- // No $fillable!
-
- protected $casts = [
- 'status' => InvoiceStatus::class, // Enum
- 'total' => 'decimal:2',
- 'issued_at' => 'datetime',
- ];
-}
-```
-
----
-
-## Filament Resources
-
-### Resource Generation
-- Must use Filament internal traits (`CanReadModelSchemas`, etc.)
-- No reflection for relationship detection
-- Separate form and table generators by field type
-- Keep configurable `$excludedFields` array
-- Detect Enums via `$casts` and `enum_exists()`
-- Add docblocks above `form()`, `table()`, `getRelations()`
-- Use `copyStubToApp()` instead of inline string replacements
-
-### Panel Separation
-- Respect proper panel namespaces (Admin/Company/Invoice)
-- Resources in correct panel directories
-- Preserve exact method signatures
-
-### Best Practices
-- Use correct `Action::make()` syntax with fluent methods
-- Don't display raw `created_at` or `updated_at` in tables/infolists
-- Use dedicated timestamp columns instead
-
----
-
-## Export System
-
-### Architecture
-- Exports use Filament's asynchronous export system
-- **Requires queue workers** to be running
-- The `exports` table is temporary (job coordination only)
-- NO export history feature
-- Auto-prunable via Laravel's model pruning
-
-### Queue Configuration
-
-**Local Development:**
-```bash
-# Option 1: Sync driver (blocks request)
-QUEUE_CONNECTION=sync
-
-# Option 2: Queue worker
-php artisan queue:work
-```
-
-**Production:**
-```bash
-# Redis (recommended)
-QUEUE_CONNECTION=redis
-
-# With Supervisor
-[program:invoiceplane-worker]
-command=php /path/to/artisan queue:work --sleep=3 --tries=3
-```
-
-### Export Test Requirements
-- Must use `Queue::fake()` and `Storage::fake()`
-- Verify job dispatching with `Bus::assertChained()`
-- Don't test file content (test job dispatch only)
-- See: `Modules/Core/Filament/Exporters/README.md`
-
----
-
-## Peppol E-Invoicing Integration
-
-### Architecture Overview
-InvoicePlane v2 includes a comprehensive Peppol integration for sending electronic invoices across the European Peppol network.
-
-**Key Components:**
-- **PeppolService:** Main facade for invoice transmission and status checking
-- **PeppolManagementService:** Integration lifecycle management (create, test, validate, send)
-- **Format Handlers:** Strategy Pattern for different e-invoice formats (UBL, FatturaPA, ZUGFeRD, etc.)
-- **Provider Factory:** Creates provider-specific clients (e.g., EInvoiceBe)
-- **API Client:** Centralized HTTP client with exception handling
-- **Event System:** Dispatches events for all major operations
-
-### Format Handlers (Strategy Pattern)
-Each format handler implements:
-- `validate(Invoice $invoice): array` - Validates invoice for format requirements
-- `transform(Invoice $invoice, array $options): array` - Converts to format-specific structure
-- `getFormat(): PeppolDocumentFormat` - Returns format enum
-
-**Supported Formats (11 total):**
-- **CII** (Cross Industry Invoice) - UN/CEFACT standard, common in Germany/France/Austria
-- **EHF 3.0** - Norwegian e-invoice format (Elektronisk Handelsformat)
-- **Factur-X** - French/German hybrid format (PDF with embedded XML)
-- **Facturae 3.2** - Spanish e-invoice format (mandatory for public administration)
-- **FatturaPA 1.2** - Italian e-invoice format (mandatory for all invoices in Italy)
-- **OIOUBL** - Danish e-invoice format
-- **PEPPOL BIS 3.0** - Default Peppol format for most European countries
-- **UBL 2.1** - Universal Business Language (most common for Peppol)
-- **UBL 2.4** - Updated UBL version with enhanced features
-- **ZUGFeRD 1.0** - German e-invoice format (PDF with embedded XML)
-- **ZUGFeRD 2.0** - Updated German format, compatible with Factur-X
-
-All format handlers are registered in `FormatHandlerFactory` and have comprehensive PHPUnit test coverage.
-The factory automatically selects the appropriate handler based on:
-1. Customer's preferred format (if set)
-2. Mandatory format for customer's country
-3. Recommended format for customer's country  
-4. Fallback to PEPPOL BIS 3.0
-
-**Format Selection Logging:**
-- Info level: Customer's preferred or recommended format unavailable
-- Warning level: Mandatory format for country unavailable (serious configuration issue)
-
-### Service Layer Pattern
-```php
-// PeppolService - Transmission & Status
-$peppolService->sendInvoiceToPeppol($invoice, $options);
-$peppolService->getDocumentStatus($documentId);
-$peppolService->cancelDocument($documentId);
-
-// PeppolManagementService - Lifecycle
-$service->createIntegration($companyId, $provider, $config, $token);
-$service->testConnection($integration);
-$service->validatePeppolId($customer, $integration);
-$service->sendInvoice($invoice, $integration);
-```
-
-### Logging & Monitoring
-- **LogsApiRequests trait:** Logs all API requests/responses
-- **LogsPeppolActivity trait:** Logs Peppol-specific events
-- **Events:** PeppolTransmissionCreated, PeppolTransmissionSent, etc.
-- **Status Tracking:** Comprehensive enum-based status system
-
-### Database Structure
-- `peppol_integrations` - Company provider configurations
-- `peppol_integration_config` - Key-value config storage
-- `peppol_transmissions` - Transmission tracking
-- `peppol_transmission_responses` - Provider responses
-- `customer_peppol_validation_history` - Validation records
-
-### Testing Peppol Components
-```php
-#[Test]
-public function it_sends_invoice_to_peppol_successfully(): void
-{
- /* Arrange */
- Http::fake(['https://api.e-invoice.be/*' => Http::response([
- 'document_id' => 'DOC-123456',
- 'status' => 'submitted',
- ], 200)]);
-
- $invoice = $this->createMockInvoice();
-
- /* Act */
- $result = $this->service->sendInvoiceToPeppol($invoice);
-
- /* Assert */
- $this->assertTrue($result['success']);
- $this->assertEquals('DOC-123456', $result['document_id']);
-}
-```
-
----
-
-## Security & Permissions
-
-### Seeding Rules
-- Seed 5 default roles: `superadmin`, `admin`, `assistance`, `useradmin`, `user`
-- Users can belong to accounts (multi-tenancy)
-- Admin Panel access restricted to `admin` and `superadmin`
-
-### Multi-tenancy
-- Use `BelongsToCompany` trait on models
-- Company context required for all user operations
-- Filament panels enforce tenant isolation
-
----
-
-## Internationalization & Translations
-
-### Translation Function Usage
-**CRITICAL:** InvoicePlane v2 uses `trans()` for all translations, NOT `__()`.
-
-```php
-// ❌ WRONG - Do not use __()
+// ❌ WRONG
 $label = __('ip.invoice_total');
-$message = __('ip.payment_successful');
 
-// ✅ CORRECT - Always use trans()
+// ✅ CORRECT
 $label = trans('ip.invoice_total');
-$message = trans('ip.payment_successful');
 ```
 
-**Blade Templates:**
-```blade
-{{-- ✅ CORRECT --}}
-{{ trans('ip.total') }}
-@lang('ip.total')  {{-- @lang() is acceptable in Blade --}}
-```
-
-### Translation Key Conventions
-- Main translation file: `resources/lang/en/ip.php`
-- Prefix all keys with `ip.` for InvoicePlane-specific translations
-- Use snake_case for key names
-- Group related translations logically
-- Example keys: `ip.invoice_total`, `ip.payment_method`, `ip.report_field_company_name`
-
-### UI Text Translation Requirements
-**ALL user-facing text must be translatable:**
-
-**Form Fields:**
-```php
-// Labels
-TextInput::make('name')
-    ->label(trans('ip.field_label'))
-
-// Placeholders
-TextInput::make('email')
-    ->placeholder(trans('ip.email_placeholder'))
-
-// Helper Text
-TextInput::make('vat_id')
-    ->helperText(trans('ip.vat_id_help'))
-
-// Section Titles
-Section::make(trans('ip.section_general'))
-```
-
-**Required Translation Coverage:**
-- ✅ Form field labels
-- ✅ Form placeholders
-- ✅ Helper text and hints
-- ✅ Tips and tooltips
-- ✅ Button labels
-- ✅ Section titles
-- ✅ Table column headers
-- ✅ Success/error messages
-- ✅ Validation messages
-- ✅ Menu items
-- ✅ Page titles
-
-### Service Translation Pattern
-When services load translatable content from config files:
-```php
-// Load from config and translate
-$label = trans(config('some-config.label'));
-
-// In service methods
-public function getTranslatedLabel(): string
-{
-    return trans($this->configKey);
-}
-```
+Translation keys: `resources/lang/en/ip.php`, prefix `ip.`, snake_case.
+Apply to: form labels, placeholders, helper text, section titles, button labels, table headers, messages.
 
 ---
 
-## Development Workflow
+## Filament Conventions
 
-### Commands
-
-**Testing:**
-```bash
-php artisan test # All tests (typically 30-60 seconds)
-php artisan test --coverage # With coverage (typically 60-120 seconds)
-php artisan test --testsuite=Unit # Unit tests only (faster - 10-30 seconds)
-php artisan test --group=export # Export tests only
+Resource anatomy:
+```
+InvoiceResource.php      — getModel(), navigationIcon(), getPages()
+Pages/ListInvoices.php   — extends ListRecords
+Pages/CreateInvoice.php  — extends CreateRecord
+Pages/EditInvoice.php    — extends EditRecord
+Tables/InvoicesTable.php — static table(Table $table): Table
+Schemas/InvoiceForm.php  — static form(Schema $schema): Schema
 ```
 
-**Important:** Always run tests before finalizing changes. All tests must pass.
+- Respect panel namespace: `Filament/Admin/` vs `Filament/Company/`
+- Use `Action::make()` with fluent method chains
+- Do not display raw `created_at`/`updated_at` — use formatted timestamp columns
 
-**Code Quality:**
+---
+
+## Common Pitfalls
+
+1. Never add business logic to `app/` — use `Modules/`
+2. Never define routes in `routes/` — panels handle routing
+3. Never use `$fillable` — use `$guarded = []`
+4. Never add JSON or ENUM columns to migrations
+5. Never call `Invoice::all()` inside tenant context without company scope — BelongsToCompany adds it automatically
+6. Never skip `->for($company)` on factory calls for company-scoped models (results in `null` company_id)
+7. Never use `__()` for translations — always `trans()`
+8. Never use floats as array keys — cast to string first
+
+---
+
+## Development Commands
+
 ```bash
-vendor/bin/pint # Format code (PSR-12) - auto-fixes violations
-vendor/bin/phpstan analyse # Static analysis (typically 20-40 seconds)
-vendor/bin/rector process --dry-run # Refactoring suggestions
-```
-
-**Validation Pipeline:** Before submitting code, you MUST run:
-1. `vendor/bin/pint` - Format code
-2. `vendor/bin/phpstan analyse` - Check for type errors
-3. `php artisan test` - Run all tests
-
-**Setup:**
-```bash
-composer install
-cp .env.example .env
-php artisan key:generate
+# Setup
+composer install && cp .env.example .env && php artisan key:generate
 php artisan migrate --seed
-php artisan queue:work # For exports
+php artisan queue:work   # required for export functionality
+
+# Validation pipeline (run in order before committing)
+vendor/bin/pint                   # 1. format code
+vendor/bin/phpstan analyse         # 2. static analysis
+php artisan test                   # 3. all tests must pass
 ```
 
-### Git Commit Conventions
-- Follow conventions in `.github/git-commit-instructions.md`
-- Use semantic commit messages
-- Reference issues when applicable
+See `.github/git-commit-instructions.md` for commit message conventions.
 
 ---
 
-## Documentation References
+## CI/CD (all must pass before merge)
 
-### Key Documentation Files
-- **Installation:** `.github/INSTALLATION.md`
-- **Contributing:** `.github/CONTRIBUTING.md`
-- **Testing:** Module tests in `Modules/*/Tests/`
-- **Seeding:** `.github/SEEDING.md`
-- **Commits:** `.github/git-commit-instructions.md`
-- **Export Architecture:** `Modules/Core/Filament/Exporters/README.md`
-- **Module Checklist:** `CHECKLIST.md`
-
-### Related Documentation
-- Laravel 12: https://laravel.com/docs/12.x
-- Filament 4: https://filamentphp.com/docs/4.x
-- Livewire 3: https://livewire.laravel.com/docs
-- PHPUnit 11: https://docs.phpunit.de/en/11.0/
+- `php artisan test` — PHPUnit green
+- `vendor/bin/phpstan analyse` — no type errors
+- `vendor/bin/pint` — PSR-12 compliant
+- Docker build — must succeed
 
 ---
 
-## GitHub Actions & Automation
-
-### CI/CD Pipeline
-
-The following automated checks run on every pull request and MUST pass:
-- **PHPUnit** - All tests must pass (`php artisan test`)
-- **PHPStan** - Static analysis must pass with no errors (`vendor/bin/phpstan analyse`)
-- **Pint** - Code must follow PSR-12 standards (`vendor/bin/pint`)
-- **Docker Build** - Docker images must build successfully
-
-See `.github/workflows/` for workflow configurations. Reference `.github/workflows/README.md` for setup details.
-
-### Automated Workflows
-
-InvoicePlane v2 uses GitHub Actions for automated dependency management and CI/CD:
-
-- **Composer Update** - Automated PHP dependency updates
-- **Yarn Update** - Automated JavaScript dependency updates
-- **Crowdin Sync** - Automated translation synchronization
-- **Release** - Automated production releases
-
-### Required Secrets
-
-Automation workflows require repository secrets to function:
-
-**PAT_TOKEN** (Personal Access Token):
-- Required for: Composer Update, Yarn Update workflows
-- Reason: Default `GITHUB_TOKEN` cannot create PRs that trigger other workflows
-- Scopes needed: `repo` and `workflow`
-- Setup: Settings → Secrets and variables → Actions → New repository secret
-
-**CROWDIN_PROJECT_ID** and **CROWDIN_PERSONAL_TOKEN**:
-- Required for: Crowdin Sync, Release workflows
-- Setup: Settings → Secrets and variables → Actions
-
-For detailed setup instructions, see `.github/workflows/README.md` and `.github/MAINTENANCE.md`.
-
----
-
-## Performance Optimization
-
-### Query Optimization
-- Use eager loading to prevent N+1 queries
-- Index foreign keys and frequently queried columns
-- Use `select()` to limit columns when possible
-- Chunk large datasets for processing
-
-### Caching Strategy
-- Cache expensive computations
-- Use Redis for session and cache storage
-- Implement query result caching where appropriate
-
-### Queue Workers
-- Use multiple workers for high-volume operations
-- Configure max execution time appropriately
-- Monitor failed jobs and retry logic
-
----
-
-## PHPStan Type Safety Rules
-
-### Critical: Avoiding Float Array Keys
-**Problem:** Floats used directly as array keys cause PHPStan errors due to precision issues.
-
-**Solution:** Cast floats to strings when using as array keys:
-```php
-// ❌ WRONG - Float as array key
-$rate = 21.0;
-$taxGroups[$rate] = ['base' => 0, 'amount' => 0];
-
-// ✅ CORRECT - Cast to string for array key
-$rate = 21.0;
-$rateKey = (string) $rate;
-$taxGroups[$rateKey] = ['base' => 0, 'amount' => 0];
-
-// When iterating, cast back to float for calculations
-foreach ($taxGroups as $rateKey => $group) {
-    $rate = (float) $rateKey;
-    // Use $rate for calculations and comparisons
-}
-```
-
-### DTO Constructor Invocation
-**Problem:** DTOs with no-arg constructors being called with parameters.
-
-**Solution:** Use static factory methods instead:
-```php
-// ❌ WRONG - Calling constructor with parameters
-$dto = new GridPositionDTO(0, 0, 6, 4);
-
-// ✅ CORRECT - Use static factory method
-$dto = GridPositionDTO::create(0, 0, 6, 4);
-```
-
-### Test Variable Definition
-**Problem:** Tests asserting on undefined variables (missing "act" section).
-
-**Solution:** Always include all three test sections:
-```php
-#[Test]
-public function it_creates_user(): void
-{
-    /* Arrange */
-    $data = ['name' => 'John', 'email' => 'john@example.com'];
-    
-    /* Act */
-    $user = $this->service->createUser($data);  // ❗ Must define variable before assert
-    
-    /* Assert */
-    $this->assertInstanceOf(User::class, $user);
-}
-```
-
-### Property Type Consistency
-**Problem:** Child class properties have different types than parent.
-
-**Solution:** Match parent class property types exactly:
-```php
-// ❌ WRONG - Nullable when parent is not
-class ChildResource extends ParentResource
-{
-    protected static ?string $navigationGroup = 'Reports';  // Parent expects string
-}
-
-// ✅ CORRECT - Match parent type
-class ChildResource extends ParentResource
-{
-    protected static string $navigationGroup = 'Reports';
-}
-```
-
-### Mock Object Type Hints
-**Problem:** Using stdClass for mocks when proper type is expected.
-
-**Solution:** Use PHPStan suppression for test mocks:
-```php
-// When mocking with stdClass in tests
-$customer = new stdClass();
-$customer->name = 'Test';
-
-/** @phpstan-ignore-next-line */
-$invoice->customer = $customer;  // Property expects Customer model
-```
-
-### Import Statements
-**Problem:** Using class aliases without proper imports.
-
-**Solution:** Always import from the correct namespace:
-```php
-// ❌ WRONG - Bare class name
-use Log;
-
-// ✅ CORRECT - Full namespace
-use Illuminate\Support\Facades\Log;
-```
-
-### Method Return Types
-**Problem:** Method return types don't match what the method actually returns.
-
-**Solution:** Use type annotations or suppressions when needed:
-```php
-// When factory returns Collection but method expects Model
-protected function createCompany(): Company
-{
-    /** @var Company $company */
-    $company = Company::factory()->create();
-    return $company;
-}
-
-// Or use PHPStan suppression for complex cases
-/** @phpstan-ignore-next-line */
-return $this->query->get();
-```
-
-### PHPDoc Annotations
-**Problem:** Invalid PHPDoc syntax causing PHPStan errors.
-
-**Solution:** Use correct PHPDoc/PHPStan syntax:
-```php
-// ❌ WRONG - Invalid PHPDoc syntax
-/** @SuppressWarnings(PHPMD.UnusedFormalParameter) */
-
-// ✅ CORRECT - Valid syntax
-/** @SuppressWarnings PHPMD.UnusedFormalParameter */
-
-// Or use PHPStan-specific suppression
-/** @phpstan-ignore-next-line */
-```
-
-### Static vs Non-Static Properties
-**Problem:** Child class makes parent property static or vice versa.
-
-**Solution:** Keep property modifiers consistent with parent:
-```php
-// If parent class has non-static $view, child must also be non-static
-// Use PHPStan suppression if framework requires static
-/** @phpstan-ignore-next-line */
-protected static string $view = 'view.name';
-```
-
-## Common Pitfalls to Avoid
-
-1. Don't use `$fillable` in models
-2. Don't create DTOs with constructors
-3. Don't build DTOs manually in services—use Transformers
-4. Don't use JSON or ENUM columns in migrations
-5. Don't add timestamps/softDeletes unless specified
-6. Don't test export file content—test job dispatching
-7. Don't make direct API calls—use Advanced API Client
-8. Don't use `updateOrCreate`—use repository upsert methods
-9. Don't nest conditions deeply—use early returns
-10. Don't duplicate logic—centralize in traits
-11. **Don't use floats as array keys**—cast to string first
-12. **Don't call DTO constructors with parameters**—use static factory methods
-13. **Don't write tests without "act" sections**—always define variables before asserting
-14. **Don't mismatch parent/child property types**—keep types consistent
-15. **Don't forget proper imports**—always use full namespaces
-
----
-
-## Code Review Checklist
-
-Before submitting code, verify:
-
-- [ ] Follows SOLID principles
-- [ ] No inline business logic (in services)
-- [ ] DTOs use static constructors, not `__construct()`
-- [ ] Transformers used for DTO ↔ Model conversions
-- [ ] Tests use `it_` prefix and `#[Test]` attribute
-- [ ] Tests have Arrange/Act/Assert comments
-- [ ] **All test variables are defined in "act" section before assertions**
-- [ ] No `$fillable` in models
-- [ ] No JSON/ENUM in migrations
-- [ ] Type hints used throughout
-- [ ] **Floats cast to strings when used as array keys**
-- [ ] **DTO static factory methods used instead of constructor calls**
-- [ ] **Property types match parent class types exactly**
-- [ ] **All imports use full namespace paths (no bare class names)**
-- [ ] Early returns instead of nested conditions
-- [ ] Fakes used instead of mocks in tests
-- [ ] **Test mocks use PHPStan suppressions when type mismatches**
-- [ ] Export tests use Queue/Storage fakes
-- [ ] Code formatted with `vendor/bin/pint`
-- [ ] Static analysis passes (`vendor/bin/phpstan`)
-- [ ] All tests pass (`php artisan test`)
-- [ ] Documentation updated if needed
-
----
-
-## Step-by-Step Development Workflow
-
-When making code changes, follow this workflow for best results:
-
-### 1. Understand the Task
-- Read the requirements carefully
-- Identify the scope of changes needed
-- Understand which modules are affected
-
-### 2. Locate Files
-- Use the module structure (`Modules/{ModuleName}/{Type}/`)
-- Check existing code patterns in similar features
-- Review relevant tests for context
-
-### 3. Make Changes
-- Follow all guidelines above (SOLID, DTOs, Transformers, etc.)
-- Keep changes minimal and focused
-- Extract duplicate code into reusable methods
-- Use early returns for better readability
-
-### 4. Write/Update Tests
-- Use `#[Test]` attribute
-- Name tests with `it_` prefix (e.g., `it_creates_invoice`)
-- Structure with Arrange/Act/Assert comments
-- Define all variables in "act" section before assertions
-- Extend appropriate abstract test case from `Modules/Core/Tests/`
-
-### 5. Validate Locally
-Run the validation pipeline in order:
-```bash
-# 1. Format code
-vendor/bin/pint
-
-# 2. Check for type errors
-vendor/bin/phpstan analyse
-
-# 3. Run all tests
-php artisan test
-```
-
-### 6. Review Changes
-- Ensure changes are minimal and surgical
-- Verify no unrelated code was modified
-- Check that all new code follows project guidelines
-- Confirm test coverage is adequate
-
-### 7. Commit
-- Follow `.github/git-commit-instructions.md`
-- Write clear, semantic commit messages
-- Reference issues when applicable
-
-**Remember:** All CI checks (PHPUnit, PHPStan, Pint, Docker Build) must pass before code can be merged.
-
----
-
-## Learning Resources
-
-### InvoicePlane-Specific
-- Review existing modules for patterns
-- Check test files for examples
-- Read module-specific README files
-- Follow CHECKLIST.md for feature status
-
-### Laravel/PHP
-- [Laravel Best Practices](https://github.com/alexeymezenin/laravel-best-practices)
-- [PHP: The Right Way](https://phptherightway.com/)
-- [SOLID Principles in PHP](https://solidprinciples.dev/)
-
-### Filament
-- [Filament Tricks](https://filamentphp.com/tricks)
-- [Filament Community](https://github.com/filamentphp)
-
----
-
-## Continuous Improvement
-
-This document should be updated as:
-- New patterns emerge
-- Architecture decisions change
-- Best practices evolve
-- Performance optimizations discovered
-
-**Last Updated:** 2026-02-21
-
----
-
-## Support
-
-- **Discord:** https://discord.gg/PPzD2hTrXt
-- **Forums:** https://community.invoiceplane.com
-- **Issues:** https://github.com/InvoicePlane/InvoicePlane/issues
-- **Wiki:** https://wiki.invoiceplane.com
-
----
-
-**Remember:** These guidelines ensure consistency, maintainability, and performance across the InvoicePlane v2 codebase. When in doubt, refer to existing code that follows these patterns, and always prioritize code quality over speed of delivery.
+## Reference Files
+
+| File | Content |
+|------|---------|
+| `.github/copilot-instructions.md` | Copilot-specific context (same facts, Copilot format) |
+| `.junie/testing.md` | Testing patterns, base classes, factory cheat sheet |
+| `.junie/architecture.md` | Auth flow, middleware, seeder details |
+| `CLAUDE.md` | Claude Code context (same facts, Claude format) |
+| `AGENTS.md` | OpenAI Codex / Agents context |
+| `.github/INSTALLATION.md` | Installation guide |
+| `.github/CONTRIBUTING.md` | Contributing guide |
+| `.github/git-commit-instructions.md` | Commit conventions |
+| `Modules/Core/Filament/Exporters/README.md` | Export architecture |

--- a/.junie/testing.md
+++ b/.junie/testing.md
@@ -1,0 +1,149 @@
+# Testing — InvoicePlane v2
+
+## Base classes
+
+All live at `Modules/Core/Tests/`.
+
+### AbstractCompanyPanelTestCase
+
+Use for any test that exercises the company panel (most tests).
+
+```php
+class MyTest extends AbstractCompanyPanelTestCase {
+    // Available in every test method:
+    // $this->user    — active User, attached to $this->company
+    // $this->company — Company with search_code='IVPLV2'
+    //
+    // Filament tenant is pre-set, session current_company_id is pre-set
+}
+```
+
+### AbstractAdminPanelTestCase
+
+Use for admin panel tests.
+
+```php
+class MyTest extends AbstractAdminPanelTestCase {
+    // Available:
+    // $this->company  — random Company
+    // $this->superAdmin() — User (no role assigned, panel set to 'admin')
+}
+```
+
+### AbstractTestCase
+
+Pure unit tests — no database refresh, no app setup beyond boot.
+
+---
+
+## Writing Livewire tests
+
+```php
+// Preferred shorthand (company panel):
+$this->testLivewire(ListInvoices::class)->assertSuccessful();
+
+// Explicit form:
+Livewire::actingAs($this->user)
+    ->test(ListInvoices::class, ['tenant' => Str::lower($this->company->search_code)])
+    ->assertSuccessful();
+
+// Admin panel:
+Livewire::actingAs($this->superAdmin())
+    ->test(ListUsers::class)
+    ->assertSuccessful();
+
+// Filling a Filament form:
+Livewire::actingAs($this->user)
+    ->test(CreateInvoice::class, ['tenant' => Str::lower($this->company->search_code)])
+    ->fillForm(['number' => 'INV-001', 'status' => InvoiceStatus::DRAFT->value])
+    ->call('create')
+    ->assertHasNoErrors();
+```
+
+---
+
+## Factories
+
+```php
+// User with a specific company attached (company is created + pivoted automatically)
+User::factory()->withCompany(['search_code' => 'IVPLV2', 'name' => 'InvoicePlane Corp'])->create()
+
+// Active, verified user
+User::factory()->create(['is_active' => true, 'email_verified_at' => now()])
+
+// Always pass ->for($company) on company-scoped models — omitting it leaves company_id null
+Invoice::factory()->for($this->company)->create()
+Expense::factory()->for($this->company)->create(['amount' => 50.00])
+```
+
+---
+
+## Roles in tests
+
+Spatie reads roles from the database. Create the DB record before assigning:
+
+```php
+Role::query()->firstOrCreate(['name' => UserRole::SUPER_ADMIN->value, 'guard_name' => 'web']);
+$user->assignRole(UserRole::SUPER_ADMIN->value);
+```
+
+---
+
+## Test method conventions
+
+```php
+#[Test]
+#[Group('smoke')]           // smoke | crud | security | authentication | redirect | edge-cases
+public function it_lists_invoices(): void
+{
+    /* Arrange */
+
+    /* Act */
+
+    /* Assert */
+}
+```
+
+- Method names: `it_<verb>_<subject>` (snake_case)
+- Always use `#[Test]` attribute (not `/** @test */`)
+- Always add `#[Group(...)]` for filtering
+- Use `/* Arrange / Act / Assert */` block comments
+
+---
+
+## PHPUnit discovery
+
+```xml
+<!-- phpunit.xml -->
+<testsuite name="Unit">   <directory>Modules/*/Tests/Unit</directory>   </testsuite>
+<testsuite name="Feature"><directory>Modules/*/Tests/Feature</directory></testsuite>
+```
+
+Run all:        `php artisan test`
+Run one module: `php artisan test Modules/Invoices/Tests/`
+Run one file:   `php artisan test Modules/Invoices/Tests/Feature/InvoicesTest.php`
+Run a group:    `php artisan test --group smoke`
+
+---
+
+## Database for tests
+
+CI uses MariaDB 11. Locally, if no MySQL is running, add to `.env.testing`:
+```
+DB_CONNECTION=sqlite
+DB_DATABASE=:memory:
+```
+
+Carbon is frozen to `2026-01-01 00:00:00` in both panel test base classes — use `Carbon::parse('2026-01-01')` in expected date assertions.
+
+---
+
+## Common pitfalls
+
+| Problem | Fix |
+|---------|-----|
+| Model created with `null` company_id | Add `->for($this->company)` to factory call |
+| Livewire test throws "No tenant" | `Filament::setTenant($company)` in setUp |
+| Role check silently fails | Create Spatie `Role` DB record before `assignRole()` |
+| Test hits MySQL instead of SQLite | Check `.env.testing` has `DB_CONNECTION=sqlite` |
+| `assertRedirect` fails on login test | Set `filament()->setCurrentPanel(filament()->getPanel('company'))` in setUp |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,217 @@
+# InvoicePlane v2 — Agent Context
+
+## What this is
+
+Laravel 11 + Filament v4 + Livewire v3 invoicing app. Modular architecture via `nwidart/laravel-modules`. PHP 8.1+ enums, Spatie roles/permissions, multi-tenancy scoped to `Company`.
+
+## Setup
+
+```bash
+composer install
+cp .env.example .env && php artisan key:generate
+php artisan migrate && php artisan db:seed
+# Tests (no MySQL locally? use SQLite)
+cp .env.testing.example .env.testing
+# set DB_CONNECTION=sqlite, DB_DATABASE=:memory: in .env.testing
+php artisan test
+```
+
+---
+
+## Directory map
+
+```
+app/                        # Thin root (Providers/AppServiceProvider.php only)
+Modules/                    # All business logic (8 modules)
+Modules/Core/Providers/     # All three Filament panel providers
+config/                     # modules.php, ip.php, filament.php, database.php
+database/migrations/        # Only the exports table — all other migrations are per-module
+database/seeders/           # Seeds ivplv2 company (id=22) + 5 random + all roles
+resources/css/filament/     # Per-panel Vite themes
+routes/                     # Empty — routing done entirely by Filament panel providers
+```
+
+### Modules
+
+| Module | Key models |
+|--------|-----------|
+| Core | User, Company, CompanyUser, TaxRate, Numbering, EmailTemplate, CustomField, Upload, Note, AuditLog, Setting, MailQueue |
+| Clients | Relation (table: `relations`), Contact, Address, Communication, ClientCustom (PK: `client_custom_id`) |
+| Invoices | Invoice, InvoiceItem, RecurringInvoice |
+| Quotes | Quote, QuoteItem |
+| Payments | Payment |
+| Products | Product, ProductUnit, ProductCategory |
+| Projects | Project, Task |
+| Expenses | Expense, ExpenseCategory, ExpenseItem |
+
+Module structure:
+```
+Modules/<Name>/
+  Database/{Factories,Migrations,Seeders}/
+  Models/
+  Filament/{Admin,Company}/Resources/<Resource>/{Pages,Tables,Schemas}/
+  Services/         # extend Modules\Core\Services\BaseService
+  Enums/            # PHP 8.1+ backed string enums
+  Events/ Listeners/ Observers/
+  Traits/ Helpers/
+  Http/{Controllers,Requests,Middleware}/
+  Providers/
+  Tests/{Unit,Feature}/
+```
+
+---
+
+## Filament panels
+
+| Provider | Panel ID | URL path | Tenanted | Roles |
+|----------|----------|----------|----------|-------|
+| AdminPanelProvider | `admin` | `/admin` | No | SUPER_ADMIN, ADMIN, ASSIST |
+| CompanyPanelProvider | `company` | `` (root, default) | Yes — Company by `search_code` | CUSTOMER_ADMIN, CUSTOMER |
+| UserPanelProvider | `user` | `/user` | No | (future) |
+
+Company panel tenant middleware (persistent):
+1. `SetTenantFromQueryString` — reads `?tenant=<search_code>`, sets session + Filament tenant
+2. `ConfigureTenant` — resolves tenant from route/query/session/user fallback
+3. `EnsureUserCanAccessCompany` — 403 if regular user not in `company_user` pivot
+
+URLs: `/ivplv2/dashboard` — `search_code` is the route segment, always lowercase.
+
+Panel routes: `filament.<panel-id>.pages.<slug>` and `filament.<panel-id>.resources.<resource>.<action>`
+
+---
+
+## Auth flow
+
+```
+Login page (Modules/Core/Filament/Pages/Auth/Login.php)
+  → checks is_active, rate-limits, regenerates session
+  → returns app(LoginResponse::class)
+
+LoginResponse (Modules/Core/Filament/Responses/LoginResponse.php)
+  → elevated (super_admin/admin/assist): Company::whereRaw('LOWER(search_code) = ?', ['ivplv2'])->first()
+                                         filament()->setTenant($tenant)
+  → regular (client_admin/client):      $user->companies()->whereRaw(...)->first()
+                                         session(['current_company_id' => $tenant->id])
+                                         filament()->setTenant($tenant)
+  → redirect()->route('filament.company.pages.dashboard', ['tenant' => Str::lower($tenant->search_code)])
+```
+
+---
+
+## Roles
+
+```php
+// Modules/Core/Enums/UserRole.php
+SUPER_ADMIN = 'super_admin'      // full access, any panel
+ADMIN       = 'admin'            // elevated
+ASSIST      = 'assist'           // elevated
+CUSTOMER_ADMIN = 'client_admin'  // company panel only
+CUSTOMER    = 'client'           // company panel only
+
+UserRole::elevated()  // ['super_admin', 'admin', 'assist']
+UserRole::nonAdmin()  // ['client_admin', 'client']
+
+$user->hasRole(UserRole::SUPER_ADMIN->value)
+$user->assignRole(UserRole::ADMIN->value)
+$user->isSuperAdmin()
+```
+
+Spatie roles need a DB record in tests:
+```php
+Role::query()->firstOrCreate(['name' => UserRole::SUPER_ADMIN->value, 'guard_name' => 'web']);
+```
+
+---
+
+## Key model facts
+
+- `Company::$primaryKey = 'id'`; URL slug is `search_code` (10 chars, unique, e.g. `ivplv2`)
+- `User::$timestamps = false`
+- `ClientCustom::$primaryKey = 'client_custom_id'`
+- `Import::$primaryKey = 'import_id'`
+- `Relation` model → table `relations` (not `customers`)
+- Soft deletes on Invoice, Quote (and their items)
+- `BelongsToCompany` trait — all business models use it; auto-injects `company_id` on create, adds global scope
+- `company_user` pivot: columns `id, company_id, user_id` (no timestamps)
+- `$user->companies()` — BelongsToMany; `$company->users()` — BelongsToMany
+
+Default company: `ivplv2` — search_code `'ivplv2'`, name `'InvoicePlane Corporation'`, `id=22` (hard-coded in seeder).
+
+---
+
+## Services
+
+All extend `Modules\Core\Services\BaseService`:
+```php
+$this->create(array $data): Model
+$this->find($id): Model
+$this->update(array $input, $model): Model
+$this->delete($id): bool
+$this->paginate($perPage): LengthAwarePaginator
+$this->getCompanyId(): ?int   // resolves from Filament/session/user
+```
+
+No DTO layer — services accept plain arrays.
+
+---
+
+## Testing
+
+### Base classes (`Modules/Core/Tests/`)
+
+```php
+AbstractAdminPanelTestCase   // RefreshDatabase; panel='admin'; $this->company; $this->superAdmin()
+AbstractCompanyPanelTestCase // RefreshDatabase; panel='company'; $this->user; $this->company (search_code='IVPLV2')
+AbstractTestCase             // no RefreshDatabase; pure unit tests
+```
+
+### Writing tests
+
+```php
+// Company panel (most common)
+class FooTest extends AbstractCompanyPanelTestCase {
+    public function it_lists_foo(): void {
+        $this->testLivewire(ListFoo::class)->assertSuccessful();
+        // or explicitly:
+        Livewire::actingAs($this->user)
+            ->test(ListFoo::class, ['tenant' => Str::lower($this->company->search_code)])
+            ->assertSuccessful();
+    }
+}
+
+// Admin panel
+class BarTest extends AbstractAdminPanelTestCase {
+    public function it_lists_bar(): void {
+        Livewire::actingAs($this->superAdmin())->test(ListBar::class)->assertSuccessful();
+    }
+}
+```
+
+### Factories
+
+```php
+User::factory()->withCompany(['search_code' => 'IVPLV2'])->create()
+User::factory()->create(['is_active' => true, 'email_verified_at' => now()])
+Company::factory()->create(['search_code' => 'acme'])
+Invoice::factory()->for($company)->create()   // always pass ->for() on scoped models
+```
+
+### PHPUnit discovery
+
+```xml
+<testsuite name="Unit">   <directory>Modules/*/Tests/Unit</directory>   </testsuite>
+<testsuite name="Feature"><directory>Modules/*/Tests/Feature</directory></testsuite>
+```
+
+---
+
+## Debugging quick-reference
+
+| Symptom | Where to look |
+|---------|--------------|
+| Company-scoped query returns nothing | `session('current_company_id')` set? Filament tenant set? |
+| 403 on company panel | User in `company_user` for that company? |
+| Login redirects to wrong company | `LoginResponse` — checks `LOWER(search_code) = 'ivplv2'` first |
+| Model created with null company_id | Missing `->for($company)` on factory |
+| Livewire test "No tenant" error | `Filament::setTenant($company)` in setUp |
+| Role check fails in tests | Create Spatie Role DB record first |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,253 @@
+# InvoicePlane v2 — Claude Context
+
+## What this is
+
+Laravel 11 + Filament v4 + Livewire v3 invoicing app. Modular architecture via `nwidart/laravel-modules`. PHP 8.1+ enums, Spatie roles/permissions, multi-tenancy via Filament's built-in tenant system scoped to `Company`.
+
+---
+
+## Directory map
+
+```
+app/                        # Thin root (Http/Controllers/ empty, Providers/AppServiceProvider.php)
+Modules/                    # All business logic lives here (8 modules)
+bootstrap/                  # app.php
+config/                     # modules.php, ip.php, filament.php, database.php, app.php
+database/migrations/        # Only the exports table — all other migrations are per-module
+database/seeders/           # DatabaseSeeder.php — seeds ivplv2 company at id=22
+resources/css/filament/     # Per-panel Vite themes (company/nord.css, admin/*, user/*)
+routes/                     # Empty — routing is handled entirely by Filament panel providers
+Modules/Core/Providers/     # All three Filament panel providers live here
+```
+
+### Module inventory
+
+| Module | Key models |
+|--------|-----------|
+| Core | User, Company, CompanyUser, TaxRate, Numbering, EmailTemplate, CustomField, Upload, Note, AuditLog, Setting, MailQueue |
+| Clients | Relation (table: `relations`), Contact, Address, Communication, ClientCustom (`PK: client_custom_id`) |
+| Invoices | Invoice, InvoiceItem, RecurringInvoice |
+| Quotes | Quote, QuoteItem |
+| Payments | Payment |
+| Products | Product, ProductUnit, ProductCategory |
+| Projects | Project, Task |
+| Expenses | Expense, ExpenseCategory, ExpenseItem |
+
+Every module follows:
+```
+Modules/<Name>/
+  Database/{Factories,Migrations,Seeders}/
+  Models/
+  Filament/{Admin,Company}/Resources/<Resource>/{Pages,Tables,Schemas}/
+  Services/
+  Enums/
+  Events/ Listeners/ Observers/
+  Traits/ Helpers/
+  Http/{Controllers,Requests,Middleware}/
+  Providers/
+  Tests/{Unit,Feature}/
+```
+
+---
+
+## Filament panels
+
+Three providers at `Modules/Core/Providers/`:
+
+| Provider | Panel ID | URL path | Tenanted | Access roles |
+|----------|----------|----------|----------|--------------|
+| AdminPanelProvider | `admin` | `/admin` | No | SUPER_ADMIN, ADMIN, ASSIST |
+| CompanyPanelProvider | `company` | `` (root, default) | Yes — `Company` by `search_code` | CUSTOMER_ADMIN, CUSTOMER |
+| UserPanelProvider | `user` | `/user` | No | (minimal, for future use) |
+
+### Company panel tenant config (critical)
+
+```php
+->tenant(Company::class, slugAttribute: 'search_code')
+->tenantMiddleware([
+    SetTenantFromQueryString::class,  // reads ?tenant=<search_code>, sets session + Filament tenant
+    ConfigureTenant::class,           // resolves tenant from route/query/session/user fallback
+    EnsureUserCanAccessCompany::class,// enforces access; 403 if regular user not in company_user
+], isPersistent: true)
+```
+
+URLs look like `/ivplv2/dashboard` (search_code as route segment).
+
+---
+
+## Auth & tenancy flow
+
+1. Login page: `Modules/Core/Filament/Pages/Auth/Login.php`
+   - Rate-limited (5 attempts), checks `$user->is_active`, regenerates session
+   - Returns `app(LoginResponse::class)`
+2. `Modules/Core/Filament/Responses/LoginResponse.php`
+   - Elevated users (super_admin/admin/assist): find company globally → `filament()->setTenant()`
+   - Regular users: find company from `$user->companies()` → set session + Filament tenant
+   - Redirects to `route('filament.company.pages.dashboard', ['tenant' => Str::lower($company->search_code)])`
+3. Company panel middleware chain then enforces access on every subsequent request.
+4. Logout: `Modules/Core/Filament/Responses/LogoutResponse.php` → redirects to `filament.company.auth.login`
+
+### Key relationships
+
+```php
+// User ↔ Company — BelongsToMany via company_user pivot (id, company_id, user_id — no timestamps)
+$user->companies()      // returns Collection<Company>
+$company->users()
+
+// All business models are scoped to a company via BelongsToCompany trait
+// Trait auto-injects company_id on create (from Filament tenant / session / user's first company)
+// Trait adds global scope — queries are always filtered by current company
+```
+
+---
+
+## Roles & permissions (Spatie)
+
+```php
+// Modules/Core/Enums/UserRole.php
+UserRole::SUPER_ADMIN  = 'super_admin'   // full system access
+UserRole::ADMIN        = 'admin'
+UserRole::ASSIST       = 'assist'
+UserRole::CUSTOMER_ADMIN = 'client_admin'  // company-scoped admin
+UserRole::CUSTOMER     = 'client'
+
+UserRole::elevated()   // ['super_admin', 'admin', 'assist'] — can access any panel
+UserRole::nonAdmin()   // ['client_admin', 'client'] — company panel only
+
+// Usage
+$user->hasRole(UserRole::SUPER_ADMIN->value)
+$user->assignRole(UserRole::ADMIN->value)
+$user->isSuperAdmin()  // shorthand
+```
+
+---
+
+## Testing
+
+### Base classes
+
+| Class | Extends | Sets up | Use for |
+|-------|---------|---------|---------|
+| `AbstractAdminPanelTestCase` | TestCase + RefreshDatabase | Company factory + superAdmin user; panel='admin'; Carbon frozen 2026-01-01 | Admin panel Livewire tests |
+| `AbstractCompanyPanelTestCase` | TestCase + RefreshDatabase | User with company (search_code='IVPLV2'); Filament tenant set quietly; session current_company_id | Company panel Livewire tests |
+| `AbstractTestCase` | TestCase (no RefreshDatabase) | Nothing | Pure unit tests |
+
+All live at `Modules/Core/Tests/`.
+
+### Patterns
+
+```php
+// Company panel test
+class FooTest extends AbstractCompanyPanelTestCase {
+    public function it_does_something(): void {
+        $response = Livewire::actingAs($this->user)
+            ->test(ListFoo::class, ['tenant' => Str::lower($this->company->search_code)])
+            ->assertSuccessful();
+    }
+    // Or use the helper:
+    $this->testLivewire(ListFoo::class)->assertSuccessful();
+}
+
+// Admin panel test
+class BarTest extends AbstractAdminPanelTestCase {
+    public function it_does_something(): void {
+        Livewire::actingAs($this->superAdmin())->test(ListBar::class)->assertSuccessful();
+    }
+}
+
+// Create a role in tests (Spatie needs DB record)
+Role::query()->firstOrCreate(['name' => UserRole::SUPER_ADMIN->value, 'guard_name' => 'web']);
+$user->assignRole(UserRole::SUPER_ADMIN->value);
+```
+
+### Factory patterns
+
+```php
+// User with a specific company attached
+User::factory()->withCompany(['search_code' => 'IVPLV2', 'name' => '...'])->create()
+
+// Company-scoped model — pass company via ->for() or via session/tenant
+Invoice::factory()->for($company)->create()
+
+// Active user
+User::factory()->create(['is_active' => true, 'email_verified_at' => now()])
+```
+
+### PHPUnit test discovery
+
+```xml
+<!-- phpunit.xml -->
+<testsuite name="Unit">   <directory>Modules/*/Tests/Unit</directory>  </testsuite>
+<testsuite name="Feature"><directory>Modules/*/Tests/Feature</directory></testsuite>
+```
+
+### DB for tests
+
+Tests need a DB. Production CI uses MariaDB 11. For local dev without MySQL, set in `.env.testing`:
+```
+DB_CONNECTION=sqlite
+DB_DATABASE=:memory:
+```
+
+---
+
+## Key model notes
+
+- `Company::$primaryKey` = `id` (standard); URL slug is `search_code` (10 chars, unique, e.g. `ivplv2`)
+- `User::$timestamps = false` — no created_at/updated_at on users table
+- `ClientCustom::$primaryKey = 'client_custom_id'` — non-standard PK
+- `Import::$primaryKey = 'import_id'` — non-standard PK
+- `Relation` model → table `relations` (not `customers`, not `clients`)
+- Soft deletes on: Invoice, Quote (and their items)
+- `BelongsToCompany` trait → adds `company()` BelongsTo, `scopeForCompany()`, and global scope
+
+---
+
+## Services
+
+All services extend `Modules\Core\Services\BaseService`:
+```php
+// BaseService gives you:
+$this->create(array $data): Model
+$this->find($id): Model
+$this->update(array $input, $model): Model
+$this->delete($id): bool
+$this->paginate($perPage): LengthAwarePaginator
+$this->getCompanyId(): ?int   // resolves from Filament/session/user
+```
+
+No DTO layer — services accept arrays and return Eloquent models.
+
+---
+
+## Seeder
+
+`database/seeders/DatabaseSeeder.php` seeds:
+- `ivplv2` company hard-coded at `id=22`, `search_code='ivplv2'`, `name='InvoicePlane Corporation'`
+- 5 additional random companies
+- Spatie roles for all UserRole values
+- One user per role, all attached to ivplv2
+
+---
+
+## Common debugging shortcuts
+
+| Symptom | Check |
+|---------|-------|
+| Company-scoped query returns nothing | `session('current_company_id')` set? Filament tenant set? |
+| 403 on company panel route | User in `company_user` pivot for that company? |
+| Redirect after login goes to wrong company | `LoginResponse::DEFAULT_COMPANY_CODE` constant and `whereRaw('LOWER(search_code) = ?')` query |
+| Factory creates model with null company_id | Pass `->for($company)` or set Filament tenant before creation |
+| Livewire test fails with "No tenant" | Call `Filament::setTenant($company)` in test setUp |
+| Test role check fails | Create Role DB record first with `Role::query()->firstOrCreate(...)` |
+
+---
+
+## Don't re-derive these
+
+- The default company is **always** `ivplv2` (search_code, lowercase in URLs)
+- Panel routes are named `filament.<panel-id>.pages.<slug>` and `filament.<panel-id>.resources.<resource>.<action>`
+- `$user->companies()` returns the BelongsToMany — call `.first()`, `.attach()`, `.detach()` on it
+- `Str::lower($company->search_code)` is always the URL tenant parameter
+- The three tenant middleware classes live at `Modules/Core/Http/Middleware/`
+- Panel providers live at `Modules/Core/Providers/`, not `app/Providers/`


### PR DESCRIPTION
Captures module layout, Filament panel config, auth/tenancy flow,
testing base classes and patterns, key model quirks (non-standard PKs,
BelongsToCompany trait), service layer, seeder defaults, and a
debugging quick-reference table.

Lets Claude sessions start with full context instead of re-scanning
the codebase on every request.

https://claude.ai/code/session_01KVV91ECY14zwgavRm99zPs