### PR TITLE
[IP-498]: feat: enforce permissions in Quotes module (Closes #498)

### DIFF
--- a/Modules/Quotes/Filament/Company/Resources/Quotes/QuoteResource.php
+++ b/Modules/Quotes/Filament/Company/Resources/Quotes/QuoteResource.php
@@ -6,6 +6,8 @@ use BackedEnum;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Filament\Company\Resources\BaseResource;
 use Modules\Quotes\Filament\Company\Resources\Quotes\Pages\ListQuotes;
 use Modules\Quotes\Filament\Company\Resources\Quotes\Schemas\QuoteForm;
@@ -59,5 +61,30 @@ class QuoteResource extends BaseResource
         return [
             'index' => ListQuotes::route('/'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_QUOTES->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::CREATE_QUOTES->value) ?? false;
+    }
+
+    public static function canView(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::VIEW_QUOTES->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::EDIT_QUOTES->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::DELETE_QUOTES->value) ?? false;
     }
 }

--- a/Modules/Quotes/Filament/Company/Resources/Quotes/Tables/QuotesTable.php
+++ b/Modules/Quotes/Filament/Company/Resources/Quotes/Tables/QuotesTable.php
@@ -10,6 +10,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Modules\Core\Enums\Permission;
 use Modules\Core\Helpers\EnumHelper;
 use Modules\Core\Support\DateHelpers;
 use Modules\Quotes\Enums\QuoteStatus;
@@ -64,11 +65,14 @@ class QuotesTable
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make('edit')
+                        ->visible(fn () => auth()->user()?->can(Permission::EDIT_QUOTES->value))
                         ->action(function (Quote $record, array $data) {
                             app(QuoteService::class)->updateQuote($record, $data);
                         })
                         ->modalWidth('full'),
                     Action::make('duplicate')
+                        ->visible(fn () => auth()->user()?->can(Permission::DUPLICATE_QUOTES->value))
+
                         ->label(trans('ip.duplicate'))
                         ->icon('heroicon-o-document-duplicate')
                         ->action(function (Quote $record): void {
@@ -76,6 +80,8 @@ class QuotesTable
                         })
                         ->successNotificationTitle(trans('ip.quote_duplicated')),
                     Action::make('download pdf')
+                        ->visible(fn () => auth()->user()?->can(Permission::DOWNLOAD_QUOTES->value))
+
                         ->label(trans('ip.download_pdf'))
                         ->modalDescription(
                             'todo: make sure we can download the PDF of the Quote through an action,
@@ -84,10 +90,44 @@ class QuotesTable
                         ->action(function (Quote $record): void {}),
                     Action::make('send email')
                         ->label(trans('ip.send_email'))
+                        ->visible(fn () => auth()->user()?->can(Permission::EMAIL_QUOTES->value))
+
                         ->modalDescription('todo: make sure we can email the Quote through an action,
                             so need for modal anymore')
                         ->action(function (Quote $record): void {}),
+                    Action::make('print')
+                        ->label(trans('ip.print'))
+                        ->icon('heroicon-o-printer')
+                        ->visible(fn () => auth()->user()?->can(Permission::PRINT_QUOTES->value))
+                        ->action(function (Quote $record): void {}),
+                    Action::make('mark_sent')
+                        ->label(trans('ip.mark_sent'))
+                        ->icon('heroicon-o-check-circle')
+                        ->visible(fn () => auth()->user()?->can(Permission::MARK_SENT_QUOTES->value))
+                        ->action(function (Quote $record): void {}),
+                    Action::make('approve')
+                        ->label(trans('ip.approve'))
+                        ->icon('heroicon-o-hand-thumb-up')
+                        ->visible(fn () => auth()->user()?->can(Permission::APPROVE_QUOTES->value))
+                        ->action(function (Quote $record): void {}),
+                    Action::make('reject')
+                        ->label(trans('ip.reject'))
+                        ->icon('heroicon-o-hand-thumb-down')
+                        ->visible(fn () => auth()->user()?->can(Permission::REJECT_QUOTES->value))
+                        ->action(function (Quote $record): void {}),
+                    Action::make('convert_to_invoice')
+                        ->label(trans('ip.convert_to_invoice'))
+                        ->icon('heroicon-o-arrow-right-circle')
+                        ->visible(fn () => auth()->user()?->can(Permission::CONVERT_TO_INVOICE_QUOTES->value))
+                        ->action(function (Quote $record): void {}),
+                    Action::make('archive')
+                        ->label(trans('ip.archive'))
+                        ->icon('heroicon-o-archive-box')
+                        ->visible(fn () => auth()->user()?->can(Permission::ARCHIVE_QUOTES->value))
+                        ->action(function (Quote $record): void {}),
                     DeleteAction::make('delete')
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_QUOTES->value))
+
                         ->action(function (Quote $quote) {
                             app(QuoteService::class)->deleteQuote($quote);
                         }),
@@ -95,7 +135,8 @@ class QuotesTable
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->visible(fn () => auth()->user()?->can(Permission::DELETE_QUOTES->value)),
                 ]),
             ])
             ->defaultSort('quote_expires_at', 'asc');


### PR DESCRIPTION
# Pull Request Checklist

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [x] I have an accompanying issue ID for this pull request.

---

## Description
Enforces Spatie permission checks across the Quotes module (`QuoteResource`, `QuotesTable`). All access control now uses `can()` calls against the `Permission` enum. Stub actions for print, mark as sent, approve, reject, convert to invoice, and archive have been added, each gated by its corresponding permission with void bodies ready for implementation in follow-up issues.

---

## Related Issue(s)
Fixes #498

---

## Motivation and Context
The Quotes module had no consistent access control — any authenticated company user could perform any action regardless of their role. This PR wires up all permission gates defined in the `Permission` enum across every quote action.

---

## Issue Type (Check one or more)
- [ ] Bugfix
- [x] Improvement of an existing feature
- [ ] New feature

---

## Screenshots (If Applicable)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented permission-based access control for quote operations. Users now see and can perform only the quote actions they are authorized for, including viewing, creating, editing, approving, rejecting, converting to invoices, and archiving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->