### PR TITLE
feat: complete the Docker setup — wire the compose stack, add a PHP 8.4 CLI image (IP-149)

### DIFF
--- a/.github/DOCKER.md
+++ b/.github/DOCKER.md
@@ -1,8 +1,7 @@
-DOCKER.md
-
 # Docker Setup for InvoicePlane V2
 
-This guide explains how to run InvoicePlane V2 using Docker.
+This guide explains how to run InvoicePlane V2 using Docker — both the web
+stack and the standalone CLI image for running tests and artisan commands.
 
 ---
 
@@ -16,66 +15,85 @@ This guide explains how to run InvoicePlane V2 using Docker.
 ## Quick Start
 
 ```bash
-git clone https://github.com/InvoicePlane/InvoicePlane.git
-cd InvoicePlane
+git clone https://github.com/InvoicePlane/InvoicePlane-v2.git
+cd InvoicePlane-v2
 
 cp .env.example .env
-composer install
-php artisan key:generate
-php artisan migrate --seed
 
+# Install dependencies and bootstrap the app through the CLI container —
+# no PHP required on the host:
+docker compose run --rm cli composer install
+docker compose run --rm cli php artisan key:generate
 docker compose up -d
+docker compose run --rm cli php artisan migrate --seed
+```
 
-Visit: http://localhost/ivpl
-
----
-
-Useful Commands
-
-Action	Command
-
-Start services	docker compose up -d
-Stop services	docker compose down
-View logs	docker compose logs -f
-Run artisan	docker compose exec app php artisan
-Rebuild containers	docker compose build --no-cache
+Visit: http://localhost:8080 (override the port with `APP_PORT` in `.env`).
 
 ---
 
-Services
+## Services
 
-App container: Laravel application
+| Service | Image | Purpose |
+|---|---|---|
+| `web` | `docker-resources/apache` (httpd 2.4 alpine) | Serves `public/`, proxies PHP to `app` |
+| `app` | `docker-resources/php-fpm` (PHP 8.4 fpm alpine) | Laravel application (FPM) |
+| `cli` | `docker-resources/php-cli` (PHP 8.4 cli alpine) | One-off runner for tests / artisan / composer — profile `tools`, never auto-started |
+| `db` | `mariadb` | Database (port 3306) |
+| `mailcatcher` | `sj26/mailcatcher` | Catches outgoing mail — UI on port 1080 |
 
-Database: MariaDB (latest)
-
-Mail: MailCatcher (port 1080)
-
-Queue: Redis (optional)
-
----
-
-Customize Docker
-
-Change database port in docker-compose.yml
-
-Override PHP version via Dockerfile
-
-Add volumes for local persistence if needed
+Both PHP images ship the full extension set the app needs: `intl`, `gd`,
+`pdo_mysql`, `bcmath`, `zip`, `exif`, `soap`, `redis`. The CLI image also has
+Composer, a 1G memory limit for the test suite, and bundled `pdo_sqlite`
+(the suite runs on an in-memory sqlite database — no db service needed for
+tests).
 
 ---
 
-Troubleshooting
+## Running the test suite
 
-Port already in use: Adjust ports in docker-compose.yml
+```bash
+docker compose run --rm cli vendor/bin/phpunit --exclude-group failing,troubleshooting
+```
 
-Permission issues: Ensure Docker has access to your project folder
+`APP_ENV=testing` is the `cli` service default, so `.env.testing`
+(sqlite `:memory:`) is picked up automatically. See `RUNNING_TESTS.md` for
+filters, groups, and suites.
 
-Missing .env config: Re-run cp .env.example .env and adjust
+### File ownership on Linux
+
+The CLI image creates its user with uid/gid `1000`. If your host user
+differs, rebuild with your ids so files written into the mounted repo
+(vendor/, storage/, compiled views) stay owned by you:
+
+```bash
+docker compose build --build-arg UID=$(id -u) --build-arg GID=$(id -g) cli
+```
 
 ---
 
