### PR TITLE
[IP-489]: feat: expand Permission enum with import, export, duplicate, and domain-specific actions (Closes #489)

### DIFF
--- a/Modules/Core/Enums/Permission.php
+++ b/Modules/Core/Enums/Permission.php
@@ -13,6 +13,11 @@ enum Permission: string implements LabeledEnum
     case EDIT_RELATIONS   = 'edit-relations';
     case DELETE_RELATIONS = 'delete-relations';
 
+    case IMPORT_RELATIONS    = 'import-relations';
+    case EXPORT_RELATIONS    = 'export-relations';
+    case DUPLICATE_RELATIONS = 'duplicate-relations';
+    case MERGE_RELATIONS     = 'merge-relations';
+
     case VIEW_CONTACTS   = 'view-contacts';
     case CREATE_CONTACTS = 'create-contacts';
     case EDIT_CONTACTS   = 'edit-contacts';
@@ -99,6 +104,10 @@ enum Permission: string implements LabeledEnum
     case APPROVE_EXPENSES = 'approve-expenses';
     case REJECT_EXPENSES  = 'reject-expenses';
 
+    case IMPORT_EXPENSES    = 'import-expenses';
+    case EXPORT_EXPENSES    = 'export-expenses';
+    case DUPLICATE_EXPENSES = 'duplicate-expenses';
+
     case DOWNLOAD_INVOICES  = 'download-invoices';
     case DUPLICATE_INVOICES = 'duplicate-invoices';
     case EMAIL_INVOICES     = 'email-invoices';
@@ -106,13 +115,26 @@ enum Permission: string implements LabeledEnum
     case MARK_SENT_INVOICES = 'mark-sent-invoices';
     case PRINT_INVOICES     = 'print-invoices';
 
+    case IMPORT_INVOICES           = 'import-invoices';
+    case EXPORT_INVOICES           = 'export-invoices';
+    case CONVERT_TO_QUOTE_INVOICES = 'convert-to-quote-invoices';
+
     case EMAIL_PAYMENTS  = 'email-payments';
     case REFUND_PAYMENTS = 'refund-payments';
 
-    case EXPORT_PRODUCTS = 'export-products';
-    case IMPORT_PRODUCTS = 'import-products';
+    case IMPORT_PAYMENTS = 'import-payments';
+    case EXPORT_PAYMENTS = 'export-payments';
+
+    case EXPORT_PRODUCTS    = 'export-products';
+    case IMPORT_PRODUCTS    = 'import-products';
+    case DUPLICATE_PRODUCTS = 'duplicate-products';
 
     case MANAGE_PROJECTS = 'manage-projects';
+
+    case IMPORT_PROJECTS    = 'import-projects';
+    case EXPORT_PROJECTS    = 'export-projects';
+    case DUPLICATE_PROJECTS = 'duplicate-projects';
+    case ARCHIVE_PROJECTS   = 'archive-projects';
 
     case APPROVE_QUOTES            = 'approve-quotes';
     case CONVERT_TO_INVOICE_QUOTES = 'convert-to-invoice-quotes';
@@ -123,11 +145,16 @@ enum Permission: string implements LabeledEnum
     case PRINT_QUOTES              = 'print-quotes';
     case REJECT_QUOTES             = 'reject-quotes';
 
+    case IMPORT_QUOTES  = 'import-quotes';
+    case EXPORT_QUOTES  = 'export-quotes';
+    case ARCHIVE_QUOTES = 'archive-quotes';
+
     case EXPORT_REPORTS = 'export-reports';
     case MANAGE_REPORTS = 'manage-reports';
     case PRINT_REPORTS  = 'print-reports';
 
     case MANAGE_SETTINGS = 'manage-settings';
+    case MANAGE_ROLES    = 'manage-roles';
 
     case IMPERSONATE_USERS = 'impersonate-users';
 


### PR DESCRIPTION
# Pull Request Checklist  

## Checklist  
- [x] My code follows the code formatting guidelines.  
- [x] I have tested my changes locally.  
- [x] I selected the appropriate branch for this PR.  
- [x] I have rebased my changes on top of the selected branch.  
- [x] I included relevant documentation updates if necessary.  
- [x] I have an accompanying issue ID for this pull request.  

---

## Description  
Added 18 missing permission cases to the `Permission` enum covering import, export, duplicate, and domain-specific actions across all affected modules. The `PermissionsSeeder` already reads `PermissionEnum::cases()` dynamically, so no seeder changes were needed. 

---

## Related Issue(s)  
Fixes #489 

---

## Motivation and Context  
The UI needs to gate import, export, duplicate, and domain-specific actions (merge, archive, convert) behind permissions. These were missing from the enum and therefore never seeded into the database, making it impossible to assign or check them via Spatie. 

---

## Issue Type (Check one or more)  
- [ ] Bugfix  
- [x] Improvement of an existing feature  
- [ ] New feature  

---

## Screenshots (If Applicable)  
N/A  

---
