### PR TITLE
[IP-493]: feat: enforce permissions in Expenses module (Closes #493)

### DIFF
--- a/Modules/Expenses/Filament/Company/Resources/ExpenseCategories/ExpenseCategoryResource.php
+++ b/Modules/Expenses/Filament/Company/Resources/ExpenseCategories/ExpenseCategoryResource.php
@@ -6,6 +6,8 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 use Modules\Expenses\Filament\Company\Resources\ExpenseCategories\Pages\ListExpenseCategories;
 use Modules\Expenses\Filament\Company\Resources\ExpenseCategories\Schemas\ExpenseCategoryForm;
@@ -60,5 +62,25 @@ class ExpenseCategoryResource extends BaseResource
         return [
             'index' => ListExpenseCategories::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_EXPENSES->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_EXPENSES->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_EXPENSES->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_EXPENSES->value) ?? false;
     }
 }

--- a/Modules/Expenses/Filament/Company/Resources/ExpenseCategories/Pages/ListExpenseCategories.php
+++ b/Modules/Expenses/Filament/Company/Resources/ExpenseCategories/Pages/ListExpenseCategories.php
@@ -4,6 +4,7 @@ namespace Modules\Expenses\Filament\Company\Resources\ExpenseCategories\Pages;
 
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
+use Modules\Core\Enums\Permission;
 use Modules\Expenses\Filament\Company\Resources\ExpenseCategories\ExpenseCategoryResource;
 use Modules\Expenses\Services\ExpenseCategoryService;
 
@@ -15,6 +16,7 @@ class ListExpenseCategories extends ListRecords
     {
         return [
             CreateAction::make()
+                ->visible(fn () => auth()->user()?->can(Permission::CREATE_EXPENSES->value))
                 ->mutateDataUsing(function (array $data) {
                     return $data;
                 })

--- a/Modules/Expenses/Filament/Company/Resources/ExpenseCategories/Tables/ExpenseCategoriesTable.php
+++ b/Modules/Expenses/Filament/Company/Resources/ExpenseCategories/Tables/ExpenseCategoriesTable.php
@@ -9,6 +9,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Modules\Core\Enums\Permission;
 use Modules\Expenses\Models\ExpenseCategory;
 use Modules\Expenses\Services\ExpenseCategoryService;
 
@@ -25,11 +26,13 @@ class ExpenseCategoriesTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make('edit')
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_EXPENSES->value))
                         ->action(function (ExpenseCategory $record, array $data) {
                             app(ExpenseCategoryService::class)->updateExpenseCategory($record, $data);
                         })
                         ->modalWidth('full'),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_EXPENSES->value))
                         ->action(function (ExpenseCategory $record, array $data) {
                             app(ExpenseCategoryService::class)->deleteExpenseCategory($record);
                         }),
@@ -37,7 +40,8 @@ class ExpenseCategoriesTable
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_EXPENSES->value)),
                 ]),
             ]);
     }

--- a/Modules/Expenses/Filament/Company/Resources/Expenses/ExpenseResource.php
+++ b/Modules/Expenses/Filament/Company/Resources/Expenses/ExpenseResource.php
@@ -6,6 +6,8 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 use Modules\Expenses\Filament\Company\Resources\Expenses\Pages\ListExpenses;
 use Modules\Expenses\Filament\Company\Resources\Expenses\Schemas\ExpenseForm;
@@ -59,5 +61,25 @@ class ExpenseResource extends BaseResource
         return [
             'index' => ListExpenses::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_EXPENSES->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_EXPENSES->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_EXPENSES->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_EXPENSES->value) ?? false;
     }
 }

--- a/Modules/Expenses/Filament/Company/Resources/Expenses/Pages/ListExpenses.php
+++ b/Modules/Expenses/Filament/Company/Resources/Expenses/Pages/ListExpenses.php
@@ -4,6 +4,7 @@ namespace Modules\Expenses\Filament\Company\Resources\Expenses\Pages;
 
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
+use Modules\Core\Enums\Permission;
 use Modules\Expenses\Filament\Company\Resources\Expenses\ExpenseResource;
 use Modules\Expenses\Services\ExpenseService;
 
@@ -15,6 +16,7 @@ class ListExpenses extends ListRecords
     {
         return [
             CreateAction::make()
+                ->visible(fn () => auth()->user()?->can(Permission::CREATE_EXPENSES->value))
                 ->mutateDataUsing(function (array $data) {
                     return $data;
                 })

--- a/Modules/Expenses/Filament/Company/Resources/Expenses/Tables/ExpensesTable.php
+++ b/Modules/Expenses/Filament/Company/Resources/Expenses/Tables/ExpensesTable.php
@@ -120,21 +120,6 @@ class ExpensesTable
                 BulkActionGroup::make([
                     DeleteBulkAction::make()
                         ->visible(fn () => auth()->user()?->can(Permission::DELETE_EXPENSES->value)),
-                    Action::make('import')
-                        ->visible(fn () => auth()->user()?->can(Permission::IMPORT_EXPENSES->value))
-                        ->requiresConfirmation()
-                        ->modalHeading('TODO: Import Expenses')
-                        ->modalDescription('This action is not yet implemented.')
-                        ->modalSubmitActionLabel('OK')
-                        ->action(fn () => null),
-
-                    Action::make('export')
-                        ->visible(fn () => auth()->user()?->can(Permission::EXPORT_EXPENSES->value))
-                        ->requiresConfirmation()
-                        ->modalHeading('TODO: Export Expenses')
-                        ->modalDescription('This action is not yet implemented.')
-                        ->modalSubmitActionLabel('OK')
-                        ->action(fn () => null),
                 ]),
             ]);
     }