+## Useful Commands
+
+| Action | Command |
+|---|---|
+| Start services | `docker compose up -d` |
+| Stop services | `docker compose down` |
+| View logs | `docker compose logs -f` |
+| Run artisan | `docker compose run --rm cli php artisan <command>` |
+| Run composer | `docker compose run --rm cli composer <command>` |
+| Rebuild containers | `docker compose build --no-cache` |
+
 ---
 
-What's Next?
+## Troubleshooting
+
+- **Port already in use**: set `APP_PORT` in `.env` (web) or adjust ports in `docker-compose.yml`
+- **Permission issues**: rebuild the `cli` image with your `UID`/`GID` (see above)
+- **Missing .env config**: re-run `cp .env.example .env` and adjust
+- **Tests fail with `could not find driver` or missing `intl`**: you are running on host PHP — use the `cli` container instead
+
+---
+
+## What's Next?
 
 Visit CHECKLIST.md if contributing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,53 @@ volumes:
         driver: "local"
 
 services:
+    app:
+        container_name: 'ivplflmnt_app'
+        build:
+            context: ./docker-resources/php-fpm
+        restart: unless-stopped
+        tty: true
+        volumes:
+            - .:/var/www/html
+        depends_on:
+            - db
+        networks:
+            - laravel
+
+    web:
+        container_name: 'ivplflmnt_web'
+        build:
+            context: ./docker-resources/apache
+        restart: unless-stopped
+        tty: true
+        ports:
+            - "${APP_PORT:-8080}:80"
+        volumes:
+            - .:/usr/local/apache2/htdocs
+        depends_on:
+            - app
+        networks:
+            - laravel
+
+    # One-off command runner for tests, artisan, and composer — not started
+    # by default (profile "tools"). Examples:
+    #   docker compose run --rm cli composer install
+    #   docker compose run --rm cli php artisan migrate --seed
+    #   docker compose run --rm cli vendor/bin/phpunit --exclude-group failing,troubleshooting
+    cli:
+        container_name: 'ivplflmnt_cli'
+        build:
+            context: ./docker-resources/php-cli
+        profiles:
+            - tools
+        tty: true
+        environment:
+            APP_ENV: "${APP_ENV:-testing}"
+        volumes:
+            - .:/var/www/html
+        networks:
+            - laravel
+
     db:
         container_name: 'ivplflmnt_db'
         image: mariadb
@@ -16,6 +63,8 @@ services:
             MARIADB_USER: "${DB_USERNAME}"
             MARIADB_PASSWORD: "${DB_PASSWORD}"
             TZ: "Europe/London"
+        networks:
+            - laravel
 
     mailcatcher:
         container_name: 'ivplflmnt_mailcatcher'
@@ -25,6 +74,9 @@ services:
         ports:
             - "25:1025"
             - "1080:1080"
+        networks:
+            - laravel
+
     # phpmyadmin:
     #   container_name: 'ivplflmnt_phpmyadmin'
     #   image: phpmyadmin/phpmyadmin

--- a/docker-resources/apache/Dockerfile
+++ b/docker-resources/apache/Dockerfile
@@ -1,0 +1,14 @@
+FROM httpd:2.4-alpine
+
+# Enable required Apache modules for PHP-FPM proxying
+RUN sed -i \
+    -e 's/^#\(LoadModule proxy_module modules\/mod_proxy.so\)/\1/' \
+    -e 's/^#\(LoadModule proxy_fcgi_module modules\/mod_proxy_fcgi.so\)/\1/' \
+    -e 's/^#\(LoadModule rewrite_module modules\/mod_rewrite.so\)/\1/' \
+    /usr/local/apache2/conf/httpd.conf
+
+COPY config/invoiceplane-vhost.conf /usr/local/apache2/conf/extra/invoiceplane-vhost.conf
+
+RUN echo "Include conf/extra/invoiceplane-vhost.conf" >> /usr/local/apache2/conf/httpd.conf
+
+EXPOSE 80

