### PR TITLE
[IP-495]: feat: enforce permissions in Payments module Closes(#495)

### DIFF
--- a/Modules/Core/Database/Seeders/RolesSeeder.php
+++ b/Modules/Core/Database/Seeders/RolesSeeder.php
@@ -106,6 +106,7 @@ class RolesSeeder extends Seeder
                             PermissionEnum::IMPERSONATE_USERS->value,
                             PermissionEnum::BACKUP->value,
                             PermissionEnum::RESTORE->value,
+                            PermissionEnum::REFUND_PAYMENTS->value,
                         ])
                 )),
             ],

--- a/Modules/Core/Models/User.php
+++ b/Modules/Core/Models/User.php
@@ -12,11 +12,13 @@ use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
+use Modules\Clients\Models\Relation;
 use Modules\Core\Database\Factories\UserFactory;
 use Modules\Core\Enums\UserRole;
 use Modules\Expenses\Models\Expense;
@@ -128,6 +130,11 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasName, 
     public function uploads(): HasMany
     {
         return $this->hasMany(Upload::class);
+    }
+
+    public function relation(): BelongsTo
+    {
+        return $this->belongsTo(Relation::class);
     }
 
     /*

--- a/Modules/Payments/Filament/Company/Resources/Payments/PaymentResource.php
+++ b/Modules/Payments/Filament/Company/Resources/Payments/PaymentResource.php
@@ -6,6 +6,10 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
+use Modules\Core\Enums\UserRole;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 use Modules\Payments\Filament\Company\Resources\Payments\Pages\ListPayments;
 use Modules\Payments\Filament\Company\Resources\Payments\Schemas\PaymentForm;
@@ -59,5 +63,37 @@ class PaymentResource extends BaseResource
         return [
             'index' => ListPayments::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_PAYMENTS->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_PAYMENTS->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_PAYMENTS->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_PAYMENTS->value) ?? false;
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+        $user  = auth()->user();
+
+        if ($user?->hasRole(UserRole::CUSTOMER->value) && $user->relation_id) {
+            $query->where('customer_id', $user->relation_id);
+        }
+
+        return $query;
     }
 }

--- a/Modules/Payments/Filament/Company/Resources/Payments/PaymentResource.php
+++ b/Modules/Payments/Filament/Company/Resources/Payments/PaymentResource.php
@@ -90,8 +90,12 @@ class PaymentResource extends BaseResource
         $query = parent::getEloquentQuery();
         $user  = auth()->user();
 
-        if ($user?->hasRole(UserRole::CUSTOMER->value) && $user->relation_id) {
-            $query->where('customer_id', $user->relation_id);
+        if ($user?->hasRole(UserRole::CUSTOMER->value)) {
+            if ($user->relation_id) {
+                $query->where('customer_id', $user->relation_id);
+            } else {
+                $query->whereRaw('1 = 0');
+            }
         }
 
         return $query;

--- a/Modules/Payments/Filament/Company/Resources/Payments/Tables/PaymentsTable.php
+++ b/Modules/Payments/Filament/Company/Resources/Payments/Tables/PaymentsTable.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Payments\Filament\Company\Resources\Payments\Tables;
 
+use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
@@ -9,6 +10,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Modules\Core\Enums\Permission;
 use Modules\Payments\Models\Payment;
 use Modules\Payments\Services\PaymentService;
 
@@ -75,11 +77,21 @@ class PaymentsTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make('edit')
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_PAYMENTS->value))
                         ->action(function (Payment $record, array $data) {
                             app(PaymentService::class)->updatePayment($record, $data);
                         })
                         ->modalWidth('full'),
+                    Action::make('email_receipt')
+                        ->visible(fn () => auth()->user()?->can(Permission::EMAIL_PAYMENTS->value))
+                        ->label(trans('ip.send_email'))
+                        ->action(function (Payment $record): void {}),
+                    Action::make('refund')
+                        ->visible(fn () => auth()->user()?->can(Permission::REFUND_PAYMENTS->value))
+                        ->label(trans('ip.refund'))
+                        ->action(function (Payment $record): void {}),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_PAYMENTS->value))
                         ->action(function (Payment $record, array $data) {
                             app(PaymentService::class)->deletePayment($record);
                         }),
@@ -87,7 +99,8 @@ class PaymentsTable
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_PAYMENTS->value)),
                 ]),
             ])->defaultSort('paid_at', 'desc');
     }

--- a/database/migrations/2026_06_23_091148_add_relation_id_to_users_table.php
+++ b/database/migrations/2026_06_23_091148_add_relation_id_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedBigInteger('relation_id')->nullable()->after('id');
+            $table->foreign('relation_id')->references('id')->on('relations')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropForeign(['relation_id']);
+            $table->dropColumn('relation_id');
+        });
+    }
+};

--- a/resources/lang/en/ip.php
+++ b/resources/lang/en/ip.php
@@ -338,6 +338,7 @@ return [
     'record_successfully_updated'                  => 'Record successfully updated',
     'recurring'                                    => 'Recurring',
     'recurring_invoices'                           => 'Recurring Invoices',
+    'refund'                                       => 'Refund',
     'rejected'                                     => 'Rejected',
     'remove'                                       => 'Remove',
     'remove_logo'                                  => 'Remove Logo',


### PR DESCRIPTION
# Pull Request Checklist  

## Checklist  
- [x] My code follows the code formatting guidelines.  
- [x] I have tested my changes locally.  
- [x] I selected the appropriate branch for this PR.  
- [x] I have rebased my changes on top of the selected branch.  
- [ ] I included relevant documentation updates if necessary.  
- [x] I have an accompanying issue ID for this pull request.  

---

## Description  
Moves access control in the Payments module from role checks to Spatie permissions. All table actions (edit, delete, bulk delete, email receipt, refund) are now conditionally shown based on the corresponding `Permission` enum values. A query scope is added to restrict `client`-role users to only see payments linked to their own invoices. The `refund-payments` permission is explicitly excluded from the `assist` role in the seeder.

---

## Related Issue(s)  
Fixes #495

---

## Motivation and Context  
The Payments module was not consistently enforcing Spatie permissions for its table actions, and the `client` role had no data-level restriction — they could see all company payments, not just their own. This change closes those gaps and aligns Payments with the permission pattern already applied to Invoices, Expenses, and Relations modules.

---

## Issue Type (Check one or more)  
- [ ] Bugfix  
- [x] Improvement of an existing feature  
- [ ] New feature  

---

## Screenshots (If Applicable)  
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refund and email receipt actions for payment management with permission-based access control.
  * Users can now be linked to customer relations.

* **Bug Fixes**
  * Restricted refund capability for the Assist role to align with permission settings.

* **Chores**
  * Updated language strings and database schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->