### PR TITLE
[PR] Repair stale Filament v5 auth translation keys on Login page

### DIFF
--- a/Modules/Core/Filament/Pages/Auth/Login.php
+++ b/Modules/Core/Filament/Pages/Auth/Login.php
@@ -17,17 +17,7 @@ class Login extends BaseLogin
         try {
             $this->rateLimit(5);
         } catch (TooManyRequestsException $exception) {
-            Notification::make()
-                ->title(trans('filament-panels::auth/pages/login.notifications.throttled.title', [
-                    'seconds' => $exception->secondsUntilAvailable,
-                    'minutes' => ceil($exception->secondsUntilAvailable / 60),
-                ]))
-                ->body(array_key_exists('body', trans('filament-panels::auth/pages/login.notifications.throttled') ?: []) ? trans('filament-panels::auth/pages/login.notifications.throttled.body', [
-                    'seconds' => $exception->secondsUntilAvailable,
-                    'minutes' => ceil($exception->secondsUntilAvailable / 60),
-                ]) : null)
-                ->danger()
-                ->send();
+            $this->getRateLimitedNotification($exception)?->send();
 
             return null;
         }

--- a/Modules/Core/Filament/Pages/Auth/Login.php
+++ b/Modules/Core/Filament/Pages/Auth/Login.php
@@ -18,11 +18,11 @@ class Login extends BaseLogin
             $this->rateLimit(5);
         } catch (TooManyRequestsException $exception) {
             Notification::make()
-                ->title(trans('filament-panels::pages/auth/login.notifications.throttled.title', [
+                ->title(trans('filament-panels::auth/pages/login.notifications.throttled.title', [
                     'seconds' => $exception->secondsUntilAvailable,
                     'minutes' => ceil($exception->secondsUntilAvailable / 60),
                 ]))
-                ->body(array_key_exists('body', trans('filament-panels::pages/auth/login.notifications.throttled') ?: []) ? trans('filament-panels::pages/auth/login.notifications.throttled.body', [
+                ->body(array_key_exists('body', trans('filament-panels::auth/pages/login.notifications.throttled') ?: []) ? trans('filament-panels::auth/pages/login.notifications.throttled.body', [
                     'seconds' => $exception->secondsUntilAvailable,
                     'minutes' => ceil($exception->secondsUntilAvailable / 60),
                 ]) : null)
@@ -62,7 +62,6 @@ class Login extends BaseLogin
     protected function getEmailFormComponent(): Component
     {
         return TextInput::make('email')
-            ->label(trans('filament-panels::pages/auth/login.form.email.label'))
             ->email()
             ->required()
             ->autocomplete()
@@ -73,7 +72,6 @@ class Login extends BaseLogin
     protected function getPasswordFormComponent(): Component
     {
         return TextInput::make('password')
-            ->label(trans('filament-panels::pages/auth/login.form.password.label'))
             ->password()
             ->revealable(filament()->arePasswordsRevealable())
             ->autocomplete('current-password')


### PR DESCRIPTION
## Summary

The custom login page (`Modules/Core/Filament/Pages/Auth/Login.php`) rendered raw translation keys instead of labels — e.g. `filament-panels::pages/auth/login.form.email.label` and `filament-panels::pages/auth/login.form.password.label` showed literally on the sign-in form.

**Cause:** Filament v5 extracted the auth pages into the `filament/auth` package and reorganised the login translations. The custom Login page still referenced v4 key paths (`filament-panels::pages/auth/login.*`), which no longer resolve under v5.

## Changes

**1. Restore the label repair** (originally on `fix/repair-stale-filament-translations`, commits `4e69878` / `6f3b944`, never merged into `develop`):
- Drop the explicit `->label(trans('filament-panels::pages/auth/login.form.email.label'))` / `...password.label` overrides so the email/password fields fall back to Filament's own translated labels.

**2. Make the rate-limit throttle notification upgrade-proof:**
- Replace the hand-built throttle `Notification` — which hardcoded the same fragile `...login.notifications.throttled.*` translation keys — with a delegation to the base page's `getRateLimitedNotification($exception)`. Filament resolves the correct keys for whatever version is installed, so this notification won't break again when Filament reshuffles its translation namespaces. This also removes the latent inconsistency in the original repair, where the throttle **body** was left pointing at the old key path.

## Developer Checklist

- [x] Translations added or updated (if needed)
- [ ] References a row in `CHECKLIST.md` — n/a (bug fix)
- [ ] Includes appropriate test coverage — none added; change is a translation-key/label repair with no new logic
- [x] Follows service/DTO/transformer structure (no inline logic)
- [x] UI follows Filament & Livewire best practices
- [ ] Ran `php artisan test` — not run in this environment (Composer deps not installed; install timed out)
- [ ] Ran `vendor/bin/pint` — not run in this environment (Composer deps not installed)

## Related Issues

- Reported by a user: Filament v5 relocated some translation keys, breaking the sign-in form labels.

## Notes for Reviewers

- Verify the sign-in form renders proper "Email"/"Password" labels and no raw `filament-panels::...` keys.
- `getRateLimitedNotification()` is the base Login page's built-in hook (stable across Filament v3–v5; the default `authenticate()` uses it internally), so delegating to it is the intended extension point rather than re-implementing the notification.
- I could not run the test suite or Pint here — Composer install timed out in this environment. A local `php artisan test` + `vendor/bin/pint` pass before merge is recommended.