--- a/docker-resources/apache/config/invoiceplane-vhost.conf
+++ b/docker-resources/apache/config/invoiceplane-vhost.conf
@@ -1,0 +1,21 @@
+<VirtualHost *:80>
+    ServerName localhost
+    DocumentRoot "/usr/local/apache2/htdocs/public"
+
+    <Directory "/usr/local/apache2/htdocs/public">
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    # ProxyPass for PHP-FPM with correct document root
+    <FilesMatch \.php$>
+        SetHandler "proxy:fcgi://app:9000/var/www/html/public"
+    </FilesMatch>
+
+    # Fallback for PATH_INFO
+    ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://app:9000/var/www/html/public/$1
+
+    ErrorLog /usr/local/apache2/logs/invoiceplane_error.log
+    CustomLog /usr/local/apache2/logs/invoiceplane_access.log combined
+</VirtualHost>

--- a/docker-resources/node/scripts/entrypoint.sh
+++ b/docker-resources/node/scripts/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Copy original vite.config.js to Docker-specific version
+mkdir -p /app/.docker
+cp /app/vite.config.js /app/.docker/vite.config.docker.js
+
+# Update resource paths to absolute paths
+sed -i "s|'resources/css/app.css'|'/app/resources/css/app.css'|g" /app/.docker/vite.config.docker.js
+sed -i "s|'resources/js/app.js'|'/app/resources/js/app.js'|g" /app/.docker/vite.config.docker.js
+
+# Add Docker-specific server configuration if not already present
+if ! grep -q "server:" /app/.docker/vite.config.docker.js; then
+    # Insert server config before the closing }); of defineConfig
+    sed -i '/^});$/i\    server: {\n        host: '\''0.0.0.0'\'',\n        port: 5173,\n        hmr: {\n            host: '\''localhost'\'',\n        },\n    },' /app/.docker/vite.config.docker.js
+fi
+
+# Install dependencies and start Vite with Docker config
+npm install && npm run dev -- --config .docker/vite.config.docker.js

