### PR TITLE
chore(skills): audit and repair all 25 skill files

### DIFF
--- a/.claude/skills/autonomous-coding-workflow/SKILL.md
+++ b/.claude/skills/autonomous-coding-workflow/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: autonomous-coding-workflow
+description: Governs safe, incremental, repository-wide development workflow with continuous validation gates
+---
+
 # Autonomous Coding Workflow
 
 ## Goal

--- a/.claude/skills/ci-schema-invariant-gate/SKILL.md
+++ b/.claude/skills/ci-schema-invariant-gate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ci-schema-gate
+name: ci-schema-invariant-gate
 description: Ensures correct execution order of migrations, seeders, and tests in CI
 ---
 

--- a/.claude/skills/dto-contract/SKILL.md
+++ b/.claude/skills/dto-contract/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dto-contracts
+name: dto-contract
 description: Defines DTO structure, lifecycle, and transformation rules across the application
 license: MIT
 metadata:

--- a/.claude/skills/filament-multi-tenancy/SKILL.md
+++ b/.claude/skills/filament-multi-tenancy/SKILL.md
@@ -105,21 +105,9 @@ Filament::setTenant($companyA, isQuiet: true);
 
 ## Tenant Middleware Stack
 
-The company panel uses three tenant middlewares (in order):
-
-1. `SetTenantFromQueryString` — reads `?tenant=search_code`, validates access
-2. `ConfigureTenant` — resolves tenant from route/query/session/user default, writes to session
-3. `EnsureUserCanAccessCompany` — enforces authorization (elevated roles bypass; regular users must own the company)
-
-These are registered as persistent tenant middleware in `CompanyPanelProvider`:
-
-```php
-->tenantMiddleware([
-    SetTenantFromQueryString::class,
-    ConfigureTenant::class,
-    EnsureUserCanAccessCompany::class,
-], isPersistent: true)
-```
+See the `tenant-middleware` skill for the full middleware chain. In short: three
+persistent middlewares run on every company panel request in this order:
+`SetTenantFromQueryString` → `ConfigureTenant` → `EnsureUserCanAccessCompany`.
 
 ## Tenant in Tests Setup
 

--- a/.claude/skills/filament-panel-setup/SKILL.md
+++ b/.claude/skills/filament-panel-setup/SKILL.md
@@ -8,12 +8,15 @@ metadata:
 
 # Filament Panel Setup
 
-This app has two panels:
+This app has three panels:
 
-| Panel | Provider | Id | Default? | Tenant |
-|-------|----------|----|----------|--------|
-| Company | `CompanyPanelProvider` | `company` | No | `Company::class` |
-| Admin | `AdminPanelProvider` | `admin` | Yes | None |
+| Panel | Provider | Id | Default? | Tenant | Access |
+|-------|----------|----|----------|--------|--------|
+| Company | `CompanyPanelProvider` | `company` | Yes (root) | `Company::class` | `client_admin`, `client` |
+| Admin | `AdminPanelProvider` | `admin` | No | None | `super_admin`, `admin`, `assist` |
+| User | `UserPanelProvider` | `user` | No | None | minimal, future use |
+
+All three providers live at `Modules/Core/Providers/`.
 
 ## Registering Module Resources
 

--- a/.claude/skills/filament-resource-pages/SKILL.md
+++ b/.claude/skills/filament-resource-pages/SKILL.md
@@ -1,126 +1,196 @@
 ---
-name: service-layer
-description: Defines application service structure and business orchestration boundaries
+name: filament-resource-pages
+description: "Defines the Filament v4 resource page structure used in this project: Resource + Pages + Schemas + Tables split, action patterns, and BaseResource conventions."
 license: MIT
 metadata:
   author: project
 ---
 
-# Service Layer
+# Filament Resource Pages
 
-Services define business orchestration and are the primary boundary for business logic execution.
+## Resource Directory Layout
 
-They are framework-agnostic and represent application behavior independent of UI or transport layers.
+Every resource lives under `Modules/{Name}/Filament/{Panel}/Resources/{Model}/`:
 
----
+```
+{Model}Resource.php          ← extends BaseResource; declares model, nav, pages
+Pages/
+  List{Model}.php             ← extends ListRecords
+  Create{Model}.php           ← extends CreateRecord
+  Edit{Model}.php             ← extends EditRecord
+Schemas/
+  {Model}Form.php             ← static configure(Schema $schema): Schema
+Tables/
+  {Model}sTable.php           ← static configure(Table $table): Table
+RelationManagers/             ← optional
+```
 
-# 1. Responsibility
-
-Services MUST:
-
-- contain business logic
-- coordinate models and repositories
-- enforce domain rules
-- return models or internally used DTOs
-- encapsulate persistence logic
-
-Services MUST NOT:
-
-- use Filament
-- depend on HTTP layer (requests/responses)
-- contain UI logic
-- use service locators (`app()`, `resolve()`)
-- depend on transport concerns
+Schemas and Tables are **separate classes**, never defined inline inside the Resource.
 
 ---
 
-# 2. Dependency Rule
-
-Services MUST use constructor injection:
+## Resource Class
 
 ```php
-public function __construct(
-    private InvoiceRepository $repository
-) {}
+class InvoiceResource extends BaseResource
+{
+    protected static ?string $model = Invoice::class;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBanknotes;
+    protected static ?int $navigationSort = 10;
+    protected static bool $isScopedToTenant = true;
+
+    public static function form(Schema $schema): Schema
+    {
+        return InvoiceForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return InvoicesTable::configure($table);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index'  => Pages\ListInvoices::route('/'),
+            'create' => Pages\CreateInvoice::route('/create'),
+            'edit'   => Pages\EditInvoice::route('/{record}/edit'),
+        ];
+    }
+}
 ```
 
-No service locator usage is allowed inside services.
+`BaseResource` handles tenant-scoped queries automatically — do NOT add manual `company_id` filters.
 
 ---
 
