### PR TITLE
chore: port test-infra fixes, tighten .gitignore, document PHP 8.3+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,6 @@
 !.env.testing.example
 /storage/*.key
 
-# Laravel – Modules (ignored generated sources)
-Modules/**/Controllers/
-Modules/**/Http/Controllers/
-Modules/**/Http/Requests/
-
 # Vite / Filament / Livewire
 /.vite
 /livewire-tmp/
@@ -40,6 +35,7 @@ package-lock.json
 
 # Pint
 /pint.txt
+/pint_output.log
 
 # PHPUnit
 /.phpunit.cache
@@ -78,5 +74,9 @@ package-lock.json
 /olddocs
 /.php-cs-fixer.cache
 *.sqlite
+/audit-report.json
 /failures.txt
 /yarnpack.txt
+/automation/
+/.claude/fable5/
+upd.sh

--- a/Modules/Core/Database/Seeders/RolesSeeder.php
+++ b/Modules/Core/Database/Seeders/RolesSeeder.php
@@ -120,6 +120,7 @@ class RolesSeeder extends Seeder
                             $isBasicAction = str_starts_with($p, 'view-')
                                 || str_starts_with($p, 'create-')
                                 || str_starts_with($p, 'edit-')
+                                || str_starts_with($p, 'delete-')
                                 || str_starts_with($p, 'export-')
                                 || str_starts_with($p, 'duplicate-');
                             $isCustomerResource = (bool) array_filter(

--- a/Modules/Core/Tests/AbstractAdminPanelTestCase.php
+++ b/Modules/Core/Tests/AbstractAdminPanelTestCase.php
@@ -5,6 +5,9 @@ namespace Modules\Core\Tests;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Carbon;
+use Modules\Core\Database\Seeders\PermissionsSeeder;
+use Modules\Core\Database\Seeders\RolesSeeder;
+use Modules\Core\Enums\UserRole;
 use Modules\Core\Models\Company;
 use Modules\Core\Models\User;
 
@@ -33,6 +36,14 @@ abstract class AbstractAdminPanelTestCase extends BaseTestCase
         $this->superAdmin = $superAdmin;
 
         session(['current_company_id' => $this->company->id]);
+
+        /*
+         * Admin resources gate every page on Spatie permissions (canViewAny
+         * etc.), so the test user needs the seeded super_admin permission set.
+         */
+        (new PermissionsSeeder())->run();
+        (new RolesSeeder())->run();
+        $this->superAdmin->assignRole(UserRole::SUPER_ADMIN->value);
 
         $this->withoutExceptionHandling();
     }

--- a/Modules/Core/Tests/AbstractCompanyPanelTestCase.php
+++ b/Modules/Core/Tests/AbstractCompanyPanelTestCase.php
@@ -3,10 +3,13 @@
 namespace Modules\Core\Tests;
 
 use Filament\Facades\Filament;
-use Filament\Schemas\Components\Livewire;
+use Livewire\Livewire;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Carbon;
+use Modules\Core\Database\Seeders\PermissionsSeeder;
+use Modules\Core\Database\Seeders\RolesSeeder;
+use Modules\Core\Enums\UserRole;
 use Modules\Core\Models\Company;
 use Modules\Core\Models\User;
 
@@ -44,6 +47,14 @@ abstract class AbstractCompanyPanelTestCase extends BaseTestCase
         $currentCompanyId = $this->user->getCurrentCompanyId();
         session(['current_company_id' => $currentCompanyId]);
 
+        /*
+         * Resources gate every page on Spatie permissions (canViewAny etc.),
+         * so the test user needs the seeded client_admin permission set.
+         */
+        (new PermissionsSeeder())->run();
+        (new RolesSeeder())->run();
+        $this->user->assignRole(UserRole::CUSTOMER_ADMIN->value);
+
         $this->withoutExceptionHandling();
     }
 
@@ -58,8 +69,9 @@ abstract class AbstractCompanyPanelTestCase extends BaseTestCase
      */
     protected function testLivewire($component, $params = [])
     {
-        return Livewire::actingAs($this->user)
-            ->withSession(['current_company_id' => $this->company->id])
-            ->test($component, $params);
+        $this->actingAs($this->user)
+            ->withSession(['current_company_id' => $this->company->id]);
+
+        return Livewire::test($component, $params);
     }
 }

--- a/Modules/Invoices/Tests/Feature/InvoicesTest.php
+++ b/Modules/Invoices/Tests/Feature/InvoicesTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 use Modules\Clients\Models\Relation;
+use Modules\Core\Enums\NumberingType;
 use Modules\Core\Models\Numbering;
 use Modules\Core\Models\TaxRate;
 use Modules\Core\Tests\AbstractCompanyPanelTestCase;
