### PR TITLE
[IP-491]: feat: make RoleHasPermissionsSeeder safe for production re-runs (Closes #491)

### DIFF
--- a/Modules/Core/Database/Seeders/RoleHasPermissionsSeeder.php
+++ b/Modules/Core/Database/Seeders/RoleHasPermissionsSeeder.php
@@ -29,26 +29,22 @@ class RoleHasPermissionsSeeder extends Seeder
 
         foreach ($roles as $role) {
             $currentPermissions = $role->permissions->pluck('name')->toArray();
-            $defaultPermissions = $this->getDefaultPermissionsForRole($role->name);
 
             if ($role->name === UserRole::SUPER_ADMIN->value) {
-                $newPermissions = $allPermissions;
+                $toAdd = array_diff($allPermissions, $currentPermissions);
             } else {
-                $newPermissions = array_intersect($defaultPermissions, $allPermissions);
-
-                $customPermissions = array_diff($currentPermissions, $defaultPermissions);
-                $newPermissions    = array_unique(array_merge($newPermissions, $customPermissions));
+                $defaultPermissions = $this->getDefaultPermissionsForRole($role->name);
+                $toAdd              = array_diff(
+                    array_intersect($defaultPermissions, $allPermissions),
+                    $currentPermissions
+                );
             }
 
-            if (count(array_diff($newPermissions, $currentPermissions)) > 0
-                || count(array_diff($currentPermissions, $newPermissions)) > 0) {
-                $role->syncPermissions($newPermissions);
+            if (count($toAdd) > 0) {
+                $role->givePermissionTo($toAdd);
                 $rolesUpdated++;
 
-                Log::info(trans('ip.role_permissions_updated', [
-                    'count' => count($newPermissions),
-                    'role'  => $role->display_name ?: $role->name,
-                ]));
+                Log::info('Added ' . count($toAdd) . ' permission(s) to role [' . $role->name . ']: ' . implode(', ', $toAdd));
             }
         }
 


### PR DESCRIPTION
# Pull Request Checklist   

## Checklist  
- [x] My code follows the code formatting guidelines.  
- [x] I have tested my changes locally.  
- [x] I selected the appropriate branch for this PR.  
- [x] I have rebased my changes on top of the selected branch.  
- [x] I included relevant documentation updates if necessary.  
- [x] I have an accompanying issue ID for this pull request.  

---

## Description  
Replaced the `syncPermissions` call in `RoleHasPermissionsSeeder` with additive logic using `givePermissionTo`. The seeder now only adds missing default permissions to each role and never removes existing ones, making it safe to run in production deployments alongside migrations.

---

## Related Issue(s)  
Fixes #491

---

## Motivation and Context  
The previous implementation used `syncPermissions`, which performs a full replace of a role's permissions. This meant any custom permissions granted through the admin UI would be wiped on the next deployment. The seeder is now purely additive: it reads the default permission set from `RolesSeeder::getDefaultRolePermissions()`, computes what the role is missing, and only grants those. `super_admin` always receives all permissions currently in the system. Each change is logged for auditability.

---

## Issue Type (Check one or more)  
- [ ] Bugfix  
- [x] Improvement of an existing feature  
- [ ] New feature  

---

## Screenshots (If Applicable)  
N/A

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated role permission seeding logic to use an add-only strategy instead of full synchronization. Super admin roles now receive any missing permissions, while other roles receive only default permissions that are missing from their current set. This prevents unintended removal of custom permissions during seeding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->