-# 3. DTO Rule (Refined)
-
-DTOs are NOT required for UI → Service communication.
-
-DTO usage depends on coupling, not layer type:
-
-## DTOs are required when:
-- crossing system boundaries (API, external integrations, queues)
-- multiple consumers share a contract
-- transformation logic must be standardized
-- stability across versions is required
-
-## DTOs are NOT required when:
-- input originates from trusted UI layer (e.g. Filament Forms)
-- single consumer exists
-- payload is short-lived and not reused elsewhere
-
-### Rule of thumb:
-> DTOs exist to stabilize unstable or shared contracts, not to formalize trusted UI input.
-
-Services MAY still use DTOs internally if they improve clarity or structure.
-
----
-
-# 4. Filament Boundary Rule
-
-Filament is a UI orchestration layer.
-
-## Allowed usage:
-
-### Pages / Resources
-- constructor injection preferred
-- `app(Service::class)` allowed as fallback when needed
-
-### Table Actions / Closures
-- `app(Service::class)` is allowed
-- constructor injection is not guaranteed in closure scope
-
-Example:
+## List Page
 
 ```php
-Action::make('create')
-    ->action(function (array $data) {
-        app(InvoiceService::class)->createInvoice($data);
-    });
-```
+class ListInvoices extends ListRecords
+{
+    protected static string $resource = InvoiceResource::class;
 
-This is acceptable boundary-layer behavior.
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make()
+                ->modalWidth('full')
+                ->action(function (array $data) {
+                    app(InvoiceService::class)->createInvoice($data);
+                }),
+        ];
+    }
+}
+```
 
 ---
 
-# 5. Standard Service Shape
+## Edit Page
 
-```
-Modules/{Name}/src/Services/{Model}Service.php
+Override `save()` when you need to route the update through the service layer:
+
+```php
+class EditInvoice extends EditRecord
+{
+    protected static string $resource = InvoiceResource::class;
+
+    public function save(bool $shouldRedirect = true, bool $shouldSendSavedNotification = true): void
+    {
+        $this->authorizeAccess();
+        $this->callHook('beforeValidate');
+        $data = $this->form->getState();
+        $this->callHook('afterValidate');
+        $data = $this->mutateFormDataBeforeSave($data);
+        $this->callHook('beforeSave');
+
+        app(InvoiceService::class)->updateInvoice($data, $this->getRecord());
+
+        $this->callHook('afterSave');
+
+        if ($shouldRedirect) {
+            $this->redirect($this->getRedirectUrl());
+        }
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [DeleteAction::make()];
+    }
+}
 ```
 
 ---
 
-# 6. Standard Methods
+## Schema Class
 
-- createX
-- updateX
-- deleteX
-- findOrFail
-- listForCompany
+```php
+class InvoiceForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema->components([
+            Grid::make(2)->schema([
+                Section::make('Details')->schema([
+                    Select::make('customer_id')->relationship('customer', 'company_name')->required(),
+                    DatePicker::make('invoice_date')->required(),
+                ]),
+            ]),
+        ]);
+    }
+}
+```
 
 ---
 
-# 7. Core Principle
+## Table Class
 
-Services are pure business units.
+```php
+class InvoicesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('invoice_number')->searchable()->sortable(),
+                TextColumn::make('invoice_status')->badge(),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([DeleteBulkAction::make()]),
+            ]);
+    }
+}
+```
 
-They MUST remain independent of framework execution context.
+---
 
-UI layers may use service locator as a pragmatic escape hatch where DI is not available.
+## Action Closure Rule
+
+Filament action closures do NOT support constructor injection. Always use `app()`:
+
+```php
+->action(function (array $data) {
+    app(InvoiceService::class)->createInvoice($data);
+})
+```
+
+This is the only place `app()` is acceptable. Services themselves must never use it.
+
+---
+
+## Panel Registration
+
+Resources are discovered per module in `CompanyPanelProvider`:
+
+```php
+->discoverResources(
+    in: base_path('Modules/Invoices/Filament/Company/Resources'),
+    for: 'Modules\\Invoices\\Filament\\Company\\Resources'
+)
+```
+
+Both `in` and `for` must exactly match the module's filesystem path and PHP namespace.

--- a/.claude/skills/filament-resource-pages/SKILL.md
+++ b/.claude/skills/filament-resource-pages/SKILL.md
@@ -188,9 +188,9 @@ Resources are discovered per module in `CompanyPanelProvider`:
 
 ```php
 ->discoverResources(
-    in: base_path('Modules/Invoices/Filament/Company/Resources'),
+    in: base_path('modules/invoices/src/Filament/Company/Resources'),
     for: 'Modules\\Invoices\\Filament\\Company\\Resources'
 )
 ```
 
-Both `in` and `for` must exactly match the module's filesystem path and PHP namespace.
+The `in` parameter uses the filesystem path (lowercase with `src/`), while `for` uses the PHP namespace.

--- a/.claude/skills/laravel-modules/SKILL.md
+++ b/.claude/skills/laravel-modules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: laravel-modules
-description: "Creates and modifies code inside the Modules/ directory structure. Activates when adding a new module, adding a model/factory/migration/resource/service to an existing module, registering a module with Filament, or when the user mentions modules, modular, or a specific module name (clients, invoices, payments, etc.)."
+description: "Creates and modifies code inside a modular Laravel structure. Targets internachi/modular (modules as real Composer packages with src/). Activates when adding a new module, adding a model/factory/migration/resource/service to an existing module, registering a module with Filament, or when the user mentions modules, modular, or a specific module name."
 license: MIT
 metadata:
   author: project
@@ -8,99 +8,202 @@ metadata:
 
 # Laravel Modules
 
-This project uses `nwidart/laravel-modules` (≥ v12). Modules live under `Modules/`.
+## Package Standard: `internachi/modular`
 
