### PR TITLE
[IP-512]: default date fields to today on creation forms

### DIFF
--- a/Modules/Clients/Filament/Company/Resources/Relations/Schemas/RelationForm.php
+++ b/Modules/Clients/Filament/Company/Resources/Relations/Schemas/RelationForm.php
@@ -120,6 +120,7 @@ class RelationForm
 
                                                 DatePicker::make('registered_at')
                                                     ->label(trans('ip.date'))
+                                                    ->default(fn () => now()->toDateString())
                                                     ->required(),
                                             ]),
                                     ]),

--- a/Modules/Core/Tests/Feature/DateFieldDefaultsTest.php
+++ b/Modules/Core/Tests/Feature/DateFieldDefaultsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Modules\Core\Tests\Feature;
+
+use Livewire\Livewire;
+use Modules\Core\Database\Seeders\PermissionsSeeder;
+use Modules\Core\Database\Seeders\RolesSeeder;
+use Modules\Core\Enums\UserRole;
+use Modules\Core\Tests\AbstractCompanyPanelTestCase;
+use Modules\Expenses\Filament\Company\Resources\Expenses\Pages\ListExpenses;
+use Modules\Invoices\Filament\Company\Resources\Invoices\Pages\ListInvoices;
+use Modules\Payments\Filament\Company\Resources\Payments\Pages\ListPayments;
+use Modules\Quotes\Filament\Company\Resources\Quotes\Pages\ListQuotes;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+/*
+ * The company panel test base freezes Carbon at 2026-01-01, so "today"
+ * is always 2026-01-01 and today+30 is 2026-01-31 in these assertions.
+ */
+class DateFieldDefaultsTest extends AbstractCompanyPanelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /*
+         * Resource pages gate on Spatie permissions, so the test user
+         * needs the seeded client_admin permission set to mount pages.
+         */
+        (new PermissionsSeeder())->run();
+        (new RolesSeeder())->run();
+        $this->user->assignRole(UserRole::CUSTOMER_ADMIN->value);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_pre_fills_invoice_dates_with_today_and_due_in_thirty_days(): void
+    {
+        Livewire::actingAs($this->user)
+            ->test(ListInvoices::class)
+            ->mountAction('create')
+            ->assertActionDataSet([
+                'invoiced_at'    => '2026-01-01',
+                'invoice_due_at' => '2026-01-31',
+            ]);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_pre_fills_quote_dates_with_today_and_expiry_in_thirty_days(): void
+    {
+        Livewire::actingAs($this->user)
+            ->test(ListQuotes::class)
+            ->mountAction('create')
+            ->assertActionDataSet([
+                'quoted_at'        => '2026-01-01',
+                'quote_expires_at' => '2026-01-31',
+            ]);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_pre_fills_expense_date_with_today(): void
+    {
+        Livewire::actingAs($this->user)
+            ->test(ListExpenses::class)
+            ->mountAction('create')
+            ->assertActionDataSet([
+                'expensed_at' => '2026-01-01',
+            ]);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_pre_fills_payment_date_with_today(): void
+    {
+        Livewire::actingAs($this->user)
+            ->test(ListPayments::class)
+            ->mountAction('create')
+            ->assertActionDataSet([
+                'paid_at' => '2026-01-01',
+            ]);
+    }
+}

--- a/Modules/Expenses/Filament/Company/Resources/Expenses/Resources/ExpenseItems/Schemas/ExpenseItemForm.php
+++ b/Modules/Expenses/Filament/Company/Resources/Expenses/Resources/ExpenseItems/Schemas/ExpenseItemForm.php
@@ -23,7 +23,8 @@ class ExpenseItemForm
                 TextInput::make('unit_id')
                     ->numeric()
                     ->default(null),
-                DatePicker::make('added_at'),
+                DatePicker::make('added_at')
+                    ->default(fn () => now()->toDateString()),
                 TextInput::make('item_name')
                     ->default(null),
                 Toggle::make('is_recurring')

--- a/Modules/Expenses/Filament/Company/Resources/Expenses/Schemas/ExpenseForm.php
+++ b/Modules/Expenses/Filament/Company/Resources/Expenses/Schemas/ExpenseForm.php
@@ -137,6 +137,7 @@ class ExpenseForm
                                     ->numeric()
                                     ->required(),
                                 DatePicker::make('expensed_at')
+                                    ->default(fn () => now()->toDateString())
                                     ->required(),
                             ])
                             ->columnSpan(1),

