### PR TITLE
[IP-492]: feat: enforce permissions in Relations (Clients) module (Closes #492)

### DIFF
--- a/Modules/Clients/Filament/Company/Resources/Contacts/ContactResource.php
+++ b/Modules/Clients/Filament/Company/Resources/Contacts/ContactResource.php
@@ -6,10 +6,12 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 use Modules\Clients\Filament\Company\Resources\Contacts\Pages\ListContacts;
 use Modules\Clients\Filament\Company\Resources\Contacts\Schemas\ContactForm;
 use Modules\Clients\Filament\Company\Resources\Contacts\Tables\ContactsTable;
 use Modules\Clients\Models\Contact;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 
 class ContactResource extends BaseResource
@@ -39,5 +41,25 @@ class ContactResource extends BaseResource
         return [
             'index' => ListContacts::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_CONTACTS->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_CONTACTS->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_CONTACTS->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_CONTACTS->value) ?? false;
     }
 }

--- a/Modules/Clients/Filament/Company/Resources/Contacts/Tables/ContactsTable.php
+++ b/Modules/Clients/Filament/Company/Resources/Contacts/Tables/ContactsTable.php
@@ -13,6 +13,7 @@ use Modules\Clients\Enums\Gender;
 use Modules\Clients\Enums\RelationType;
 use Modules\Clients\Models\Contact;
 use Modules\Clients\Services\ContactService;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Helpers\EnumHelper;
 
 class ContactsTable
@@ -67,11 +68,13 @@ class ContactsTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make('edit')
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_CONTACTS->value))
                         ->action(function (Contact $record, array $data) {
                             app(ContactService::class)->updateContact($record, $data);
                         })
                         ->modalWidth('full'),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_CONTACTS->value))
                         ->action(function (Contact $record, array $data) {
                             app(ContactService::class)->deleteContact($record);
                         }),
@@ -79,7 +82,8 @@ class ContactsTable
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_CONTACTS->value)),
                 ]),
             ]);
     }

--- a/Modules/Clients/Filament/Company/Resources/Relations/RelationResource.php
+++ b/Modules/Clients/Filament/Company/Resources/Relations/RelationResource.php
@@ -6,10 +6,12 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 use Modules\Clients\Filament\Company\Resources\Relations\Pages\ListRelations;
 use Modules\Clients\Filament\Company\Resources\Relations\Schemas\RelationForm;
 use Modules\Clients\Filament\Company\Resources\Relations\Tables\RelationsTable;
 use Modules\Clients\Models\Relation;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 
 class RelationResource extends BaseResource
@@ -38,5 +40,25 @@ class RelationResource extends BaseResource
         return [
             'index' => ListRelations::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_RELATIONS->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_RELATIONS->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_RELATIONS->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_RELATIONS->value) ?? false;
     }
 }

--- a/Modules/Clients/Filament/Company/Resources/Relations/Tables/RelationsTable.php
+++ b/Modules/Clients/Filament/Company/Resources/Relations/Tables/RelationsTable.php
@@ -13,6 +13,7 @@ use Modules\Clients\Enums\RelationStatus;
 use Modules\Clients\Enums\RelationType;
 use Modules\Clients\Models\Relation;
 use Modules\Clients\Services\CustomerService;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Helpers\EnumHelper;
 
 class RelationsTable
@@ -88,11 +89,13 @@ class RelationsTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make('edit')
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_RELATIONS->value))
                         ->action(function (Relation $record, array $data) {
                             app(CustomerService::class)->updateCustomer($record, $data);
                         })
                         ->modalWidth('full'),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_RELATIONS->value))
                         ->action(function (Relation $record, array $data) {
                             app(\Modules\Clients\Services\RelationService::class)->deleteRelation($record);
                         }),
@@ -100,7 +103,8 @@ class RelationsTable
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_RELATIONS->value)),
                 ]),
             ])->defaultSort('company_name', 'asc');
     }


### PR DESCRIPTION
# Pull Request Checklist

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [x] I have an accompanying issue ID for this pull request.

---

## Description
Enforces Spatie permission checks in the Clients module for `RelationResource` and `ContactResource`. All access control now uses `Permission` enum values via `auth()->user()->can()` instead of role checks.

---

## Related Issue(s)
Fixes #492

---

## Motivation and Context
The Relations and Contacts module relied on implicit role-based access with no explicit permission guards. This change moves all access control to Spatie permission checks, consistent with the pattern established in the Expenses module (#493).

---

## Issue Type (Check one or more)
- [ ] Bugfix
- [x] Improvement of an existing feature
- [ ] New feature

---

## Screenshots (If Applicable)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented permission-based access control for contact and relation management. Users can now only view, create, edit, or delete contacts and relations if they have the required permissions. Edit and delete actions are hidden from unauthorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->