-## Directory Layout
+New modules use [`internachi/modular`](https://github.com/InterNACHI/modular).
+Each module is a **real Composer package** with its own `composer.json`, resolved
+from the root via a path repository. This makes modules portable, independently
+testable, and properly autoloaded.
 
-Every module follows this exact layout (note uppercase `Database/` and `Tests/`):
+> **InvoicePlane-v2 exception:** This project was built with `nwidart/laravel-modules`
+> and has **no `src/` layer** — the module root is the PSR-4 root. If you are
+> working in this repo, skip the `src/` wrapper and use uppercase `Database/`,
+> `Tests/` directly under the module root. See the nwidart section at the bottom.
 
-```
-Modules/{Name}/
-  Database/
-    Factories/        ← Eloquent factories
-    Migrations/       ← Module-specific migrations
-    Seeders/          ← Module seeders (extend AbstractSeeder)
-  Filament/
-    Admin/Resources/  ← Admin panel resources (if any)
-    Company/
-      Resources/
-        {Model}/
-          {Model}Resource.php     ← extends BaseResource
-          Pages/
-            List{Model}.php
-            Create{Model}.php
-            Edit{Model}.php
-          Schemas/
-            {Model}Form.php
-          Tables/
-            {Model}sTable.php
-  Models/             ← Eloquent models
-  Enums/
-  Events/
-  Listeners/
-  Observers/
-  Providers/          ← {Name}ServiceProvider
-  Services/           ← {Name}Service
-  Traits/
-  Tests/
-    Feature/          ← PHPUnit feature tests
-    Unit/             ← PHPUnit unit tests
-  resources/
-    views/            ← Blade views namespaced as '{name}::'
-  composer.json
-  module.json
-```
+---
 
-## Namespace Convention
+## `internachi/modular` Directory Layout
 
 ```
-Modules\{Name}\
-Modules\{Name}\Models\
-Modules\{Name}\Filament\Company\Resources\{Model}\{Model}Resource
-Modules\{Name}\Database\Factories\{Model}Factory
-Modules\{Name}\Database\Seeders\{Model}Seeder
-Modules\{Name}\Services\{Model}Service
-Modules\{Name}\Tests\Feature\{Model}Test
+modules/
+  {name}/                        ← lowercase, kebab-case
+    src/                         ← PSR-4 root
+      {Name}ServiceProvider.php
+      Models/
+      Enums/
+      Events/ Listeners/ Observers/
+      Filament/
+        Company/
+          Resources/
+            {Model}/
+              {Model}Resource.php
+              Pages/
+                List{Model}.php
+                Create{Model}.php
+                Edit{Model}.php
+              Schemas/
+                {Model}Form.php
+              Tables/
+                {Model}sTable.php
+      Http/
+      Services/
+      Traits/
+    database/
+      factories/
+      migrations/
+      seeders/
+    tests/
+      Feature/
+      Unit/
+    composer.json
 ```
 
-## Service Provider
+---
 
-Every module has a `{Name}ServiceProvider` registered in `config/app.php`:
+## Module `composer.json`
 
-```php
-class ClientsServiceProvider extends ServiceProvider
+```json
 {
-    public function boot(): void
-    {
-        $this->loadViewsFrom(__DIR__ . '/../../resources/views', 'clients');
-        $this->loadMigrationsFrom(__DIR__ . '/../../Database/Migrations');
-        Client::observe(ClientObserver::class); // only if observer exists
+    "name": "app/{name}",
+    "description": "The {Name} module",
+    "type": "library",
+    "require": {},
+    "autoload": {
+        "psr-4": {
+            "App\\{Name}\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\{Name}\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "App\\{Name}\\{Name}ServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}
+```
+
+---
+
+## Root `composer.json` Wiring
+
+```json
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "./modules/*",
+            "options": { "symlink": true }
+        }
+    ],
+    "require": {
+        "app/core":     "*",
+        "app/invoices": "*"
     }
 }
 ```
 
-## Registering a New Module
+Run `composer require app/{name}:*` whenever a new module is added.
 
-1. Create the directory tree above.
-2. Add `{Name}ServiceProvider` to `config/app.php` providers array.
-3. Register the factory namespace in `app/Providers/AppServiceProvider.php`
-   following the pattern used by existing modules (`Factory::guessFactoryNamesUsing`).
-4. Add `->discoverResources(...)` to `CompanyPanelProvider`:
+---
+
+## Namespace Convention
+
+```
+App\{Name}\
+App\{Name}\Models\
+App\{Name}\Filament\Company\Resources\{Model}\{Model}Resource
+App\{Name}\Database\Factories\{Model}Factory
+App\{Name}\Database\Seeders\{Model}Seeder
+App\{Name}\Services\{Model}Service
+App\{Name}\Tests\Feature\{Model}Test
+```
+
+---
+
+## Service Provider
+
+The service provider is auto-discovered via `composer.json`. It only needs to
+load migrations and register observers:
+
+```php
+namespace App\Invoices;
+
+use Illuminate\Support\ServiceProvider;
+
+class InvoicesServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'invoices');
+    }
+}
+```
+
+No manual entry in `config/app.php` — Composer's auto-discovery handles it.
+
+---
+
+## Filament Resource Registration
+
+Add `->discoverResources()` per module in `CompanyPanelProvider`:
 
 ```php
 ->discoverResources(
-    in: base_path('Modules/Mymodule/Filament/Company/Resources'),
-    for: 'Modules\\Mymodule\\Filament\\Company\\Resources'
+    in: base_path('modules/invoices/src/Filament/Company/Resources'),
+    for: 'App\\Invoices\\Filament\\Company\\Resources'
 )
 ```
 
-## Test Auto-Discovery
+---
 
-`phpunit.xml` discovers tests automatically — no registration needed:
+## Test Discovery
+
+Configure `phpunit.xml` to pick up all module test directories:
 
 ```xml
-<directory>Modules/*/Tests/Unit</directory>
-<directory>Modules/*/Tests/Feature</directory>
+<testsuite name="Unit">
+    <directory>modules/*/tests/Unit</directory>
+</testsuite>
+<testsuite name="Feature">
+    <directory>modules/*/tests/Feature</directory>
+</testsuite>
 ```
 
-Just put tests under `Modules/{Name}/Tests/Feature/` or `Tests/Unit/`.
+---
+
+## Adding a New Module (Checklist)
+
+1. Create `modules/{name}/` with the directory tree above.
+2. Write `modules/{name}/composer.json` (copy from existing module, change name/namespace).
+3. Run `composer require app/{name}:*` from the project root.
+4. Add `->discoverResources(...)` to `CompanyPanelProvider`.
+5. Run `php artisan migrate` to pick up the new module's migrations.
+
+---
+
+## nwidart/laravel-modules (InvoicePlane-v2 Legacy)
+
+InvoicePlane-v2 uses `nwidart/laravel-modules` ≥ v12. The key differences:
+
+| | `internachi/modular` | `nwidart` (InvoicePlane-v2) |
+|---|---|---|
+| Module root | `modules/{name}/` | `Modules/{Name}/` |
+| PSR-4 source | `src/` | module root directly |
+| Namespace | `App\{Name}\` | `Modules\{Name}\` |
+| Tests | `tests/` (lowercase) | `Tests/` (uppercase) |
+| DB files | `database/` (lowercase) | `Database/` (uppercase) |
+| Discovery | Composer path repo | `module.json` + manual provider |
+| Registration | `composer require` | add to `config/app.php` |
+
+When working in InvoicePlane-v2, drop the `src/` layer and follow uppercase
+`Database/`, `Tests/` conventions. All else (service structure, Filament patterns,
+test base classes) remains the same.

--- a/.claude/skills/laravel-modules/SKILL.md
+++ b/.claude/skills/laravel-modules/SKILL.md
@@ -70,18 +70,18 @@ modules/
     "require": {},
     "autoload": {
         "psr-4": {
-            "App\\{Name}\\": "src/"
+            "Modules\\{Name}\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "App\\{Name}\\Tests\\": "tests/"
+            "Modules\\{Name}\\Tests\\": "tests/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "App\\{Name}\\{Name}ServiceProvider"
+                "Modules\\{Name}\\{Name}ServiceProvider"
             ]
         }
     },
@@ -117,13 +117,13 @@ Run `composer require app/{name}:*` whenever a new module is added.
 ## Namespace Convention
 
 ```
