### PR TITLE
[IP-547]: fix: allow empty MariaDB root password in docker-compoer. Closes #547

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         ports:
             - "3306:3306"
         environment:
-            MARIADB_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+            MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "yes"
             MARIADB_DATABASE: "${DB_DATABASE}"
             MARIADB_USER: "${DB_USERNAME}"
             MARIADB_PASSWORD: "${DB_PASSWORD}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
         environment:
             MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "yes"
             MARIADB_DATABASE: "${DB_DATABASE}"
-            MARIADB_USER: "${DB_USERNAME}"
-            MARIADB_PASSWORD: "${DB_PASSWORD}"
             TZ: "Europe/London"
 
     mailcatcher:


### PR DESCRIPTION
# Pull Request Checklist  

## Checklist  
- [x] My code follows the code formatting guidelines.  
- [x] I have tested my changes locally.  
- [x] I selected the appropriate branch for this PR.  
- [x] I have rebased my changes on top of the selected branch.  
- [x] I included relevant documentation updates if necessary.  
- [x] I have an accompanying issue ID for this pull request.  

---

## Description  
Replace `MARIADB_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"` with `MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "yes"` in `docker-compose.yml`. The previous configuration caused the MariaDB container to crash-loop on a fresh clone because `MYSQL_ROOT_PASSWORD` is not defined in `.env` or `.env.example`. 

---

## Related Issue(sr)  
Fixes #547

---

## Motivation and Context  
On a fresh clone, `docker compose up` would leave the DB container in a restart loop with `[ERROR] Database is uninitialized and password option is not specified`. This blocked local development entirely. The fix aligns the Docker config with the project's existing `.env` convention of using root with no password (`DB_USERNAME=root`, `DB_PASSWORD` empty). 

---

## Issue Type (Check one or more)  
- [x] Bugfix  

---

## Screenshots (If Applicable)  
N/A, this is a configuration fix with no UI impact. 

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration to streamline local development environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->