### PR TITLE
feat(#191,#192): create invoice/quote pre-filled from client detail

### DIFF
--- a/Modules/Invoices/Filament/Company/Resources/Invoices/InvoiceResource.php
+++ b/Modules/Invoices/Filament/Company/Resources/Invoices/InvoiceResource.php
@@ -7,6 +7,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Modules\Core\Filament\Company\Resources\BaseResource;
+use Modules\Invoices\Filament\Company\Resources\Invoices\Pages\CreateInvoice;
 use Modules\Invoices\Filament\Company\Resources\Invoices\Pages\ListInvoices;
 use Modules\Invoices\Filament\Company\Resources\Invoices\Schemas\InvoiceForm;
 use Modules\Invoices\Filament\Company\Resources\Invoices\Tables\InvoicesTable;
@@ -58,7 +59,8 @@ class InvoiceResource extends BaseResource
     public static function getPages(): array
     {
         return [
-            'index' => ListInvoices::route('/'),
+            'index'  => ListInvoices::route('/'),
+            'create' => CreateInvoice::route('/create'),
         ];
     }
 }

--- a/Modules/Invoices/Filament/Company/Resources/Invoices/Pages/CreateInvoice.php
+++ b/Modules/Invoices/Filament/Company/Resources/Invoices/Pages/CreateInvoice.php
@@ -6,6 +6,7 @@ use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Database\Eloquent\Model;
 use Modules\Invoices\Filament\Company\Resources\Invoices\InvoiceResource;
 use Modules\Invoices\Services\InvoiceService;
+use function request;
 
 class CreateInvoice extends CreateRecord
 {
@@ -44,5 +45,23 @@ class CreateInvoice extends CreateRecord
     protected function handleRecordCreation(array $data): Model
     {
         return app(InvoiceService::class)->createInvoice($data);
+    }
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        if ($customerId = request()->integer('customer_id')) {
+            $data['customer_id'] = $customerId;
+        }
+
+        return $data;
+    }
+
+    public function mount(): void
+    {
+        parent::mount();
+
+        if ($customerId = request()->integer('customer_id')) {
+            $this->form->fill(['customer_id' => $customerId]);
+        }
     }
 }

--- a/Modules/Quotes/Filament/Company/Resources/Quotes/Pages/CreateQuote.php
+++ b/Modules/Quotes/Filament/Company/Resources/Quotes/Pages/CreateQuote.php
@@ -6,6 +6,7 @@ use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Database\Eloquent\Model;
 use Modules\Quotes\Filament\Company\Resources\Quotes\QuoteResource;
 use Modules\Quotes\Services\QuoteService;
+use function request;
 
 class CreateQuote extends CreateRecord
 {
@@ -43,5 +44,23 @@ class CreateQuote extends CreateRecord
     protected function handleRecordCreation(array $data): Model
     {
         return app(QuoteService::class)->createQuote($data);
+    }
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        if ($customerId = request()->integer('customer_id')) {
+            $data['customer_id'] = $customerId;
+        }
+
+        return $data;
+    }
+
+    public function mount(): void
+    {
+        parent::mount();
+
+        if ($customerId = request()->integer('customer_id')) {
+            $this->form->fill(['customer_id' => $customerId]);
+        }
     }
 }

--- a/Modules/Quotes/Filament/Company/Resources/Quotes/QuoteResource.php
+++ b/Modules/Quotes/Filament/Company/Resources/Quotes/QuoteResource.php
@@ -7,6 +7,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Modules\Core\Filament\Company\Resources\BaseResource;
+use Modules\Quotes\Filament\Company\Resources\Quotes\Pages\CreateQuote;
 use Modules\Quotes\Filament\Company\Resources\Quotes\Pages\ListQuotes;
 use Modules\Quotes\Filament\Company\Resources\Quotes\Schemas\QuoteForm;
 use Modules\Quotes\Filament\Company\Resources\Quotes\Tables\QuotesTable;
@@ -57,7 +58,8 @@ class QuoteResource extends BaseResource
     public static function getPages(): array
     {
         return [
-            'index' => ListQuotes::route('/'),
+            'index'  => ListQuotes::route('/'),
+            'create' => CreateQuote::route('/create'),
         ];
     }
 }


### PR DESCRIPTION
## Summary

- **#191** — `InvoiceResource` now registers `CreateInvoice` page; `CreateInvoice.mount()` reads `?customer_id=` from URL and pre-fills the form; `mutateFormDataBeforeCreate()` persists the value
- **#192** — same pattern for `QuoteResource` / `CreateQuote`
- Client detail table actions (Create Invoice / Create Quote buttons) wired up in the #221 PR via `RelationsTable`

## Test plan

- [ ] Navigate to client detail → "Create Invoice" button → invoice form opens with client pre-selected
- [ ] Navigate to client detail → "Create Quote" button → quote form opens with client pre-selected
- [ ] Create an invoice/quote without the `?customer_id` param — form still works normally

Addresses #191
Addresses #192

https://claude.ai/code/session_01L9apN3AW7b5h7ypmBA5pUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9apN3AW7b5h7ypmBA5pUg)_