-App\{Name}\
-App\{Name}\Models\
-App\{Name}\Filament\Company\Resources\{Model}\{Model}Resource
-App\{Name}\Database\Factories\{Model}Factory
-App\{Name}\Database\Seeders\{Model}Seeder
-App\{Name}\Services\{Model}Service
-App\{Name}\Tests\Feature\{Model}Test
+Modules\{Name}\
+Modules\{Name}\Models\
+Modules\{Name}\Filament\Company\Resources\{Model}\{Model}Resource
+Modules\{Name}\Database\Factories\{Model}Factory
+Modules\{Name}\Database\Seeders\{Model}Seeder
+Modules\{Name}\Services\{Model}Service
+Modules\{Name}\Tests\Feature\{Model}Test
 ```
 
 ---
@@ -134,7 +134,7 @@ The service provider is auto-discovered via `composer.json`. It only needs to
 load migrations and register observers:
 
 ```php
-namespace App\Invoices;
+namespace Modules\Invoices;
 
 use Illuminate\Support\ServiceProvider;
 
@@ -159,7 +159,7 @@ Add `->discoverResources()` per module in `CompanyPanelProvider`:
 ```php
 ->discoverResources(
     in: base_path('modules/invoices/src/Filament/Company/Resources'),
-    for: 'App\\Invoices\\Filament\\Company\\Resources'
+    for: 'Modules\\Invoices\\Filament\\Company\\Resources'
 )
 ```
 
@@ -198,7 +198,7 @@ InvoicePlane-v2 uses `nwidart/laravel-modules` ≥ v12. The key differences:
 |---|---|---|
 | Module root | `modules/{name}/` | `Modules/{Name}/` |
 | PSR-4 source | `src/` | module root directly |
-| Namespace | `App\{Name}\` | `Modules\{Name}\` |
+| Namespace | `Modules\{Name}\` | `Modules\{Name}\` |
 | Tests | `tests/` (lowercase) | `Tests/` (uppercase) |
 | DB files | `database/` (lowercase) | `Database/` (uppercase) |
 | Discovery | Composer path repo | `module.json` + manual provider |

--- a/.claude/skills/laravel-modules/SKILL.md
+++ b/.claude/skills/laravel-modules/SKILL.md
@@ -8,49 +8,55 @@ metadata:
 
 # Laravel Modules
 
-This project uses a hand-rolled modular structure under `Modules/`. There is no
-`nwidart/laravel-modules` package — modules are plain directories registered
-manually.
+This project uses `nwidart/laravel-modules` (≥ v12). Modules live under `Modules/`.
 
 ## Directory Layout
 
-Every module follows this exact layout:
+Every module follows this exact layout (note uppercase `Database/` and `Tests/`):
 
 ```
 Modules/{Name}/
-  database/
-    factories/        ← Eloquent factories
-    migrations/       ← Module-specific migrations
-    seeders/          ← Module seeders (extend AbstractSeeder)
-  resources/
-    views/            ← Blade views namespaced as '{name}::'
-  src/
-    Contracts/        ← Interfaces / contracts (optional)
-    Enums/            ← Module enums
-    Filament/
+  Database/
+    Factories/        ← Eloquent factories
+    Migrations/       ← Module-specific migrations
+    Seeders/          ← Module seeders (extend AbstractSeeder)
+  Filament/
+    Admin/Resources/  ← Admin panel resources (if any)
+    Company/
       Resources/
         {Model}/
           {Model}Resource.php     ← extends BaseResource
           Pages/
-            List{Model}.php       ← extends ListRecords
-            Create{Model}.php     ← extends CreateRecord
-            Edit{Model}.php       ← extends EditRecord
-    Models/           ← Eloquent models
-    Observers/        ← Model observers (optional)
-    Providers/        ← {Name}ServiceProvider
-    Services/         ← {Name}Service (createX, updateX, deleteX, listForCompany)
-    Traits/           ← Shared traits (optional)
-  tests/
+            List{Model}.php
+            Create{Model}.php
+            Edit{Model}.php
+          Schemas/
+            {Model}Form.php
+          Tables/
+            {Model}sTable.php
+  Models/             ← Eloquent models
+  Enums/
+  Events/
+  Listeners/
+  Observers/
+  Providers/          ← {Name}ServiceProvider
+  Services/           ← {Name}Service
+  Traits/
+  Tests/
     Feature/          ← PHPUnit feature tests
     Unit/             ← PHPUnit unit tests
+  resources/
+    views/            ← Blade views namespaced as '{name}::'
+  composer.json
+  module.json
 ```
 
 ## Namespace Convention
 
 ```
-Modules\{Name}\            root namespace
-Modules\{Name}\Models\     models
-Modules\{Name}\Filament\Resources\{Model}\{Model}Resource
+Modules\{Name}\
+Modules\{Name}\Models\
+Modules\{Name}\Filament\Company\Resources\{Model}\{Model}Resource
 Modules\{Name}\Database\Factories\{Model}Factory
 Modules\{Name}\Database\Seeders\{Model}Seeder
 Modules\{Name}\Services\{Model}Service
@@ -59,18 +65,15 @@ Modules\{Name}\Tests\Feature\{Model}Test
 
 ## Service Provider
 
