### PR TITLE
Fix pre-existing naming and AAA structure violations in QuotesTest files

### DIFF
--- a/Modules/Quotes/Tests/Feature/QuoteDuplicateNumberPreventionTest.php
+++ b/Modules/Quotes/Tests/Feature/QuoteDuplicateNumberPreventionTest.php
@@ -28,7 +28,7 @@ class QuoteDuplicateNumberPreventionTest extends AbstractAdminPanelTestCase
             'quote_number' => 'QUO-2025-0001',
         ]);
 
-        /* Act & Assert */
+        /* Act */
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Duplicate quote number 'QUO-2025-0001'");
 
@@ -36,6 +36,8 @@ class QuoteDuplicateNumberPreventionTest extends AbstractAdminPanelTestCase
             'numbering_id' => $numbering->id,
             'quote_number' => 'QUO-2025-0001',
         ]);
+
+        /* Assert */
     }
 
     #[Test]

--- a/Modules/Quotes/Tests/Feature/QuotesTest.php
+++ b/Modules/Quotes/Tests/Feature/QuotesTest.php
@@ -63,6 +63,7 @@ class QuotesTest extends AbstractCompanyPanelTestCase
     #[Group('crud')]
     public function it_creates_a_quote_through_a_modal(): void
     {
+        /* Arrange */
         $prospect      = Relation::factory()->for($this->company)->prospect()->create();
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
@@ -101,12 +102,14 @@ class QuotesTest extends AbstractCompanyPanelTestCase
             ],
         ];
 
+        /* Act */
         $component = Livewire::actingAs($this->user)
             ->test(ListQuotes::class, ['tenant' => Str::lower($this->company->search_code)])
             ->mountAction('create')
             ->fillForm($payload)
             ->callMountedAction();
 
+        /* Assert */
         $component->assertHasNoFormErrors();
 
         // Patch date fields for DB assertion
@@ -343,6 +346,7 @@ class QuotesTest extends AbstractCompanyPanelTestCase
      */
     public function it_creates_a_quote(): void
     {
+        /* Arrange */
         $prospect      = Relation::factory()->for($this->company)->prospect()->create();
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
@@ -580,7 +584,6 @@ class QuotesTest extends AbstractCompanyPanelTestCase
             ->test(ListQuotes::class);
 
         /* Assert */
-        /* Assert */
         $component->assertSuccessful();
         $component->assertSeeText('Q-VISIBLE');
         $this->assertDatabaseHas('quotes', ['quote_number' => 'Q-HIDDEN']);
@@ -592,7 +595,7 @@ class QuotesTest extends AbstractCompanyPanelTestCase
     #[Test]
     #[Group('crud')]
     #[Group('failing')]
-    public function widget_shows_only_current_tenant_quotes(): void
+    public function it_shows_only_current_tenant_quotes_in_the_widget(): void
     {
         $this->markTestSkipped('No widget route is currently registered for quotes');
     }


### PR DESCRIPTION
- Add missing /* Arrange */ comment to it_creates_a_quote_through_a_modal
- Add missing /* Act */ and /* Assert */ comments to same method
- Add missing /* Arrange */ comment to it_creates_a_quote
- Remove duplicate /* Assert */ comment in it_only_lists_quotes_for_the_current_tenant
- Rename widget_shows_only_current_tenant_quotes → it_shows_only_current_tenant_quotes_in_the_widget (noun-before-verb naming violation)
- Split forbidden /* Act & Assert */ into separate /* Act */ and /* Assert */ in QuoteDuplicateNumberPreventionTest

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DqwRdtVHYbBGYkENv1D78R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved organization and clarity of test comments for quote number prevention and creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->