--- a/Modules/Expenses/Filament/Company/Resources/Expenses/Tables/ExpensesTable.php
+++ b/Modules/Expenses/Filament/Company/Resources/Expenses/Tables/ExpensesTable.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Expenses\Filament\Company\Resources\Expenses\Tables;
 
+use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
@@ -9,6 +10,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Helpers\EnumHelper;
 use Modules\Expenses\Enums\ExpenseStatus;
 use Modules\Expenses\Enums\ExpenseType;
@@ -76,19 +78,63 @@ class ExpensesTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make('edit')
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_EXPENSES->value))
                         ->action(function (Expense $record, array $data) {
                             app(ExpenseService::class)->updateExpense($record, $data);
                         })
                         ->modalWidth('full'),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_EXPENSES->value))
                         ->action(function (Expense $record, array $data) {
                             app(ExpenseService::class)->deleteExpense($record);
                         }),
+
+                    Action::make('approve')
+                        ->visible(fn () => auth()->user()?->can(Permission::APPROVE_EXPENSES->value))
+                        ->color('success')
+                        ->requiresConfirmation()
+                        ->modalHeading('TODO: Approve Expense')
+                        ->modalDescription('This action is not yet implemented.')
+                        ->modalSubmitActionLabel('OK')
+                        ->action(fn () => null),
+
+                    Action::make('reject')
+                        ->visible(fn () => auth()->user()?->can(Permission::REJECT_EXPENSES->value))
+                        ->color('danger')
+                        ->requiresConfirmation()
+                        ->modalHeading('TODO: Reject Expense')
+                        ->modalDescription('This action is not yet implemented.')
+                        ->modalSubmitActionLabel('OK')
+                        ->action(fn () => null),
+
+                    Action::make('duplicate')
+                        ->visible(fn () => auth()->user()?->can(Permission::DUPLICATE_EXPENSES->value))
+                        ->requiresConfirmation()
+                        ->modalHeading('TODO: Duplicate Expense')
+                        ->modalDescription('This action is not yet implemented.')
+                        ->modalSubmitActionLabel('OK')
+                        ->action(fn () => null),
                 ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_EXPENSES->value)),
+                    Action::make('import')
+                        ->visible(fn () => auth()->user()?->can(Permission::IMPORT_EXPENSES->value))
+                        ->requiresConfirmation()
+                        ->modalHeading('TODO: Import Expenses')
+                        ->modalDescription('This action is not yet implemented.')
+                        ->modalSubmitActionLabel('OK')
+                        ->action(fn () => null),
+
+                    Action::make('export')
+                        ->visible(fn () => auth()->user()?->can(Permission::EXPORT_EXPENSES->value))
+                        ->requiresConfirmation()
+                        ->modalHeading('TODO: Export Expenses')
+                        ->modalDescription('This action is not yet implemented.')
+                        ->modalSubmitActionLabel('OK')
+                        ->action(fn () => null),
                 ]),
             ]);
     }


### PR DESCRIPTION
## Checklist  
- [x] My code follows the code formatting guidelines.  
- [x] I have tested my changes locally.  
- [x] I selected the appropriate branch for this PR.  
- [x] I have rebased my changes on top of the selected branch.  
- [ ] I included relevant documentation updates if necessary.  
- [x] I have an accompanying issue ID for this pull request.  

---

## Description  
Replaces open (role-free) access in the Expenses module with explicit permission checks using the `Permission` enum. Both `ExpenseResource` and `ExpenseCategoryResource` now enforce `can()` checks at the resource level and on every table/toolbar action. Approve, reject, duplicate,  import, and export actions are stubbed with TODO modals pending their business logic implementation.

---

## Related Issue(s)  
Fixes #493  

---

## Motivation and Context  
Access control in the Expenses module was previously role-free, any authenticated company user could create, edit, delete, approve, or import expenses regardless of their assigned permissions. This change enforces the permission matrix defined in the `Permission` enum so that actions are only visible and executable by users whose role grants the corresponding permission.

---

## Issue Type (Check one or more)  
- [ ] Bugfix  
- [x] Improvement of an existing feature  
- [ ] New feature  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added permission-based authorization for viewing, creating, editing, and deleting expense categories and expenses.
  * Updated expense and category screens so create actions only appear when the user has the matching permission.
  * Restricted table actions (edit/delete/bulk delete) to users with the required permissions.

* **New Features**
  * Added per-expense actions for **Approve**, **Reject**, and **Duplicate** (currently show a TODO confirmation and don’t perform an operation yet).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->