### PR TITLE
feat: Rebuild RolesSeeder — define complete role permission matrix for all 5 roles (Closes #490)

### DIFF
--- a/Modules/Core/Database/Seeders/RolesSeeder.php
+++ b/Modules/Core/Database/Seeders/RolesSeeder.php
@@ -84,13 +84,29 @@ class RolesSeeder extends Seeder
             ],
             UserRole::ADMIN->value => [
                 'name'        => 'Administrator',
-                'permissions' => $allPermissions,
+                'permissions' => array_values(array_filter(
+                    $allPermissions,
+                    fn ($p) => ! in_array($p, [
+                        PermissionEnum::IMPERSONATE_USERS->value,
+                        PermissionEnum::BACKUP->value,
+                        PermissionEnum::RESTORE->value,
+                    ])
+                )),
             ],
+
             UserRole::ASSIST->value => [
                 'name'        => 'Assist',
                 'permissions' => array_values(array_filter(
                     $allPermissions,
-                    fn ($p) => ! str_starts_with($p, 'delete-') && ! str_starts_with($p, 'manage-')
+                    fn ($p) => ! str_starts_with($p, 'delete-')
+                        && ! str_starts_with($p, 'manage-')
+                        && ! str_starts_with($p, 'approve-')
+                        && ! str_starts_with($p, 'reject-')
+                        && ! in_array($p, [
+                            PermissionEnum::IMPERSONATE_USERS->value,
+                            PermissionEnum::BACKUP->value,
+                            PermissionEnum::RESTORE->value,
+                        ])
                 )),
             ],
 
@@ -102,7 +118,9 @@ class RolesSeeder extends Seeder
                         function ($p) use ($customerResources) {
                             $isBasicAction = str_starts_with($p, 'view-')
                                 || str_starts_with($p, 'create-')
-                                || str_starts_with($p, 'edit-');
+                                || str_starts_with($p, 'edit-')
+                                || str_starts_with($p, 'export-')
+                                || str_starts_with($p, 'duplicate-');
                             $isCustomerResource = (bool) array_filter(
                                 $customerResources,
                                 fn ($r) => str_ends_with($p, '-' . $r)
@@ -112,7 +130,7 @@ class RolesSeeder extends Seeder
                         }
                     )),
                     $customerSpecialPermissions,
-                    [PermissionEnum::VIEW_DASHBOARD->value],
+                    [PermissionEnum::VIEW_DASHBOARD->value, PermissionEnum::MANAGE_COMPANY_SETTINGS->value],
                 )),
             ],
             UserRole::CUSTOMER->value => [


### PR DESCRIPTION
# Pull Request Checklist   

## Checklist  
- [x] My code follows the code formatting guidelines.  
- [x] I have tested my changes locally.  
- [x] I selected the appropriate branch for this PR.  
- [x] I have rebased my changes on top of the selected branch.  
- [x] I included relevant documentation updates if necessary.  
- [x] I have an accompanying issue ID for this pull request.  

---

## Description  
Updated `RolesSeeder::getDefaultRolePermissions()` to reflect the expanded permission set from #489 and align each role with the agreed permission matrix.

---

## Related Issue(s)  
Fixes #490  

---

## Motivation and Context  
After the Permission enum was expanded in #489, the RolesSeeder was not assigning the new permissions to any role. This update ensures all roles receive the correct permissions per the defined matrix, making assignments explicit and auditable. 

---

## Issue Type (Check one or more)  
- [ ] Bugfix  
- [x] Improvement of an existing feature  
- [ ] New feature  

---

## Screenshots (If Applicable)  

N/A

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted sensitive operations from certain administrative roles for enhanced security.

* **New Features**
  * Expanded customer administrator capabilities to include export and duplicate actions.
  * Added company settings management permission to the customer administrator role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->