-Every module has a `{Name}ServiceProvider` that loads migrations and views.
-Observers are registered here too:
+Every module has a `{Name}ServiceProvider` registered in `config/app.php`:
 
 ```php
 class ClientsServiceProvider extends ServiceProvider
 {
-    public function register(): void {}
-
     public function boot(): void
     {
         $this->loadViewsFrom(__DIR__ . '/../../resources/views', 'clients');
-        $this->loadMigrationsFrom(__DIR__ . '/../../database/migrations');
+        $this->loadMigrationsFrom(__DIR__ . '/../../Database/Migrations');
         Client::observe(ClientObserver::class); // only if observer exists
     }
 }
@@ -79,29 +82,25 @@ class ClientsServiceProvider extends ServiceProvider
 ## Registering a New Module
 
 1. Create the directory tree above.
-2. Add the service provider to `config/app.php` providers array.
+2. Add `{Name}ServiceProvider` to `config/app.php` providers array.
 3. Register the factory namespace in `app/Providers/AppServiceProvider.php`
-   (look at how existing modules do it — there's a `Factory::guessFactoryNamesUsing` callback).
-4. Add `->discoverResources(...)` to `CompanyPanelProvider` for the new module.
-
-## Registering Resources in the Panel
-
-`app/Providers/Filament/CompanyPanelProvider.php` discovers resources per module:
+   following the pattern used by existing modules (`Factory::guessFactoryNamesUsing`).
+4. Add `->discoverResources(...)` to `CompanyPanelProvider`:
 
 ```php
 ->discoverResources(
-    in: base_path('Modules/mymodule/src/Filament/Resources'),
-    for: 'Modules\\Mymodule\\Filament\\Resources'
+    in: base_path('Modules/Mymodule/Filament/Company/Resources'),
+    for: 'Modules\\Mymodule\\Filament\\Company\\Resources'
 )
 ```
 
-## Tests Are Auto-Discovered
+## Test Auto-Discovery
 
-`phpunit.xml` includes module test directories:
+`phpunit.xml` discovers tests automatically — no registration needed:
 
 ```xml
-<directory>Modules/*/tests/Unit</directory>
-<directory>Modules/*/tests/Feature</directory>
+<directory>Modules/*/Tests/Unit</directory>
+<directory>Modules/*/Tests/Feature</directory>
 ```
 
-No extra registration needed — just put tests in the right place.
+Just put tests under `Modules/{Name}/Tests/Feature/` or `Tests/Unit/`.

--- a/.claude/skills/non-standard-pks/SKILL.md
+++ b/.claude/skills/non-standard-pks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: non-standard-pks
-description: "Works with models that have non-standard primary key names. Activates when writing factories, tests, relationships, or seeders for models that use user_id, client_id, invoice_id, etc. instead of id."
+description: "Works with models that have non-standard primary key names. Activates when writing factories, tests, relationships, or seeders for models that use a custom primary key instead of id."
 license: MIT
 metadata:
   author: project
@@ -8,124 +8,74 @@ metadata:
 
 # Non-Standard Primary Keys
 
-Most models in this app use descriptive primary key names, not `id`.
+Most models in this app use `id` as their primary key (Laravel default). Only a
+handful declare a custom `$primaryKey`. **Never assume a model has a non-standard
+PK without checking the model file.**
 
-## PK Reference Table
+## Confirmed Non-Standard PKs
 
 | Model | Table | Primary Key |
 |-------|-------|-------------|
-| User | users | `user_id` |
-| Client | clients | `client_id` |
-| Invoice | invoices | `invoice_id` |
-| InvoiceGroup | invoice_groups | `invoice_group_id` |
-| Quote | quotes | `quote_id` |
-| Payment | payments | `payment_id` |
-| Product | products | `product_id` |
-| Project | projects | `project_id` |
-| Task | tasks | `task_id` |
-| TaxRate | tax_rates | `tax_rate_id` |
-| Family | families | `family_id` |
-| Unit | units | `unit_id` |
-| EmailTemplate | email_templates | `email_template_id` |
-| Company | companies | `id` ← standard |
-| Expense | expenses | `id` ← standard |
-| ExpenseCategory | expense_categories | `id` ← standard |
+| `ClientCustom` | `client_custom` | `client_custom_id` |
+| `Import` | `imports` | `import_id` |
 
-## Accessing the PK
+All other models should be assumed to use `id` unless their model file explicitly
+declares `protected $primaryKey = '...'`.
 
-Use `$model->getKey()` when you need the PK value generically. Use the named
-attribute only when you know the model:
+## Accessing the PK Safely
+
+Use `$model->getKey()` for generic access. Use the named attribute only when
+you know the model's actual PK:
 
 ```php
-$invoice->invoice_id   // ✓ typed access
-$invoice->getKey()     // ✓ generic access
-$invoice->id           // ✗ returns null on non-standard PKs
+$custom->client_custom_id   // ✓ typed access for ClientCustom
+$custom->getKey()           // ✓ generic access
+$custom->id                 // ✗ returns null — ClientCustom uses client_custom_id
 ```
 
-## In Factories: Pass the FK by Name
+## Factories: Pass the FK by Name
 
-When a factory creates related records, pass the FK column explicitly:
+When creating related records that reference a non-standard PK, pass the FK
+column explicitly:
 
 ```php
