### PR TITLE
[IP-494]: feat: enforce permissions in Invoices module (Closes #494)

### DIFF
--- a/Modules/Invoices/Filament/Company/Resources/Invoices/InvoiceResource.php
+++ b/Modules/Invoices/Filament/Company/Resources/Invoices/InvoiceResource.php
@@ -6,6 +6,8 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 use Modules\Invoices\Filament\Company\Resources\Invoices\Pages\ListInvoices;
 use Modules\Invoices\Filament\Company\Resources\Invoices\Schemas\InvoiceForm;
@@ -60,5 +62,25 @@ class InvoiceResource extends BaseResource
         return [
             'index' => ListInvoices::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_INVOICES->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_INVOICES->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_INVOICES->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_INVOICES->value) ?? false;
     }
 }

--- a/Modules/Invoices/Filament/Company/Resources/Invoices/Tables/InvoicesTable.php
+++ b/Modules/Invoices/Filament/Company/Resources/Invoices/Tables/InvoicesTable.php
@@ -11,6 +11,7 @@ use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use InvalidArgumentException;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Support\DateHelpers;
 use Modules\Invoices\Enums\InvoiceStatus;
 use Modules\Invoices\Models\Invoice;
@@ -77,6 +78,7 @@ class InvoicesTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_INVOICES->value))
                         ->mutateDataUsing(function (array $data, Invoice $record) {
                             $data['invoiceItems'] = $record->invoiceItems()->get()->map(function ($item) {
                                 $product = $item->product;
@@ -105,6 +107,7 @@ class InvoicesTable
                         })
                         ->modalWidth('full'),
                     Action::make('download pdf')
+                        ->visible(fn () => auth()->user()?->can(Permission::DOWNLOAD_INVOICES->value))
                         ->label(trans('ip.download_pdf'))
                         ->modalDescription(
                             'todo: make sure we can download the PDF of the Invoice through an action,
@@ -112,6 +115,7 @@ class InvoicesTable
                         )
                         ->action(function (Invoice $record): void {}),
                     Action::make('send email')
+                        ->visible(fn () => auth()->user()?->can(Permission::EMAIL_INVOICES->value))
                         ->label(trans('ip.send_email'))
                         ->action(function (Invoice $record): void {
                             app(InvoiceService::class)->sendInvoiceEmail($record);
@@ -123,6 +127,7 @@ class InvoicesTable
                                 ->send();
                         }),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_INVOICES->value))
                         ->action(function (Invoice $record, array $data) {
                             try {
                                 app(InvoiceService::class)->deleteInvoice($record);
@@ -137,7 +142,8 @@ class InvoicesTable
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_INVOICES->value)),
                 ]),
             ])
             ->defaultSort('invoice_due_at', 'desc');

--- a/Modules/Invoices/Filament/Company/Resources/RecurringInvoices/RecurringInvoiceResource.php
+++ b/Modules/Invoices/Filament/Company/Resources/RecurringInvoices/RecurringInvoiceResource.php
@@ -7,6 +7,8 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Invoices\Filament\Company\Resources\RecurringInvoices\Pages\ListRecurringInvoices;
 use Modules\Invoices\Filament\Company\Resources\RecurringInvoices\Schemas\RecurringInvoiceForm;
 use Modules\Invoices\Filament\Company\Resources\RecurringInvoices\Tables\RecurringInvoicesTable;
@@ -60,5 +62,25 @@ class RecurringInvoiceResource extends Resource
         return [
             'index' => ListRecurringInvoices::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_INVOICES->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_INVOICES->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_INVOICES->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_INVOICES->value) ?? false;
     }
 }

--- a/Modules/Invoices/Filament/Company/Resources/RecurringInvoices/Tables/RecurringInvoicesTable.php
+++ b/Modules/Invoices/Filament/Company/Resources/RecurringInvoices/Tables/RecurringInvoicesTable.php
@@ -4,10 +4,12 @@ namespace Modules\Invoices\Filament\Company\Resources\RecurringInvoices\Tables;
 
 use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Helpers\EnumHelper;
 use Modules\Invoices\Enums\RecurringFrequency;
 
@@ -40,14 +42,19 @@ class RecurringInvoicesTable
             ])
             ->filters([
             ])
-            ->actions([
+            ->recordActions([
                 ActionGroup::make([
-                    EditAction::make()->modalWidth('full'),
+                    EditAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_INVOICES->value))
+                        ->modalWidth('full'),
+                    DeleteAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_INVOICES->value)),
                 ]),
             ])
-            ->bulkActions([
+            ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_INVOICES->value)),
                 ]),
             ]);
     }


### PR DESCRIPTION
# Pull Request Checklist

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [x] I have an accompanying issue ID for this pull request.

---

## Description
Enforces Spatie permission checks across the Invoices module for `InvoiceResource` and `RecurringInvoiceResource`. All table actions are now conditionally visible based on the corresponding permission, and resource-level `canViewAny`, `canCreate`, `canEdit`, `canDelete` methods are wired to the `Permission` enum.

---

## Related Issue(s)
Fixes #494

---

## Motivation and Context
The Invoices module had no explicit permission guards, any authenticated user could see and trigger all actions regardless of their role. This change moves all access control to Spatie permission checks, consistent with the pattern established in the Expenses (#493) and Clients (#492) modules.

---

## Issue Type (Check one or more)
- [ ] Bugfix
- [x] Improvement of an existing feature
- [ ] New feature

---

## Screenshots (If Applicable)
N/A