--- a/docker-resources/php-cli/Dockerfile
+++ b/docker-resources/php-cli/Dockerfile
@@ -1,0 +1,67 @@
+FROM php:8.4-cli-alpine
+
+# Match the host user so files created in mounted volumes (vendor/,
+# storage/, compiled views) keep sane ownership. Override at build time:
+#   docker compose build --build-arg UID=$(id -u) --build-arg GID=$(id -g) cli
+ARG UID=1000
+ARG GID=1000
+
+RUN addgroup -g ${GID} dockeruser \
+    && adduser -D -s /bin/bash -u ${UID} -G dockeruser dockeruser
+
+# Install build dependencies (temporary)
+RUN apk add --no-cache --virtual .build-deps \
+        autoconf \
+        g++ \
+        make \
+        pkgconf \
+        zstd-dev \
+    # Install runtime dependencies (permanent)
+    && apk add --no-cache \
+        bash \
+        git \
+        curl \
+        zip \
+        unzip \
+        icu-dev \
+        libxml2-dev \
+        oniguruma-dev \
+        libzip-dev \
+        libpng-dev \
+        libjpeg-turbo-dev \
+        freetype-dev \
+        zstd \
+    # Configure and install PHP extensions (pdo_sqlite ships with the base
+    # image — the test suite runs on an in-memory sqlite database)
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) \
+        pdo \
+        pdo_mysql \
+        mbstring \
+        exif \
+        pcntl \
+        bcmath \
+        gd \
+        zip \
+        intl \
+        xml \
+        soap \
+        opcache \
+    # Install PECL extensions
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    # Remove only build dependencies
+    && apk del .build-deps \
+    && rm -rf /var/cache/apk/*
+
+# PHPUnit needs more than the 128M default on the full suite
+RUN echo 'memory_limit=1G' > /usr/local/etc/php/conf.d/memory-limit.ini
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+USER dockeruser
+
+WORKDIR /var/www/html
+
+CMD ["php", "-a"]

--- a/docker-resources/php-fpm/Dockerfile
+++ b/docker-resources/php-fpm/Dockerfile
@@ -1,0 +1,58 @@
+FROM php:8.4-fpm-alpine
+
+RUN adduser -D -s /bin/bash dockeruser
+
+# Install build dependencies (temporary)
+RUN apk add --no-cache --virtual .build-deps \
+        autoconf \
+        g++ \
+        make \
+        pkgconf \
+        zstd-dev \
+    # Install runtime dependencies (permanent)
+    && apk add --no-cache \
+        bash \
+        git \
+        curl \
+        zip \
+        unzip \
+        icu-dev \
+        libxml2-dev \
+        oniguruma-dev \
+        libzip-dev \
+        libpng-dev \
+        libjpeg-turbo-dev \
+        freetype-dev \
+        zstd \
+    # Configure and install PHP extensions
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) \
+        pdo \
+        pdo_mysql \
+        mbstring \
+        exif \
+        pcntl \
+        bcmath \
+        gd \
+        zip \
+        intl \
+        xml \
+        soap \
+        opcache \
+    # Install PECL extensions
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    # Remove only build dependencies
+    && apk del .build-deps \
+    && rm -rf /var/cache/apk/*
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+USER dockeruser
+
+WORKDIR /var/www/html
+
+EXPOSE 9000
+
+CMD ["php-fpm"]


### PR DESCRIPTION
Completes the standalone Docker setup from `feature/149-docker-setup` (issue #149) and adds the missing piece: a **CLI image** so users and contributors can run the test suite, artisan, and composer with no PHP on the host.

## What this adds on top of the existing branch

1. **`docker-resources/php-cli/Dockerfile`** — PHP 8.4 CLI (alpine), the exact extension twin of the existing php-fpm image (`intl`, `gd`, `pdo_mysql`, `bcmath`, `zip`, `exif`, `soap`, `redis`) plus Composer, a 1G memory limit (the full suite OOMs at the 128M default), and bundled `pdo_sqlite` — the test suite runs on in-memory sqlite, so **tests need zero services**. `UID`/`GID` build args let Linux users match host ownership for files written into the mounted repo (vendor/, storage/) — this exact mismatch produces hundreds of confusing `tempnam()` test errors otherwise.
2. **`docker-compose.yml` actually wires the images in.** The branch shipped apache + php-fpm Dockerfiles but the compose file only started `db` + `mailcatcher`, and DOCKER.md referenced an `app` container that didn't exist. Now: `web` (apache, port `${APP_PORT:-8080}`) → `app` (php-fpm, matching the vhost's `fcgi://app:9000`) → `db`, plus the new `cli` service behind a `tools` profile so it never auto-starts.
3. **`.github/DOCKER.md` rewritten to match reality** — corrected clone URL (pointed at v1's repo), a services table, a no-host-PHP quick start, test-suite instructions, and the UID/GID troubleshooting entry.

## Why a CLI image at all

The vendor tree requires PHP ≥ 8.3 with `intl` + `gd`; typical host PHPs miss at least one of those (Filament table rendering hard-requires `intl`, dompdf wants `gd`). This image is the supported, reproducible way to run `vendor/bin/phpunit` — validated by developing the Report Builder with a hand-rolled equivalent of exactly this image.

## Verified

- `docker compose config` valid; `--profile tools` exposes `cli` alongside the five services
- CLI image builds clean; `php -m` shows the full extension set; `composer --version` works
- Test suite executes through `docker compose run --rm cli vendor/bin/phpunit` (sqlite in-memory). Note: some company-panel tests fail on **this branch's lineage** because it predates the permission-seeding fixes on `develop` — pre-existing to this PR; the same command is fully green on branches that include those fixes.
- Web stack (`web` + `app`) is config-validated against the existing vhost (`fcgi://app:9000`, docroot `htdocs/public`); it still needs a bootstrapped `.env` + key to serve, per DOCKER.md's quick start.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