-Invoice::factory()->create([
-    'company_id'       => $this->companyId,
-    'client_id'        => $client->client_id,      // not $client->id
-    'invoice_group_id' => $group->invoice_group_id, // not $group->id
-    'user_id'          => $user->user_id,           // not $user->id
+// ClientCustom's PK is client_custom_id, not id
+SomeRelated::factory()->create([
+    'client_custom_id' => $custom->client_custom_id,
 ]);
 ```
 
-## In Tests: Use the PK for the Record Parameter
+## Filament Edit Page
 
-Filament's Edit page `record` parameter expects the PK value:
+The `record` parameter expects the PK value:
 
 ```php
 Livewire::actingAs($this->user)
-    ->test(EditInvoice::class, [
-        'record' => $invoice->invoice_id,  // not $invoice->id
-        'tenant' => $this->company,
+    ->test(EditClientCustom::class, [
+        'record' => $custom->client_custom_id,  // not $custom->id
+        'tenant' => $this->company->search_code,
     ])
 ```
 
 ## Model Definition
 
-Always declare `$primaryKey` explicitly. Models also set `$timestamps = false`
-since they manage date columns manually:
+Always declare `$primaryKey` explicitly for non-standard models:
 
 ```php
-class Invoice extends Model
+class ClientCustom extends Model
 {
-    protected $table      = 'invoices';
-    protected $primaryKey = 'invoice_id';
+    protected $table      = 'client_custom';
+    protected $primaryKey = 'client_custom_id';
     public    $timestamps = false;
 }
 ```
 
-## Relationships Must Specify Keys
+## Adding a New Non-Standard PK
 
-BelongsTo and HasMany must specify the FK and owner key when they differ from
-Laravel's convention (`{model}_id` → `id`):
+When you introduce a model with a non-standard PK, update this skill's
+**Confirmed Non-Standard PKs** table immediately.
 
-```php
-// On Invoice — points to users.user_id, not users.id
-public function user(): BelongsTo
-{
-    return $this->belongsTo(User::class, 'user_id', 'user_id');
-}
+## Timestamps
 
-// On Company — invoice FK column is invoice_group_id, PK is invoice_group_id
-public function invoiceGroups(): HasMany
-{
-    return $this->hasMany(InvoiceGroup::class, 'company_id', 'id');
-}
-```
-
----
-
-## Never Assume "id"
-
-Never access:
-
-$model->id
-
-Never reference:
-
-'id'
-
-unless the model explicitly uses a standard primary key.
-
-Use:
-
-$model->getKey()
-
-or the named primary key property.
-
----
-
-## Fix-One-Fix-All
-
-If one test, factory, seeder, relationship, resource, or service incorrectly
-uses `id` instead of the model's primary key, search the repository for the
-same pattern and correct all occurrences.
-
-Primary key assumptions tend to fail systematically rather than individually.
+Almost all models in this app have `$timestamps = false` — they manage date
+columns manually. Do not assume `created_at`/`updated_at` exist.

--- a/.claude/skills/pest-control/SKILL.md
+++ b/.claude/skills/pest-control/SKILL.md
@@ -171,7 +171,40 @@ When asked to eliminate Pest from a codebase, check and fix all of the following
 
 ---
 
-## Rule 7 — Conversion Reference
+## Rule 7 — Arrange / Act / Assert
+
+Every test method MUST be structured in three named phases, each preceded by its
+own `// Arrange`, `// Act`, or `// Assert` comment. No exceptions.
+
+```php
+#[Test]
+public function it_creates_an_invoice(): void
+{
+    // Arrange
+    $client  = Relation::factory()->for($this->company)->create();
+    $payload = ['customer_id' => $client->getKey(), 'invoice_date' => '2026-01-01'];
+
+    // Act
+    app(InvoiceService::class)->createInvoice($payload);
+
+    // Assert
+    $this->assertDatabaseHas('invoices', [
+        'customer_id' => $client->getKey(),
+        'company_id'  => $this->company->id,
+    ]);
+}
+```
+
+A test with no `// Arrange` / `// Act` / `// Assert` comments is rejected on
+review, no matter how correct the assertions are.
+
+If a phase is genuinely empty (e.g. a pure-assertion unit test with no setup),
+keep the comment and leave a blank line — the structure is the contract, not the
+line count.
+
+---
+
+## Rule 8 — Conversion Reference
 
 | Pest | PHPUnit equivalent |
 |------|--------------------|

--- a/.claude/skills/pest-control/SKILL.md
+++ b/.claude/skills/pest-control/SKILL.md
@@ -171,7 +171,30 @@ When asked to eliminate Pest from a codebase, check and fix all of the following
 
 ---
 
-## Rule 7 — Arrange / Act / Assert
+## Rule 7 — Test Method Naming
+
+Test methods MUST follow the `it_{verb}_{object}` convention. The name must read
+as a sentence describing observable behavior.
+
+```php
+// Correct
+it_creates_an_invoice
+it_rejects_a_duplicate_email
+it_returns_404_for_missing_resource
+it_assigns_company_id_to_new_invoices
+
+// Wrong — noun before verb
+it_invoice_creates
+
+// Wrong — no verb
+it_invoice
+```
+
+Never describe implementation. Describe what the system does from the outside.
+
+---
+
+## Rule 8 — Arrange / Act / Assert
 
 Every test method MUST be structured in three named phases, each preceded by its
 own `/* Arrange */`, `/* Act */`, or `/* Assert */` comment. No exceptions.

--- a/.claude/skills/pest-control/SKILL.md
+++ b/.claude/skills/pest-control/SKILL.md
@@ -174,20 +174,20 @@ When asked to eliminate Pest from a codebase, check and fix all of the following
 ## Rule 7 — Arrange / Act / Assert
 
 Every test method MUST be structured in three named phases, each preceded by its
-own `// Arrange`, `// Act`, or `// Assert` comment. No exceptions.
+own `/* Arrange */`, `/* Act */`, or `/* Assert */` comment. No exceptions.
 
 ```php
 #[Test]
 public function it_creates_an_invoice(): void
 {
-    // Arrange
+    /* Arrange */
     $client  = Relation::factory()->for($this->company)->create();
     $payload = ['customer_id' => $client->getKey(), 'invoice_date' => '2026-01-01'];
 
-    // Act
+    /* Act */
     app(InvoiceService::class)->createInvoice($payload);
 
-    // Assert
+    /* Assert */
     $this->assertDatabaseHas('invoices', [
         'customer_id' => $client->getKey(),
         'company_id'  => $this->company->id,
@@ -195,7 +195,7 @@ public function it_creates_an_invoice(): void
 }
 ```
 
-A test with no `// Arrange` / `// Act` / `// Assert` comments is rejected on
+A test with no `/* Arrange */` / `/* Act */` / `/* Assert */` comments is rejected on
 review, no matter how correct the assertions are.
 
 If a phase is genuinely empty (e.g. a pure-assertion unit test with no setup),

--- a/.claude/skills/safe-refactoring-rules/SKILL.md
+++ b/.claude/skills/safe-refactoring-rules/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: safe-refactoring-rules
+description: Ensures all refactoring is deterministic, behavior-preserving, and non-breaking
+---
+
 # Safe Refactoring Rules
 
 ## Purpose

--- a/.claude/skills/senior-laravel-developer-code-reviewer/SKILL.md
+++ b/.claude/skills/senior-laravel-developer-code-reviewer/SKILL.md
@@ -1,145 +1,143 @@
 ---
 name: senior-laravel-developer-code-reviewer
-description: "Orchestrates existing Laravel skills to produce structured PR reviews"
+description: "Orchestrates existing Laravel skills to produce structured PR reviews as a grumpy, no-nonsense Senior Laravel developer"
 ---
 
-# Purpose
+# Senior Laravel Developer — Code Reviewer
 
-This skill does not implement rules.
+You are a grumpy Senior Laravel developer. You have seen every anti-pattern twice.
+You do not sugarcoat. You do not pad your feedback with compliments. You report
+exactly what is wrong and exactly how to fix it.
 
-It orchestrates existing skills to produce a complete pull request review.
+You are not unkind — you are precise. You want the code to be correct, not to feel
+good about itself.
 
 ---
 
 # Delegation Model
 
-This reviewer MUST delegate evaluation to existing skills:
+Do not invent rules. Delegate evaluation to existing skills:
 
-## Architecture
+**Architecture & code quality**
+- `application-architecture-standard`
+- `service-layer`
+- `laravel-modules`
+- `non-standard-pks`
+- `dto-contract`
+- `safe-refactoring-rules`
 
-Delegate to:
+**Tests**
+- `filament-resource-testing`
+- `test-honesty`
+- `pest-control`
 
-- application-architecture-standard
-- service-layer skill
-- laravel-modules skill
-- non-standard-pks skill
-- dto-contract skill
-- safe-refactoring-rules skill
+**Security**
+- `security-review`
+- `spatie-roles`
 
-## Tests
-Use:
-- filament-resource-testing skill
-- test-honesty skill
-
-## Security
-Use:
-- security-review skill
-- otherwise infer from architecture + test gaps
+**Tenancy**
+- `filament-multi-tenancy`
+- `tenant-middleware`
 
 ---
 
 # Review Process
 
-When reviewing a PR:
-
 ## 1. Architecture pass
-Summarize findings from architecture-related skills.
 
-Do NOT restate rules.
+Report violations only. Do not restate rules.
 
-Only report violations.
+Bad example of what NOT to write:
+> "The service layer principle states that services should not use Filament..."
+
+Good example:
+> "`InvoiceService::create()` calls `Filament::getTenant()` directly. Services must not touch Filament."
 
 ---
 
 ## 2. Test pass
-Summarize findings from test-related skills.
 
 Focus on:
-- weak tests
-- missing coverage
-- nondeterministic tests
-- missing failure cases
+- Tests that pass even when the feature is broken (assertion on wrong thing)
+- Missing failure-path tests
+- Hardcoded IDs (violates `test-honesty`)
+- Pest syntax in a PHPUnit-only project
+- Livewire tests that bypass the service layer and assert nothing in the DB
 
 ---
 
 ## 3. Security pass
-Identify:
-- missing authorization
-- unsafe access paths
-- privilege escalation risks
-- missing validation
+
+Report:
+- Unguarded resource actions (no policy, no gate, no role check)
+- Privilege escalation paths
+- Missing input validation at system boundaries
 
 ---
 
 ## 4. Consolidation
 
-Merge findings into:
+Group findings into three buckets — and only three:
 
-- Critical issues (must fix)
-- Important issues
-- Suggestions
+- **Must fix** — production bugs, security holes, data integrity risks, broken tests
+- **Should fix** — architecture violations, test gaps, maintainability problems
+- **Could fix** — cosmetic improvements, style, naming
+
+Never let "Could fix" items crowd out "Must fix" items.
 
 ---
 
 # Output Format
 
+```
 ## Summary
-Short PR assessment
+One paragraph. What does this PR do, and is it shippable?
 
-## Critical Issues
-Bullets only
+## Must Fix
+- <file>:<line> — <what's wrong> — <how to fix it>
 
-## Important Issues
-Bullets only
+## Should Fix
+- <file>:<line> — <what's wrong>
 
-## Suggestions
-Bullets only
+## Could Fix
+- <file>:<line> — <what's wrong>
 
-## Test Risk Summary
-Only risks, no rule explanation
+## Test Risk
+- <specific test names or gaps that worry you>
 
-## Security Notes
-Only vulnerabilities, no theory
+## Security
+- <specific vulnerabilities, or "None identified">
 
 ## Suggested Fixes
-Copy/paste code only
+<paste-ready code snippets for the must-fix items only>
+```
 
 ---
 
-# Constraints
+# Tone Rules
 
-- Do NOT restate rules defined in other skills
-- Do NOT include full explanations of SOLID, DRY, etc.
-- Do NOT duplicate test philosophy definitions
-- Only report deviations
-- Keep output strictly diagnostic
+Say: "This bypasses the service layer and writes directly to the model."
+Not: "This could potentially be considered a violation of layered architecture..."
+
+Say: "Missing authorization. Any authenticated user can delete any invoice."
+Not: "It might be worth considering adding an authorization check here..."
+
+Say: "This test asserts nothing in the database. It passes whether the record was created or not."
+Not: "The test coverage could be improved by adding database assertions..."
+
+If it is wrong, say it is wrong. If it is broken, say it is broken.
+If something is genuinely fine, say nothing about it.
 
 ---
 
-# Prioritization
-
-Report issues in this order:
+# Priority Order
 
 1. Production bugs
 2. Security issues
 3. Data integrity risks
-4. Test honesty violations
+4. Broken or dishonest tests
 5. Architecture violations
-6. Maintainability improvements
-7. Cosmetic suggestions
+6. Maintainability
+7. Style
 
-Never allow style issues to obscure correctness issues.
-
----
-
-# Tone
-
-Simple, direct, non-verbose.
-
-Explain issues like:
-
-> "This bypasses the service layer and writes directly to the model."
-
-Not:
-
-> "This violates layered architecture principles..."
+Never allow item 7 to appear before items 1–4 are exhausted.

--- a/.claude/skills/senior-laravel-developer-code-reviewer/SKILL.md
+++ b/.claude/skills/senior-laravel-developer-code-reviewer/SKILL.md
@@ -63,6 +63,7 @@ Focus on:
 - Hardcoded IDs (violates `test-honesty`)
 - Pest syntax in a PHPUnit-only project
 - Livewire tests that bypass the service layer and assert nothing in the DB
+- **Missing `// Arrange` / `// Act` / `// Assert` phase comments** — every test method requires all three, no exceptions
 
 ---
 

--- a/.claude/skills/senior-laravel-developer-code-reviewer/SKILL.md
+++ b/.claude/skills/senior-laravel-developer-code-reviewer/SKILL.md
@@ -63,7 +63,7 @@ Focus on:
 - Hardcoded IDs (violates `test-honesty`)
 - Pest syntax in a PHPUnit-only project
 - Livewire tests that bypass the service layer and assert nothing in the DB
-- **Missing `// Arrange` / `// Act` / `// Assert` phase comments** — every test method requires all three, no exceptions
+- **Missing `/* Arrange */` / `/* Act */` / `/* Assert */` phase comments** — every test method requires all three, no exceptions
 
 ---
 

--- a/.claude/skills/senior-laravel-developer-phpunit-interpreter/SKILL.md
+++ b/.claude/skills/senior-laravel-developer-phpunit-interpreter/SKILL.md
@@ -29,7 +29,9 @@ Remove completely:
 
 ## Path Cleanup
 
-Replace `/home/runner/work/spotivel/` with an empty string. Do not replace any other paths.
+Remove the absolute project root path prefix from all file paths so only the
+relative path remains (e.g. strip `/home/runner/work/<project>/` or
+`/var/www/<project>/` — whatever the CI runner's working directory is).
 
 ---
 

--- a/.claude/skills/service-layer/SKILL.md
+++ b/.claude/skills/service-layer/SKILL.md
@@ -8,9 +8,7 @@ metadata:
 
 # Service Layer
 
-Services define **business orchestration only**.
-
-They are framework-agnostic and represent the application’s business operations.
+Services are the only place business logic lives. They are framework-agnostic.
 
 ---
 
@@ -19,23 +17,22 @@ They are framework-agnostic and represent the application’s business operation
 Services MUST:
 
 - contain business logic
-- coordinate models and repositories
+- coordinate models
 - enforce domain rules
 - return models or DTOs
 
 Services MUST NOT:
 
-- use Filament
-- use HTTP layer
-- depend on request/response objects
+- import or use Filament
+- accept or return HTTP request/response objects
 - contain UI logic
-- use service locators (`app()`, `resolve()`)
+- use `app()` or `resolve()` internally
 
 ---
 
 # 2. Dependency Rule
 
-Services MUST use constructor injection:
+Constructor injection only:
 
 ```php
 public function __construct(
@@ -43,25 +40,28 @@ public function __construct(
 ) {}
 ```
 
-No `app()` or service locator usage inside services.
+---
+
+# 3. DTO Rule
+
+DTOs are **not** required for Filament → Service calls. Arrays are fine when the
+source is a trusted Filament form.
+
+Use DTOs when:
+- crossing system boundaries (API, queues, external integrations)
+- multiple services share a contract
+- the payload must be stable across refactors
+
+Skip DTOs when:
+- input comes from a single Filament form
+- the data is short-lived and not reused
 
 ---
 
-# 3. Filament Boundary Rule
+# 4. Filament Action Exception
 
-Filament is a UI boundary layer with different lifecycle constraints.
-
-Allowed patterns:
-
-### Pages / Resources
-- constructor injection preferred
-- `app(Service::class)` allowed as fallback
-
-### Table Actions / Closures
-- `app(Service::class)` is allowed
-- constructor injection is not guaranteed in closures
-
-Example:
+Filament closures do not support constructor DI. `app()` is the only acceptable
+escape hatch — and it belongs in the closure, not inside the service:
 
 ```php
 Action::make('create')
@@ -70,32 +70,12 @@ Action::make('create')
     });
 ```
 
-This is acceptable UI-layer coupling.
-
 ---
 
-# 4. Standard Service Shape
+# 5. Standard Shape
 
 ```
-Modules/{Name}/src/Services/{Model}Service.php
+Modules/{Name}/Services/{Model}Service.php
 ```
 
----
-
-# 5. Standard Methods
-
-- createX
-- updateX
-- deleteX
-- findOrFail
-- listForCompany
-
----
-
-# 6. Core Principle
-
-Services are pure business units.
-
-They must not depend on framework execution context.
-
-UI layers may use service locator as a pragmatic boundary escape hatch.
+Standard method names: `createX`, `updateX`, `deleteX`, `findOrFail`, `listForCompany`.

--- a/.claude/skills/sync-stale-branches/SKILL.md
+++ b/.claude/skills/sync-stale-branches/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: sync-stale-branches
+description: Brings diverged remote branches up to date with develop — classifies, rescues unique work, then resets or deletes stale branches
+---
+
 # Skill: sync-stale-branches
 
 Bring old/diverged remote branches up to date with `develop`.


### PR DESCRIPTION
- filament-resource-pages: replace wrong service-layer content with actual
  Filament v4 resource/pages/schemas/tables patterns from the codebase
- service-layer: merge nuanced DTO guidance from the evicted duplicate;
  trim to single authoritative file
- laravel-modules: remove false "no nwidart" claim (composer.json has it);
  fix directory structure to match reality (no src/ layer, uppercase Database/Tests/)
- non-standard-pks: remove fabricated model PK table; keep only the two
  confirmed non-standard PKs (ClientCustom, Import)
- senior-laravel-developer-phpunit-interpreter: remove hardcoded project path
  /home/runner/work/spotivel/ so skill is reusable across projects
- filament-panel-setup: add missing User panel (three panels, not two)
- autonomous-coding-workflow: add missing YAML frontmatter
- safe-refactoring-rules: add missing YAML frontmatter
- sync-stale-branches: add missing YAML frontmatter
- ci-schema-invariant-gate: fix name mismatch (ci-schema-gate → ci-schema-invariant-gate)
- dto-contract: fix name mismatch (dto-contracts → dto-contract)
- filament-multi-tenancy: remove duplicated middleware chain docs; point to tenant-middleware skill
- senior-laravel-developer-code-reviewer: add grumpy Senior Laravel developer persona
  with direct, no-nonsense tone and structured Must/Should/Could fix output format

## Summary by CodeRabbit

* **Documentation**
  * Updated development skill guidelines for Laravel module structure, service layer architecture, and code review standards.
  * Introduced mandatory Arrange-Act-Assert comment structure for test methods.
  * Enhanced documentation for non-standard primary key handling and Filament resource pages.
  * Added metadata identifiers to skill definitions for improved organization and discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->