### PR TITLE
[IP-488]: feat: add Permission enum (#488)

### DIFF
--- a/Modules/Core/Database/Seeders/PermissionsSeeder.php
+++ b/Modules/Core/Database/Seeders/PermissionsSeeder.php
@@ -4,60 +4,17 @@ namespace Modules\Core\Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Log;
+use Modules\Core\Enums\Permission as PermissionEnum;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\PermissionRegistrar;
 
 class PermissionsSeeder extends Seeder
 {
-    public array $basicActions = [
-        'view', 'create', 'edit', 'delete',
-    ];
-
-    public array $specialPermissions = [
-        'customers' => ['manage'],
-        'expenses'  => ['approve', 'reject'],
-        'invoices'  => ['download', 'duplicate', 'email', 'mark-paid', 'mark-sent', 'print'],
-        'payments'  => ['email', 'refund'],
-        'products'  => ['export', 'import'],
-        'projects'  => ['manage'],
-        'quotes'    => ['approve', 'convert-to-invoice', 'download', 'duplicate', 'email', 'mark-sent', 'print', 'reject'],
-        'reports'   => ['export', 'manage', 'print'],
-        'settings'  => ['manage'],
-        'users'     => ['impersonate'],
-    ];
-
-    public array $resources = [
-        'companies', 'contacts', 'expenses', 'email-templates', 'invoices', 'payments', 'permissions', 'products',
-        'projects', 'quotes', 'relations', 'reports', 'roles', 'settings', 'tasks', 'tax-rates', 'users',
-    ];
-
     public function run(): void
     {
         app()[PermissionRegistrar::class]->forgetCachedPermissions();
 
-        $permissions = [];
-
-        foreach ($this->resources as $resource) {
-            foreach ($this->basicActions as $action) {
-                $permissions[] = "{$action}-{$resource}";
-            }
-
-            // Add special permissions if they exist for this resource
-            if (isset($this->specialPermissions[$resource])) {
-                foreach ($this->specialPermissions[$resource] as $special) {
-                    $permissions[] = "{$special}-{$resource}";
-                }
-            }
-        }
-
-        $permissions = array_merge($permissions, [
-            'view-dashboard',
-            'manage-company-settings',
-            'import',
-            'export',
-            'backup',
-            'restore',
-        ]);
+        $permissions = array_column(PermissionEnum::cases(), 'value');
 
         $existingPermissions = Permission::whereIn('name', $permissions)
             ->pluck('name')
@@ -65,7 +22,7 @@ class PermissionsSeeder extends Seeder
 
         $newPermissions = array_diff($permissions, $existingPermissions);
 
-        foreach ($newPermissions as $permission) {
+        foreach($newPermissions as $permission) {
             Permission::create([
                 'name'       => $permission,
                 'guard_name' => 'web',

--- a/Modules/Core/Database/Seeders/PermissionsSeeder.php
+++ b/Modules/Core/Database/Seeders/PermissionsSeeder.php
@@ -22,7 +22,7 @@ class PermissionsSeeder extends Seeder
 
         $newPermissions = array_diff($permissions, $existingPermissions);
 
-        foreach($newPermissions as $permission) {
+        foreach ($newPermissions as $permission) {
             Permission::create([
                 'name'       => $permission,
                 'guard_name' => 'web',

--- a/Modules/Core/Database/Seeders/RolesSeeder.php
+++ b/Modules/Core/Database/Seeders/RolesSeeder.php
@@ -63,7 +63,19 @@ class RolesSeeder extends Seeder
         $allPermissions = array_column(PermissionEnum::cases(), 'value');
 
         $customerResources = ['relations', 'contacts', 'invoices', 'quotes', 'payments', 'projects', 'tasks', 'products', 'expenses'];
-        $allowedActions    = ['view-', 'create-', 'edit-', 'download-', 'print-', 'email-', 'approve-', 'export-'];
+
+        $customerSpecialPermissions = [
+            PermissionEnum::DOWNLOAD_INVOICES->value,
+            PermissionEnum::EMAIL_INVOICES->value,
+            PermissionEnum::PRINT_INVOICES->value,
+            PermissionEnum::EMAIL_PAYMENTS->value,
+            PermissionEnum::EXPORT_PRODUCTS->value,
+            PermissionEnum::DOWNLOAD_QUOTES->value,
+            PermissionEnum::EMAIL_QUOTES->value,
+            PermissionEnum::PRINT_QUOTES->value,
+            PermissionEnum::EXPORT_REPORTS->value,
+            PermissionEnum::PRINT_REPORTS->value,
+        ];
 
         return [
             UserRole::SUPER_ADMIN->value => [
@@ -84,24 +96,23 @@ class RolesSeeder extends Seeder
 
             UserRole::CUSTOMER_ADMIN->value => [
                 'name'        => 'Customer Admin',
-                'permissions' => array_values(array_filter(
-                    $allPermissions,
-                    function ($p) use ($customerResources, $allowedActions) {
-                        if ($p === PermissionEnum::VIEW_DASHBOARD->value) {
-                            return true;
+                'permissions' => array_unique(array_merge(
+                    array_values(array_filter(
+                        $allPermissions,
+                        function ($p) use ($customerResources) {
+                            $isBasicAction = str_starts_with($p, 'view-')
+                                || str_starts_with($p, 'create-')
+                                || str_starts_with($p, 'edit-');
+                            $isCustomerResource = (bool) array_filter(
+                                $customerResources,
+                                fn ($r) => str_ends_with($p, '-' . $r)
+                            );
+
+                            return $isBasicAction && $isCustomerResource;
                         }
-
-                        $isCustomerResource = (bool) array_filter(
-                            $customerResources,
-                            fn ($r) => str_ends_with($p, '-' . $r)
-                        );
-                        $isAllowedAction = (bool) array_filter(
-                            $allowedActions,
-                            fn ($a) => str_starts_with($p, $a)
-                        );
-
-                        return $isCustomerResource && $isAllowedAction;
-                    }
+                    )),
+                    $customerSpecialPermissions,
+                    [PermissionEnum::VIEW_DASHBOARD->value],
                 )),
             ],
             UserRole::CUSTOMER->value => [

--- a/Modules/Core/Database/Seeders/RolesSeeder.php
+++ b/Modules/Core/Database/Seeders/RolesSeeder.php
@@ -107,11 +107,16 @@ class RolesSeeder extends Seeder
             UserRole::CUSTOMER->value => [
                 'name'        => 'Customer',
                 'permissions' => [
-                    'view-contacts', 'edit-contacts',
-                    'view-invoices', 'download-invoices', 'print-invoices',
-                    'view-quotes', 'download-quotes', 'print-quotes',
-                    'view-payments',
-                    'view-dashboard',
+                    PermissionEnum::VIEW_CONTACTS->value,
+                    PermissionEnum::EDIT_CONTACTS->value,
+                    PermissionEnum::VIEW_INVOICES->value,
+                    PermissionEnum::DOWNLOAD_INVOICES->value,
+                    PermissionEnum::PRINT_INVOICES->value,
+                    PermissionEnum::VIEW_QUOTES->value,
+                    PermissionEnum::DOWNLOAD_QUOTES->value,
+                    PermissionEnum::PRINT_QUOTES->value,
+                    PermissionEnum::VIEW_PAYMENTS->value,
+                    PermissionEnum::VIEW_DASHBOARD->value,
                 ],
             ],
         ];

--- a/Modules/Core/Database/Seeders/RolesSeeder.php
+++ b/Modules/Core/Database/Seeders/RolesSeeder.php
@@ -4,6 +4,7 @@ namespace Modules\Core\Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Log;
+use Modules\Core\Enums\Permission as PermissionEnum;
 use Modules\Core\Enums\UserRole;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
@@ -59,11 +60,7 @@ class RolesSeeder extends Seeder
 
     public function getDefaultRolePermissions(): array
     {
-        $permissionsSeeder = new PermissionsSeeder();
-        $allCrud           = $this->getAllCrudPermissions($permissionsSeeder->resources, $permissionsSeeder->basicActions);
-        $allSpecial        = $this->getAllSpecialPermissions($permissionsSeeder->specialPermissions);
-        $systemPermissions = $this->getSystemPermissions();
-        $allPermissions    = array_merge($allCrud, $allSpecial, $systemPermissions);
+        $allPermissions = array_column(PermissionEnum::cases(), 'value');
 
         return [
             UserRole::SUPER_ADMIN->value => [
@@ -76,26 +73,25 @@ class RolesSeeder extends Seeder
             ],
             UserRole::ASSIST->value => [
                 'name'        => 'Assist',
-                'permissions' => array_merge(
-                    array_filter($allCrud, fn ($p) => ! str_starts_with($p, 'delete-')),
-                    array_filter($allSpecial, fn ($p) => ! in_array(explode('-', $p)[0], ['delete', 'manage'])),
-                    ['view-dashboard']
-                ),
+                'permissions' => array_values(array_filter(
+                    $allPermissions,
+                    fn ($p) => ! str_starts_with($p, 'delete-') && ! str_starts_with($p, 'manage-')
+                )),
             ],
+
             UserRole::CUSTOMER_ADMIN->value => [
                 'name'        => 'Customer Admin',
-                'permissions' => array_merge(
-                    array_filter($allCrud, fn ($p) => str_starts_with($p, 'view-')),
-                    array_filter(
-                        $allCrud,
-                        fn ($p) => str_starts_with($p, 'create-') || str_starts_with($p, 'edit-')
-                    ),
-                    array_filter(
-                        $allSpecial,
-                        fn ($p) => in_array(explode('-', $p)[0], ['download', 'print', 'email', 'export'])
-                    ),
-                    ['view-dashboard']
-                ),
+                'permissions' => array_values(array_filter(
+                    $allPermissions,
+                    fn ($p) => str_starts_with($p, 'view-')
+                        || str_starts_with($p, 'create-')
+                        || str_starts_with($p, 'edit-')
+                        || in_array($p, [
+                            'download-invoices', 'print-invoices', 'email-invoices',
+                            'download-quotes', 'print-quotes', 'email-quotes',
+                            'export-products', 'export-reports', 'view-dashboard',
+                        ])
+                )),
             ],
             UserRole::CUSTOMER->value => [
                 'name'        => 'Customer',
@@ -108,36 +104,5 @@ class RolesSeeder extends Seeder
                 ],
             ],
         ];
-    }
-
-    protected function getSystemPermissions(): array
-    {
-        return [
-            'view-dashboard', 'manage-company-settings', 'import', 'export', 'backup', 'restore',
-        ];
-    }
-
-    protected function getAllCrudPermissions(array $resources, array $basicActions): array
-    {
-        $permissions = [];
-        foreach ($resources as $resource) {
-            foreach ($basicActions as $action) {
-                $permissions[] = "{$action}-{$resource}";
-            }
-        }
-
-        return $permissions;
-    }
-
-    protected function getAllSpecialPermissions(array $specialPermissions): array
-    {
-        $permissions = [];
-        foreach ($specialPermissions as $resource => $actions) {
-            foreach ($actions as $action) {
-                $permissions[] = "{$action}-{$resource}";
-            }
-        }
-
-        return $permissions;
     }
 }

--- a/Modules/Core/Database/Seeders/RolesSeeder.php
+++ b/Modules/Core/Database/Seeders/RolesSeeder.php
@@ -62,6 +62,9 @@ class RolesSeeder extends Seeder
     {
         $allPermissions = array_column(PermissionEnum::cases(), 'value');
 
+        $customerResources = ['relations', 'contacts', 'invoices', 'quotes', 'payments', 'projects', 'tasks', 'products', 'expenses'];
+        $allowedActions    = ['view-', 'create-', 'edit-', 'download-', 'print-', 'email-', 'approve-', 'export-'];
+
         return [
             UserRole::SUPER_ADMIN->value => [
                 'name'        => 'Super Admin',
@@ -83,14 +86,22 @@ class RolesSeeder extends Seeder
                 'name'        => 'Customer Admin',
                 'permissions' => array_values(array_filter(
                     $allPermissions,
-                    fn ($p) => str_starts_with($p, 'view-')
-                        || str_starts_with($p, 'create-')
-                        || str_starts_with($p, 'edit-')
-                        || in_array($p, [
-                            'download-invoices', 'print-invoices', 'email-invoices',
-                            'download-quotes', 'print-quotes', 'email-quotes',
-                            'export-products', 'export-reports', 'view-dashboard',
-                        ])
+                    function ($p) use ($customerResources, $allowedActions) {
+                        if ($p === PermissionEnum::VIEW_DASHBOARD->value) {
+                            return true;
+                        }
+
+                        $isCustomerResource = (bool) array_filter(
+                            $customerResources,
+                            fn ($r) => str_ends_with($p, '-' . $r)
+                        );
+                        $isAllowedAction = (bool) array_filter(
+                            $allowedActions,
+                            fn ($a) => str_starts_with($p, $a)
+                        );
+
+                        return $isCustomerResource && $isAllowedAction;
+                    }
                 )),
             ],
             UserRole::CUSTOMER->value => [

--- a/Modules/Core/Enums/Permission.php
+++ b/Modules/Core/Enums/Permission.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Modules\Core\Enums;
+
+use Modules\Core\Contracts\LabeledEnum;
+
+enum Permission: string implements LabeledEnum
+{
+    // CRUD PERMISSIONS
+
+    case VIEW_RELATIONS   = 'view-relations';
+    case CREATE_RELATIONS = 'create-relations';
+    case EDIT_RELATIONS   = 'edit-relations';
+    case DELETE_RELATIONS = 'delete-relations';
+
+    case VIEW_CONTACTS   = 'view-contacts';
+    case CREATE_CONTACTS = 'create-contacts';
+    case EDIT_CONTACTS   = 'edit-contacts';
+    case DELETE_CONTACTS = 'delete-contacts';
+
+    case VIEW_EXPENSES   = 'view-expenses';
+    case CREATE_EXPENSES = 'create-expenses';
+    case EDIT_EXPENSES   = 'edit-expenses';
+    case DELETE_EXPENSES = 'delete-expenses';
+
+    case VIEW_INVOICES   = 'view-invoices';
+    case CREATE_INVOICES = 'create-invoices';
+    case EDIT_INVOICES   = 'edit-invoices';
+    case DELETE_INVOICES = 'delete-invoices';
+
+    case VIEW_COMPANIES   = 'view-companies';
+    case CREATE_COMPANIES = 'create-companies';
+    case EDIT_COMPANIES   = 'edit-companies';
+    case DELETE_COMPANIES = 'delete-companies';
+
+    case VIEW_PAYMENTS   = 'view-payments';
+    case CREATE_PAYMENTS = 'create-payments';
+    case EDIT_PAYMENTS   = 'edit-payments';
+    case DELETE_PAYMENTS = 'delete-payments';
+
+    case VIEW_PERMISSIONS   = 'view-permissions';
+    case CREATE_PERMISSIONS = 'create-permissions';
+    case EDIT_PERMISSIONS   = 'edit-permissions';
+    case DELETE_PERMISSIONS = 'delete-permissions';
+
+    case VIEW_PRODUCTS   = 'view-products';
+    case CREATE_PRODUCTS = 'create-products';
+    case EDIT_PRODUCTS   = 'edit-products';
+    case DELETE_PRODUCTS = 'delete-products';
+
+    case VIEW_PROJECTS   = 'view-projects';
+    case CREATE_PROJECTS = 'create-projects';
+    case EDIT_PROJECTS   = 'edit-projects';
+    case DELETE_PROJECTS = 'delete-projects';
+
+    case VIEW_QUOTES   = 'view-quotes';
+    case CREATE_QUOTES = 'create-quotes';
+    case EDIT_QUOTES   = 'edit-quotes';
+    case DELETE_QUOTES = 'delete-quotes';
+
+    case VIEW_REPORTS   = 'view-reports';
+    case CREATE_REPORTS = 'create-reports';
+    case EDIT_REPORTS   = 'edit-reports';
+    case DELETE_REPORTS = 'delete-reports';
+
+    case VIEW_ROLES   = 'view-roles';
+    case CREATE_ROLES = 'create-roles';
+    case EDIT_ROLES   = 'edit-roles';
+    case DELETE_ROLES = 'delete-roles';
+
+    case VIEW_SETTINGS   = 'view-settings';
+    case CREATE_SETTINGS = 'create-settings';
+    case EDIT_SETTINGS   = 'edit-settings';
+    case DELETE_SETTINGS = 'delete-settings';
+
+    case VIEW_TASKS   = 'view-tasks';
+    case CREATE_TASKS = 'create-tasks';
+    case EDIT_TASKS   = 'edit-tasks';
+    case DELETE_TASKS = 'delete-tasks';
+
+    case VIEW_TAX_RATES   = 'view-tax-rates';
+    case CREATE_TAX_RATES = 'create-tax-rates';
+    case EDIT_TAX_RATES   = 'edit-tax-rates';
+    case DELETE_TAX_RATES = 'delete-tax-rates';
+
+    case VIEW_USERS   = 'view-users';
+    case CREATE_USERS = 'create-users';
+    case EDIT_USERS   = 'edit-users';
+    case DELETE_USERS = 'delete-users';
+
+    case VIEW_EMAIL_TEMPLATES   = 'view-email-templates';
+    case CREATE_EMAIL_TEMPLATES = 'create-email-templates';
+    case EDIT_EMAIL_TEMPLATES   = 'edit-email-templates';
+    case DELETE_EMAIL_TEMPLATES = 'delete-email-templates';
+
+    // Special Permissions
+    case MANAGE_CUSTOMERS = 'manage-customers';
+
+    case APPROVE_EXPENSES = 'approve-expenses';
+    case REJECT_EXPENSES  = 'reject-expenses';
+
+    case DOWNLOAD_INVOICES  = 'download-invoices';
+    case DUPLICATE_INVOICES = 'duplicate-invoices';
+    case EMAIL_INVOICES     = 'email-invoices';
+    case MARK_PAID_INVOICES = 'mark-paid-invoices';
+    case MARK_SENT_INVOICES = 'mark-sent-invoices';
+    case PRINT_INVOICES     = 'print-invoices';
+
+    case EMAIL_PAYMENTS  = 'email-payments';
+    case REFUND_PAYMENTS = 'refund-payments';
+
+    case EXPORT_PRODUCTS = 'export-products';
+    case IMPORT_PRODUCTS = 'import-products';
+
+    case MANAGE_PROJECTS = 'manage-projects';
+
+    case APPROVE_QUOTES            = 'approve-quotes';
+    case CONVERT_TO_INVOICE_QUOTES = 'convert-to-invoice-quotes';
+    case DOWNLOAD_QUOTES           = 'download-quotes';
+    case DUPLICATE_QUOTES          = 'duplicate-quotes';
+    case EMAIL_QUOTES              = 'email-quotes';
+    case MARK_SENT_QUOTES          = 'mark-sent-quotes';
+    case PRINT_QUOTES              = 'print-quotes';
+    case REJECT_QUOTES             = 'reject-quotes';
+
+    case EXPORT_REPORTS = 'export-reports';
+    case MANAGE_REPORTS = 'manage-reports';
+    case PRINT_REPORTS  = 'print-reports';
+
+    case MANAGE_SETTINGS = 'manage-settings';
+
+    case IMPERSONATE_USERS = 'impersonate-users';
+
+    case VIEW_DASHBOARD          = 'view-dashboard';
+    case MANAGE_COMPANY_SETTINGS = 'manage-company-settings';
+    case IMPORT                  = 'import';
+    case EXPORT                  = 'export';
+    case BACKUP                  = 'backup';
+    case RESTORE                 = 'restore';
+
+    public function label(): string
+    {
+        return str($this->value)->replace('-', ' ')->title()->toString();
+    }
+
+    public function color(): string
+    {
+        return match(true) {
+            str_starts_with($this->value, 'view')   => 'gray',
+            str_starts_with($this->value, 'create') => 'success',
+            str_starts_with($this->value, 'edit')   => 'warning',
+            str_starts_with($this->value, 'delete') => 'danger',
+            str_starts_with($this->value, 'manage') => 'primary',
+            default                                 => 'secondary',
+        };
+    }
+}

--- a/Modules/Core/Enums/Permission.php
+++ b/Modules/Core/Enums/Permission.php
@@ -133,10 +133,12 @@ enum Permission: string implements LabeledEnum
 
     case VIEW_DASHBOARD          = 'view-dashboard';
     case MANAGE_COMPANY_SETTINGS = 'manage-company-settings';
-    case IMPORT                  = 'import';
-    case EXPORT                  = 'export';
-    case BACKUP                  = 'backup';
-    case RESTORE                 = 'restore';
+
+    // System-wide operations
+    case IMPORT  = 'import';
+    case EXPORT  = 'export';
+    case BACKUP  = 'backup';
+    case RESTORE = 'restore';
 
     public function label(): string
     {


### PR DESCRIPTION
# Pull Request Checklist  

## Checklist  
- [x] My code follows the code formatting guidelines.  
- [x] I have tested my changes locally.  
- [x] I selected the appropriate branch for this PR.  
- [x] I have rebased my changes on top of the selected branch.  
- [x] I included relevant documentation updates if necessary.  
- [x] I have an accompanying issue ID for this pull request.  

---

## Description  
Introduces a typed `Permission` enum as the single source of truth for all permission names in the system, replacing scattered string literals in seeders. Updates `PermissionsSeeder` and `RolesSeeder` to derive permission lists from `Permission::cases()`. 

---

## Related Issue(s)  
Addresses #488  

---

## Motivation and Context  
Permission names were previously defined as inline string arrays in `PermissionsSeeder`, making them prone to typos and painful to refactor. This change centralises all 101 permission names in a single typed enum (`Modules/Core/Enums/Permission`), consistent with the existing `UserRole` enum pattern. Any future permission addition or rename now has a single place to change.

---

## Issue Type (Check one or more)  
- [ ] Bugfix  
- [ ] Improvement of an existing feature  
- [x] New feature  

---

## Screenshots (If Applicable)  
N/A, no UI changes. 

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Permission enum as a centralized source of truth for all application permissions.
  * Added human-readable labels and color coding for permissions based on their action type.

* **Refactor**
  * Streamlined role permission assignment logic for improved maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->