@@ -38,7 +39,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
         /* Arrange */
         $user            = $this->user;
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -87,7 +88,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -141,7 +142,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -186,7 +187,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -229,7 +230,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -274,7 +275,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -325,7 +326,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
     public function it_creates_an_invoice_with_items(): void
     {
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -381,7 +382,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
         /* Arrange */
         $user            = $this->user;
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -425,7 +426,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
         /* Arrange */
         $user            = $this->user;
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -467,7 +468,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
         /* Arrange */
         $user            = $this->user;
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -510,7 +511,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();
@@ -586,7 +587,7 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
         /* Arrange */
         $user            = $this->user;
         $customer        = Relation::factory()->for($this->company)->customer()->create();
-        $documentGroup   = Numbering::factory()->for($this->company)->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
         $productUnit     = ProductUnit::factory()->for($this->company)->create();

--- a/Modules/Quotes/Tests/Feature/QuotesTest.php
+++ b/Modules/Quotes/Tests/Feature/QuotesTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 use Modules\Clients\Models\Relation;
+use Modules\Core\Enums\NumberingType;
 use Modules\Core\Models\Numbering;
 use Modules\Core\Models\TaxRate;
 use Modules\Core\Tests\AbstractCompanyPanelTestCase;
@@ -65,7 +66,7 @@ class QuotesTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         $prospect      = Relation::factory()->for($this->company)->prospect()->create();
-        $documentGroup = Numbering::factory()->for($this->company)->create();
+        $documentGroup = Numbering::factory()->for($this->company)->state(['type' => NumberingType::QUOTE->value])->create();
 
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
@@ -139,7 +140,7 @@ class QuotesTest extends AbstractCompanyPanelTestCase
     public function it_fails_to_create_a_quote_through_a_modal_without_required_prospect(): void
     {
         /* Arrange */
-        $documentGroup = Numbering::factory()->for($this->company)->create();
+        $documentGroup = Numbering::factory()->for($this->company)->state(['type' => NumberingType::QUOTE->value])->create();
 
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();
@@ -295,7 +296,7 @@ class QuotesTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         $prospect      = Relation::factory()->for($this->company)->prospect()->create();
-        $documentGroup = Numbering::factory()->for($this->company)->create();
+        $documentGroup = Numbering::factory()->for($this->company)->state(['type' => NumberingType::QUOTE->value])->create();
 
         $quote = Quote::factory()
             ->for($this->company)
@@ -348,7 +349,7 @@ class QuotesTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         $prospect      = Relation::factory()->for($this->company)->prospect()->create();
-        $documentGroup = Numbering::factory()->for($this->company)->create();
+        $documentGroup = Numbering::factory()->for($this->company)->state(['type' => NumberingType::QUOTE->value])->create();
 
         $taxRate         = TaxRate::factory()->for($this->company)->create();
         $productCategory = ProductCategory::factory()->for($this->company)->create();

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # InvoicePlane v2
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![PHP Version](https://img.shields.io/badge/PHP-8.2%2B-blue.svg)](https://php.net)
+[![PHP Version](https://img.shields.io/badge/PHP-8.3%2B-blue.svg)](https://php.net)
 [![Laravel Version](https://img.shields.io/badge/Laravel-13%2B-red.svg)](https://laravel.com)
 [![Filament Version](https://img.shields.io/badge/Filament-5.x-orange.svg)](https://filamentphp.com)
 
@@ -44,7 +44,7 @@
 
 ## 📦 Requirements
 
-- **PHP** 8.2 or higher
+- **PHP** 8.3 or higher
 - **Composer** 2.x
 - **Node.js** 20+ and Yarn
 - **Database** MariaDB 10.11+ (recommended), MySQL 8.0+, or SQLite (dev only)


### PR DESCRIPTION
Ports the standing fixes that so far lived only on the underdogg-forks develop branch, so feature PRs can be cut from this repo directly without dragging fork-only history along.

## What's in here

1. **Test infrastructure** — the panel test base classes now seed Spatie roles/permissions in `setUp()` (without this, every company-panel Livewire test 403s), and `AbstractCompanyPanelTestCase::testLivewire()` is fixed: it imported `Filament\Schemas\Components\Livewire` (a schema component) instead of the Livewire test facade and chained `withSession()` onto the wrong object — it could never have executed. Plus the matching `RolesSeeder` company-CRUD permissions and Invoices/Quotes test adjustments.
2. **.gitignore** — excludes the local tooling that kept leaking into PRs: `/automation/`, `/.claude/fable5/`, `pint_output.log`, `audit-report.json`. Also drops the `Modules/**/Http/Controllers` ignores that hid real source files.
3. **README** — the resolved dependency tree requires **PHP ≥ 8.3** (composer's platform check rejects 8.2), so the badge and Requirements section now say 8.3+.

## Known follow-up (deliberately not in this PR)

`composer.json` still declares `"php": "^8.2"`. Bumping it requires re-resolving the lock, which currently **fails**: `roave/security-advisories` (dev-latest) conflicts with the locked `guzzlehttp/guzzle < 7.12.1` — the same guzzle version carrying three open advisories (CVE-2026-55767, CVE-2026-55568, CVE-2026-55766 in guzzle/psr7). A follow-up `composer update -W guzzlehttp/guzzle` fixes the constraint and the advisories together, but that's a dependency bump that deserves its own review.

## Verified

Full PHPUnit suite through the Docker CLI image from #601 (sqlite in-memory): green on this branch. These are the exact fixes that took the fork's suite from mass-403s to green.

This PR is the base for the Report Builder (#130), tabular reports (#145), and email-variables (#363) PRs — they are rebased on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
