### PR TITLE
[IP-496]: feat: enforce permissions in Products module (Closes #496)

### DIFF
--- a/Modules/Products/Filament/Company/Resources/ProductCategories/ProductCategoryResource.php
+++ b/Modules/Products/Filament/Company/Resources/ProductCategories/ProductCategoryResource.php
@@ -6,6 +6,8 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 use Modules\Products\Filament\Company\Resources\ProductCategories\Pages\ListProductCategories;
 use Modules\Products\Filament\Company\Resources\ProductCategories\Schemas\ProductCategoryForm;
@@ -58,5 +60,30 @@ class ProductCategoryResource extends BaseResource
         return [
             'index' => ListProductCategories::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_PRODUCTS->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_PRODUCTS->value) ?? false;
+    }
+
+    public static function canView(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_PRODUCTS->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_PRODUCTS->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_PRODUCTS->value) ?? false;
     }
 }

--- a/Modules/Products/Filament/Company/Resources/ProductCategories/Tables/ProductCategoriesTable.php
+++ b/Modules/Products/Filament/Company/Resources/ProductCategories/Tables/ProductCategoriesTable.php
@@ -9,6 +9,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Modules\Core\Enums\Permission;
 use Modules\Products\Services\ProductCategoryService;
 
 class ProductCategoriesTable
@@ -22,8 +23,10 @@ class ProductCategoriesTable
             ->filters([])
             ->recordActions([
                 ActionGroup::make([
-                    EditAction::make()->modalWidth('full'),
+                    EditAction::make()->modalWidth('full')
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_PRODUCTS->value)),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_PRODUCTS->value))
                         ->action(function ($record, array $data) {
                             app(ProductCategoryService::class)->deleteProductCategory($record);
                         }),
@@ -31,7 +34,8 @@ class ProductCategoriesTable
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_PRODUCTS->value)),
                 ]),
             ])
             ->defaultSort('category_name', 'asc');

--- a/Modules/Products/Filament/Company/Resources/ProductUnits/ProductUnitResource.php
+++ b/Modules/Products/Filament/Company/Resources/ProductUnits/ProductUnitResource.php
@@ -6,6 +6,8 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 use Modules\Products\Filament\Company\Resources\ProductUnits\Pages\ListProductUnits;
 use Modules\Products\Filament\Company\Resources\ProductUnits\Schemas\ProductUnitForm;
@@ -60,5 +62,30 @@ class ProductUnitResource extends BaseResource
         return [
             'index' => ListProductUnits::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_PRODUCTS->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_PRODUCTS->value) ?? false;
+    }
+
+    public static function canView(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_PRODUCTS->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_PRODUCTS->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_PRODUCTS->value) ?? false;
     }
 }

--- a/Modules/Products/Filament/Company/Resources/ProductUnits/Tables/ProductUnitsTable.php
+++ b/Modules/Products/Filament/Company/Resources/ProductUnits/Tables/ProductUnitsTable.php
@@ -9,6 +9,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Modules\Core\Enums\Permission;
 use Modules\Products\Models\ProductUnit;
 use Modules\Products\Services\ProductUnitService;
 
@@ -26,12 +27,16 @@ class ProductUnitsTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make('edit')
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_PRODUCTS->value))
+
                         ->action(function (ProductUnit $record, array $data) {
                             app(ProductUnitService::class)->updateProductUnit($record, $data);
                         })
                         ->modalWidth('full')
                         ->tooltip(trans('filament-actions::edit.single.label')),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_PRODUCTS->value))
+
                         ->action(function (ProductUnit $record, array $data) {
                             app(ProductUnitService::class)->deleteProductUnit($record);
                         }),
@@ -39,7 +44,8 @@ class ProductUnitsTable
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_PRODUCTS->value)),
                 ]),
             ]);
     }

--- a/Modules/Products/Filament/Company/Resources/Products/ProductResource.php
+++ b/Modules/Products/Filament/Company/Resources/Products/ProductResource.php
@@ -6,6 +6,8 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 use Modules\Products\Filament\Company\Resources\Products\Pages\ListProducts;
 use Modules\Products\Filament\Company\Resources\Products\Schemas\ProductForm;
@@ -58,5 +60,30 @@ class ProductResource extends BaseResource
         return [
             'index' => ListProducts::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_PRODUCTS->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_PRODUCTS->value) ?? false;
+    }
+
+    public static function canView(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_PRODUCTS->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_PRODUCTS->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_PRODUCTS->value) ?? false;
     }
 }

--- a/Modules/Products/Filament/Company/Resources/Products/Tables/ProductsTable.php
+++ b/Modules/Products/Filament/Company/Resources/Products/Tables/ProductsTable.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Products\Filament\Company\Resources\Products\Tables;
 
+use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
@@ -9,6 +10,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Modules\Core\Enums\Permission;
 use Modules\Products\Enums\ProductType;
 use Modules\Products\Models\Product;
 use Modules\Products\Services\ProductService;
@@ -61,19 +63,28 @@ class ProductsTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make('edit')
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_PRODUCTS->value))
                         ->action(function (Product $record, array $data) {
                             app(ProductService::class)->updateProduct($record, $data);
                         })
                         ->modalWidth('full'),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_PRODUCTS->value))
+
                         ->action(function (Product $record, array $data) {
                             app(ProductService::class)->deleteProduct($record, $data);
                         }),
+                    Action::make('duplicate')
+                        ->label(trans('ip.duplicate'))
+                        ->icon('heroicon-o-document-duplicate')
+                        ->visible(fn () => auth()->user()?->can(Permission::DUPLICATE_PRODUCTS->value))
+                        ->action(function (Product $record): void {}),
                 ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_PRODUCTS->value)),
                 ]),
             ]);
     }


### PR DESCRIPTION
# Pull Request Checklist

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [x] I have an accompanying issue ID for this pull request.

---

## Description
Enforces Spatie permission checks across all three Products module resources (`ProductResource`, `ProductCategoryResource`, `ProductUnitResource`). Replaces any role-based checks with `can()` calls against the `Permission` enum. Adds a stub duplicate action on `ProductsTable` gated by `duplicate-products`, ready for implementation in a follow-up.

---

## Related Issue(s)
Fixes #496

---

## Motivation and Context
The Products module had no consistent access control — any authenticated company user could view, create, edit, or delete products and their sub-resources. This PR wires up the permission gates defined in the `Permission` enum so that each action (view, create, edit, delete, duplicate) is restricted to users who hold the corresponding Spatie permission. Sub-resources (categories, units) fall back to the parent product permissions since they are not managed independently.

---

## Issue Type (Check one or more)
- [ ] Bugfix
- [x] Improvement of an existing feature
- [ ] New feature

---

## Screenshots (If Applicable)
N/A