--- a/Modules/Invoices/Filament/Company/Resources/Invoices/Resources/InvoiceItems/Schemas/InvoiceItemForm.php
+++ b/Modules/Invoices/Filament/Company/Resources/Invoices/Resources/InvoiceItems/Schemas/InvoiceItemForm.php
@@ -27,7 +27,8 @@ class InvoiceItemForm
                 Select::make('product_unit_id')
                     ->relationship('productUnit', 'id')
                     ->default(null),
-                DatePicker::make('added_at'),
+                DatePicker::make('added_at')
+                    ->default(fn () => now()->toDateString()),
                 TextInput::make('item_name')
                     ->default(null),
                 TextInput::make('product_unit')

--- a/Modules/Invoices/Filament/Company/Resources/Invoices/Schemas/InvoiceForm.php
+++ b/Modules/Invoices/Filament/Company/Resources/Invoices/Schemas/InvoiceForm.php
@@ -84,10 +84,12 @@ class InvoiceForm
 
                                         DatePicker::make('invoiced_at')
                                             ->label(trans('ip.invoice_date'))
+                                            ->default(fn () => now()->toDateString())
                                             ->required(),
 
                                         DatePicker::make('invoice_due_at')
                                             ->label(trans('ip.invoice_due_at'))
+                                            ->default(fn () => now()->addDays(30)->toDateString())
                                             ->required(),
 
                                         Select::make('numbering_id')

--- a/Modules/Invoices/Filament/Company/Resources/RecurringInvoices/Schemas/RecurringInvoiceForm.php
+++ b/Modules/Invoices/Filament/Company/Resources/RecurringInvoices/Schemas/RecurringInvoiceForm.php
@@ -27,6 +27,7 @@ class RecurringInvoiceForm
                     ->options(RecurringFrequency::class)
                     ->required(),
                 DatePicker::make('start_at')
+                    ->default(fn () => now()->toDateString())
                     ->required(),
                 DatePicker::make('end_at'),
             ]);

--- a/Modules/Payments/Filament/Company/Resources/Payments/Schemas/PaymentForm.php
+++ b/Modules/Payments/Filament/Company/Resources/Payments/Schemas/PaymentForm.php
@@ -84,6 +84,7 @@ class PaymentForm
                                             ->schema([
                                                 DatePicker::make('paid_at')
                                                     ->label(trans('ip.paid_at'))
+                                                    ->default(fn () => now()->toDateString())
                                                     ->required(),
 
                                                 Select::make('payment_method')

--- a/Modules/Projects/Filament/Company/Resources/Projects/Schemas/ProjectForm.php
+++ b/Modules/Projects/Filament/Company/Resources/Projects/Schemas/ProjectForm.php
@@ -77,6 +77,7 @@ class ProjectForm
 
                                         DatePicker::make('start_at')
                                             ->label(trans('ip.start_at'))
+                                            ->default(fn () => now()->toDateString())
                                             ->required()
                                             ->native(false),
 

--- a/Modules/Quotes/Filament/Company/Resources/Quotes/Schemas/QuoteForm.php
+++ b/Modules/Quotes/Filament/Company/Resources/Quotes/Schemas/QuoteForm.php
@@ -91,10 +91,12 @@ class QuoteForm
 
                                         DatePicker::make('quoted_at')
                                             ->label(trans('ip.quote_date'))
+                                            ->default(fn () => now()->toDateString())
                                             ->native(false),
 
                                         DatePicker::make('quote_expires_at')
                                             ->label(trans('ip.quote_expires_at'))
+                                            ->default(fn () => now()->addDays(30)->toDateString())
                                             ->native(false),
 
                                         Select::make('numbering_id')


### PR DESCRIPTION
Closes-when-approved: #512 (kept open per workflow — PRs stay draft, issues stay open)

## What

All date fields on creation forms now pre-fill so the user never types today's date:

| Field | Default |
|---|---|
| Invoice `invoiced_at`, Quote `quoted_at`, Expense `expensed_at`, Payment `paid_at`, Relation `registered_at`, Recurring/Project `start_at`, item `added_at` | today |
| Invoice `invoice_due_at`, Quote `quote_expires_at` | today + 30 days |

Defaults are schema-level (`->default()`), so they only apply on create — edit forms keep the record's value.

## Tests

`Modules/Core/Tests/Feature/DateFieldDefaultsTest` — 4 tests asserting mounted create-action data for invoices, quotes, expenses, and payments (Carbon frozen at 2026-01-01 by the test base).

Note: upstream CI is currently failing at job startup on every branch (no runner assigned) — validated locally instead; module suites match the develop baseline exactly plus the new passing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)