### PR TITLE
[IP-497]: feat: enforce permissions in Projects module (Closes #497)

### DIFF
--- a/Modules/Projects/Filament/Company/Resources/Projects/ProjectResource.php
+++ b/Modules/Projects/Filament/Company/Resources/Projects/ProjectResource.php
@@ -6,6 +6,8 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 use Modules\Projects\Filament\Company\Resources\Projects\Pages\ListProjects;
 use Modules\Projects\Filament\Company\Resources\Projects\Schemas\ProjectForm;
@@ -60,5 +62,30 @@ class ProjectResource extends BaseResource
         return [
             'index' => ListProjects::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_PROJECTS->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_PROJECTS->value) ?? false;
+    }
+
+    public static function canView(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_PROJECTS->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_PROJECTS->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_PROJECTS->value) ?? false;
     }
 }

--- a/Modules/Projects/Filament/Company/Resources/Projects/Tables/ProjectsTable.php
+++ b/Modules/Projects/Filament/Company/Resources/Projects/Tables/ProjectsTable.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Projects\Filament\Company\Resources\Projects\Tables;
 
+use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
@@ -9,6 +10,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Helpers\EnumHelper;
 use Modules\Projects\Enums\ProjectStatus;
 use Modules\Projects\Models\Project;
@@ -53,11 +55,23 @@ class ProjectsTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make('edit')
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_PROJECTS->value))
                         ->action(function (Project $record, array $data) {
                             app(ProjectService::class)->updateProject($record, $data);
                         })
                         ->modalWidth('full'),
+                    Action::make('duplicate')
+                        ->label(trans('ip.duplicate'))
+                        ->icon('heroicon-o-document-duplicate')
+                        ->visible(fn () => auth()->user()?->can(Permission::DUPLICATE_PROJECTS->value))
+                        ->action(function (): void {}),
+                    Action::make('archive')
+                        ->label(trans('ip.archive'))
+                        ->icon('heroicon-o-archive-box')
+                        ->visible(fn () => auth()->user()?->can(Permission::ARCHIVE_PROJECTS->value))
+                        ->action(function (): void {}),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_PROJECTS->value))
                         ->action(function (Project $record, array $data) {
                             app(ProjectService::class)->deleteProject($record);
                         }),
@@ -65,7 +79,8 @@ class ProjectsTable
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_PROJECTS->value)),
                 ]),
             ])
             ->defaultSort('end_at', 'asc');

--- a/Modules/Projects/Filament/Company/Resources/Tasks/Tables/TasksTable.php
+++ b/Modules/Projects/Filament/Company/Resources/Tasks/Tables/TasksTable.php
@@ -9,6 +9,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Modules\Core\Enums\Permission;
 use Modules\Projects\Enums\TaskStatus;
 use Modules\Projects\Models\Task;
 use Modules\Projects\Services\TaskService;
@@ -87,6 +88,7 @@ class TasksTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_TASKS->value))
                         ->action(
                             fn (Task $record, array $data) => app(TaskService::class)
                                 ->updateTask($record, $data)
@@ -94,6 +96,7 @@ class TasksTable
                         ->modalWidth('full')
                         ->tooltip(trans('filament-actions::edit.single.label')),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_TASKS->value))
                         ->action(
                             fn (Task $record, array $data) => app(TaskService::class)
                                 ->deleteTask($record)
@@ -102,7 +105,8 @@ class TasksTable
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_TASKS->value)),
                 ]),
             ]);
     }

--- a/Modules/Projects/Filament/Company/Resources/Tasks/TaskResource.php
+++ b/Modules/Projects/Filament/Company/Resources/Tasks/TaskResource.php
@@ -6,6 +6,8 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 use Modules\Projects\Filament\Company\Resources\Tasks\Pages\ListTasks;
 use Modules\Projects\Filament\Company\Resources\Tasks\Schemas\TaskForm;
@@ -59,5 +61,30 @@ class TaskResource extends BaseResource
         return [
             'index' => ListTasks::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_TASKS->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_TASKS->value) ?? false;
+    }
+
+    public static function canView(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_TASKS->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_TASKS->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_TASKS->value) ?? false;
     }
 }


### PR DESCRIPTION
# Pull Request Checklist

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [x] I have an accompanying issue ID for this pull request.

---

## Description
Replaces role-based access checks with Spatie permission gates across the Projects module. `ProjectResource` and `TaskResource` now implement `canViewAny`, `canCreate`, `canEdit`, and `canDelete` using the Permission enum. Table actions (edit, delete, bulk delete, duplicate, archive) are individually gated via `->visible()` checks against the corresponding permission.

---

## Related Issue(s)
Fixes #497

---

## Motivation and Context
Access control in the Projects module was either missing or relying on role checks, which is inconsistent with the permission-based model used elsewhere in the application (Invoices, Payments, Clients). This PR brings Projects and Tasks in line with that pattern, ensuring fine-grained control over who can view, create, edit, delete, duplicate, and archive projects and tasks.

---

## Issue Type (Check one or more)
- [ ] Bugfix
- [x] Improvement of an existing feature
- [ ] New feature

---

## Screenshots (If Applicable)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented permission-based access controls for projects (view, create, edit, delete)
  * Implemented permission-based access controls for tasks (view, create, edit, delete)
  * Table actions now respect user permissions for editing, deleting, and duplicating/archiving projects
  * Bulk delete operations are now permission-gated for both projects and tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->