### PR TITLE
[IP-389]: Notes template/selection option in quotations and invoices

### DIFF
--- a/Modules/Core/Database/Factories/NoteTemplateFactory.php
+++ b/Modules/Core/Database/Factories/NoteTemplateFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\Core\Database\Factories;
+
+use Modules\Core\Models\Company;
+use Modules\Core\Models\NoteTemplate;
+
+class NoteTemplateFactory extends AbstractFactory
+{
+    protected $model = NoteTemplate::class;
+
+    public function definition(): array
+    {
+        $companyId = $this->resolveCompanyId();
+
+        return [
+            'company_id'     => $companyId ?? Company::factory(),
+            'template_title' => $this->faker->sentence(),
+            'template_body'  => $this->faker->paragraph(),
+        ];
+    }
+}

--- a/Modules/Core/Database/Migrations/2026_07_14_000001_create_note_templates_table.php
+++ b/Modules/Core/Database/Migrations/2026_07_14_000001_create_note_templates_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('note_templates', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('company_id');
+            $table->string('template_title');
+            $table->longText('template_body');
+
+            $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('note_templates');
+    }
+};

--- a/Modules/Core/Filament/Company/Actions/InsertNoteTemplateAction.php
+++ b/Modules/Core/Filament/Company/Actions/InsertNoteTemplateAction.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Modules\Core\Filament\Company\Actions;
+
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Modules\Core\Models\NoteTemplate;
+
+class InsertNoteTemplateAction
+{
+    public static function make(string $field): Action
+    {
+        return Action::make('insert_note_template_' . $field)
+            ->label('Insert Template')
+            ->icon('heroicon-o-document-duplicate')
+            ->schema([
+                Select::make('note_template_id')
+                    ->label('Template')
+                    ->options(fn () => NoteTemplate::forCompany()->pluck('template_title', 'id'))
+                    ->searchable()
+                    ->required(),
+
+                Toggle::make('replace_content')
+                    ->label('Replace existing content')
+                    ->default(false),
+            ])
+            ->modalHeading('Insert Note Template')
+            ->modalSubmitActionLabel('Insert')
+            ->action(function (array $data, Set $set, Get $get) use ($field): void {
+                $template = NoteTemplate::query()->find($data['note_template_id']);
+
+                if ( ! $template) {
+                    return;
+                }
+
+                $existing = $get($field);
+
+                $set($field, ($data['replace_content'] || blank($existing))
+                    ? $template->template_body
+                    : $existing . "\n\n" . $template->template_body);
+            });
+    }
+}

--- a/Modules/Core/Filament/Company/Resources/NoteTemplates/NoteTemplateResource.php
+++ b/Modules/Core/Filament/Company/Resources/NoteTemplates/NoteTemplateResource.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Modules\Core\Filament\Company\Resources\NoteTemplates;
+
+use BackedEnum;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
+use Modules\Core\Filament\Company\Resources\BaseResource;
+use Modules\Core\Filament\Company\Resources\NoteTemplates\Pages\ListNoteTemplates;
+use Modules\Core\Filament\Company\Resources\NoteTemplates\Schemas\NoteTemplateForm;
+use Modules\Core\Filament\Company\Resources\NoteTemplates\Tables\NoteTemplatesTable;
+use Modules\Core\Models\NoteTemplate;
+
+class NoteTemplateResource extends BaseResource
+{
+    protected static ?string $model = NoteTemplate::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::DocumentText;
+
+    protected static ?string $navigationLabel = 'Note Templates';
+
+    protected static ?string $modelLabel = 'Note Template';
+
+    public static function form(Schema $schema): Schema
+    {
+        return NoteTemplateForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return NoteTemplatesTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListNoteTemplates::route('/'),
+        ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->can(Permission::MANAGE_COMPANY_SETTINGS->value) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->can(Permission::MANAGE_COMPANY_SETTINGS->value) ?? false;
+    }
+
+    public static function canView(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::MANAGE_COMPANY_SETTINGS->value) ?? false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::MANAGE_COMPANY_SETTINGS->value) ?? false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return auth()->user()?->can(Permission::MANAGE_COMPANY_SETTINGS->value) ?? false;
+    }
+}

--- a/Modules/Core/Filament/Company/Resources/NoteTemplates/Pages/ListNoteTemplates.php
+++ b/Modules/Core/Filament/Company/Resources/NoteTemplates/Pages/ListNoteTemplates.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Modules\Core\Filament\Company\Resources\NoteTemplates\Pages;
+
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Modules\Core\Filament\Company\Resources\NoteTemplates\NoteTemplateResource;
+use Modules\Core\Services\NoteTemplateService;
+
+class ListNoteTemplates extends ListRecords
+{
+    protected static string $resource = NoteTemplateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make()
+                ->action(function (array $data) {
+                    app(NoteTemplateService::class)->createNoteTemplate($data);
+                })
+                ->modalWidth('full'),
+        ];
+    }
+}

--- a/Modules/Core/Filament/Company/Resources/NoteTemplates/Schemas/NoteTemplateForm.php
+++ b/Modules/Core/Filament/Company/Resources/NoteTemplates/Schemas/NoteTemplateForm.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Core\Filament\Company\Resources\NoteTemplates\Schemas;
+
+use Filament\Forms\Components\MarkdownEditor;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class NoteTemplateForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Template')
+                    ->schema([
+                        TextInput::make('template_title')
+                            ->label('Title')
+                            ->required()
+                            ->maxLength(255),
+
+                        MarkdownEditor::make('template_body')
+                            ->label('Body')
+                            ->required()
+                            ->toolbarButtons([
+                                'bold', 'italic', 'strike', 'link',
+                                'heading',
+                                'blockquote', 'codeBlock', 'bulletList', 'orderedList',
+                                'undo', 'redo',
+                            ])
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+}

--- a/Modules/Core/Filament/Company/Resources/NoteTemplates/Tables/NoteTemplatesTable.php
+++ b/Modules/Core/Filament/Company/Resources/NoteTemplates/Tables/NoteTemplatesTable.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Modules\Core\Filament\Company\Resources\NoteTemplates\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Modules\Core\Models\NoteTemplate;
+use Modules\Core\Services\NoteTemplateService;
+
+class NoteTemplatesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('template_title')
+                    ->label('Title')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('template_body')
+                    ->label('Body')
+                    ->limit(50)
+                    ->searchable(),
+            ])
+            ->defaultSort('template_title', 'asc')
+            ->recordActions([
+                EditAction::make()
+                    ->action(function (NoteTemplate $record, array $data) {
+                        app(NoteTemplateService::class)->updateNoteTemplate($record, $data);
+                    })
+                    ->modalWidth('full'),
+                DeleteAction::make()
+                    ->action(function (NoteTemplate $record, array $data) {
+                        app(NoteTemplateService::class)->deleteNoteTemplate($record, $data);
+                    }),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/Modules/Core/Models/NoteTemplate.php
+++ b/Modules/Core/Models/NoteTemplate.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Modules\Core\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Database\Factories\NoteTemplateFactory;
+use Modules\Core\Traits\BelongsToCompany;
+
+/**
+ * @property int    $id
+ * @property int    $company_id
+ * @property string $template_title
+ * @property string $template_body
+ * @property Company $company
+ */
+class NoteTemplate extends Model
+{
+    use BelongsToCompany;
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected static function newFactory(): Factory
+    {
+        return NoteTemplateFactory::new();
+    }
+}

--- a/Modules/Core/Providers/CompanyPanelProvider.php
+++ b/Modules/Core/Providers/CompanyPanelProvider.php
@@ -25,6 +25,7 @@ use Modules\Clients\Filament\Company\Resources\Relations\RelationResource;
 use Modules\Core\Filament\Company\Pages\Auth\EditProfile;
 use Modules\Core\Filament\Company\Pages\Dashboard;
 use Modules\Core\Filament\Company\Pages\MyCompanies;
+use Modules\Core\Filament\Company\Resources\NoteTemplates\NoteTemplateResource;
 use Modules\Core\Filament\Pages\Auth\Login;
 use Modules\Core\Http\Middleware\ConfigureTenant;
 use Modules\Core\Http\Middleware\EnsureUserCanAccessCompany;
@@ -169,6 +170,7 @@ class CompanyPanelProvider extends PanelProvider
                 ProjectResource::class,
                 TaskResource::class,
                 QuoteResource::class,
+                NoteTemplateResource::class,
             ])
             ->discoverPages(in: app_path('Filament/Company/Pages'), for: 'App\Filament\Company\Pages')
             ->discoverWidgets(in: app_path('Filament/Company/Widgets'), for: 'App\Filament\Company\Widgets')
@@ -236,6 +238,12 @@ class CompanyPanelProvider extends PanelProvider
 
                                 ...ProjectResource::getNavigationItems(),
                                 ...TaskResource::getNavigationItems(),
+                            ]),
+
+                        NavigationGroup::make('Settings')
+                            //->icon('heroicon-o-cog-6-tooth')
+                            ->items([
+                                ...NoteTemplateResource::getNavigationItems(),
                             ]),
                     ]);
             })

--- a/Modules/Core/Services/NoteTemplateService.php
+++ b/Modules/Core/Services/NoteTemplateService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Modules\Core\Services;
+
+use Illuminate\Support\Facades\DB;
+use Modules\Core\Models\NoteTemplate;
+use Throwable;
+
+class NoteTemplateService extends BaseService
+{
+    public function model(): string
+    {
+        return NoteTemplate::class;
+    }
+
+    public function createNoteTemplate(array $data): NoteTemplate
+    {
+        return NoteTemplate::query()->create([
+            'company_id'     => $this->getCompanyId(),
+            'template_title' => $data['template_title'],
+            'template_body'  => $data['template_body'],
+        ]);
+    }
+
+    public function updateNoteTemplate(NoteTemplate $model, array $data): NoteTemplate
+    {
+        $model->update([
+            'template_title' => $data['template_title'],
+            'template_body'  => $data['template_body'],
+        ]);
+
+        return $model;
+    }
+
+    public function deleteNoteTemplate(NoteTemplate $noteTemplate, array $data = []): NoteTemplate
+    {
+        DB::beginTransaction();
+        try {
+            $noteTemplate->delete();
+            DB::commit();
+        } catch (Throwable $e) {
+            DB::rollBack();
+            throw $e;
+        }
+
+        return $noteTemplate;
+    }
+}

--- a/Modules/Core/Tests/Feature/NoteTemplatesTest.php
+++ b/Modules/Core/Tests/Feature/NoteTemplatesTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Modules\Core\Tests\Feature;
+
+use Filament\Actions\Testing\TestAction;
+use Livewire\Livewire;
+use Modules\Core\Filament\Company\Resources\NoteTemplates\NoteTemplateResource;
+use Modules\Core\Filament\Company\Resources\NoteTemplates\Pages\ListNoteTemplates;
+use Modules\Core\Models\Company;
+use Modules\Core\Models\NoteTemplate;
+use Modules\Core\Tests\AbstractCompanyPanelTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(NoteTemplateResource::class)]
+class NoteTemplatesTest extends AbstractCompanyPanelTestCase
+{
+    # region smoke
+    #[Test]
+    #[Group('smoke')]
+    public function it_lists_note_templates(): void
+    {
+        /* Arrange */
+        $template = NoteTemplate::factory()->for($this->company)->create([
+            'template_title' => 'SEO Terms',
+            'template_body'  => 'Payment due Net 30.',
+        ]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ListNoteTemplates::class);
+
+        /* Assert */
+        $component->assertSuccessful();
+        $component->assertSee('SEO Terms');
+
+        $this->assertDatabaseHas('note_templates', $template->toArray());
+    }
+    # endregion
+
+    # region multi-tenancy
+    #[Test]
+    #[Group('multi-tenancy')]
+    public function it_does_not_show_note_templates_from_another_company(): void
+    {
+        /* Arrange */
+        $other = NoteTemplate::factory()->for(Company::factory()->create())->create([
+            'template_title' => 'Other Terms',
+        ]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ListNoteTemplates::class);
+
+        /* Assert */
+        $component->assertSuccessful();
+        $component->assertDontSee('Other Terms');
+        $component->assertCanNotSeeTableRecords([$other]);
+    }
+    # endregion
+
+    # region crud
+    #[Test]
+    #[Group('crud')]
+    public function it_creates_a_note_template_through_a_modal(): void
+    {
+        /* Arrange */
+        $payload = [
+            'template_title' => 'Web Dev Payment Terms',
+            'template_body'  => '50% deposit, 50% on delivery.',
+        ];
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ListNoteTemplates::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $component->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('note_templates', array_merge($payload, [
+            'company_id' => $this->company->id,
+        ]));
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_fails_to_create_a_note_template_without_required_title(): void
+    {
+        /* Arrange */
+        $payload = [
+            'template_body' => 'Some body text.',
+        ];
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ListNoteTemplates::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $component->assertHasFormErrors(['template_title']);
+
+        $this->assertDatabaseMissing('note_templates', $payload);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_updates_a_note_template_through_a_modal(): void
+    {
+        /* Arrange */
+        $template = NoteTemplate::factory()->for($this->company)->create([
+            'template_title' => 'Old Title',
+            'template_body'  => 'Old body.',
+        ]);
+
+        $payload = ['template_title' => 'Updated Title'];
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ListNoteTemplates::class)
+            ->mountAction(TestAction::make('edit')->table($template), $payload)
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $component->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('note_templates', array_merge($payload, [
+            'id' => $template->id,
+        ]));
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_deletes_a_note_template(): void
+    {
+        /* Arrange */
+        $template = NoteTemplate::factory()->for($this->company)->create([
+            'template_title' => 'Template to Delete',
+        ]);
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ListNoteTemplates::class)
+            ->mountAction(TestAction::make('delete')->table($template))
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseMissing('note_templates', ['id' => $template->id]);
+    }
+    # endregion
+}

--- a/Modules/Invoices/Filament/Company/Resources/Invoices/Schemas/InvoiceForm.php
+++ b/Modules/Invoices/Filament/Company/Resources/Invoices/Schemas/InvoiceForm.php
@@ -15,6 +15,7 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Modules\Core\Enums\NumberingType;
+use Modules\Core\Filament\Company\Actions\InsertNoteTemplateAction;
 use Modules\Invoices\Enums\InvoiceStatus;
 use Modules\Invoices\Support\InvoiceCalculator;
 use Modules\Products\Models\Product;
@@ -224,7 +225,8 @@ class InvoiceForm
                             ->schema([
                                 MarkdownEditor::make('notes')
                                     ->label(trans('ip.notes'))
-                                    ->toolbarButtons(['bold', 'italic']),
+                                    ->toolbarButtons(['bold', 'italic'])
+                                    ->hintAction(InsertNoteTemplateAction::make('notes')),
                             ])
                             ->columnSpan(1),
 
@@ -244,7 +246,8 @@ class InvoiceForm
                     ->schema([
                         MarkdownEditor::make('invoice_terms')
                             ->toolbarButtons(['bold', 'italic'])
-                            ->label(trans('ip.invoice_terms')),
+                            ->label(trans('ip.invoice_terms'))
+                            ->hintAction(InsertNoteTemplateAction::make('invoice_terms')),
                     ])
                     ->columnSpanFull(),
             ]);

--- a/Modules/Invoices/Tests/Feature/InvoicesTest.php
+++ b/Modules/Invoices/Tests/Feature/InvoicesTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Livewire\Livewire;
 use Modules\Clients\Models\Relation;
 use Modules\Core\Models\Numbering;
+use Modules\Core\Models\NoteTemplate;
 use Modules\Core\Models\TaxRate;
 use Modules\Core\Tests\AbstractCompanyPanelTestCase;
 use Modules\Invoices\Enums\InvoiceStatus;
@@ -577,6 +578,34 @@ class InvoicesTest extends AbstractCompanyPanelTestCase
             'invoice_item_subtotal' => 100,
             'invoice_total'         => 120,
         ]);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_inserts_a_note_template_into_the_notes_field(): void
+    {
+        /* Arrange */
+        $customer = Relation::factory()->customer()->for($this->company)->create();
+        $invoice  = Invoice::factory()->for($this->company)->create([
+            'customer_id' => $customer->id,
+            'user_id'     => $this->user->id,
+            'notes'       => null,
+        ]);
+        $template = NoteTemplate::factory()->for($this->company)->create([
+            'template_title' => 'SEO Terms',
+            'template_body'  => 'Payment due Net 30.',
+        ]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(EditInvoice::class, ['record' => $invoice->id])
+            ->callFormComponentAction('notes', 'insert_note_template_notes', [
+                'note_template_id' => $template->id,
+                'replace_content'  => true,
+            ]);
+
+        /* Assert */
+        $component->assertFormSet(['notes' => 'Payment due Net 30.']);
     }
 
     #[Test]

--- a/Modules/Quotes/Filament/Company/Resources/Quotes/Schemas/QuoteForm.php
+++ b/Modules/Quotes/Filament/Company/Resources/Quotes/Schemas/QuoteForm.php
@@ -16,6 +16,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Modules\Core\Enums\NumberingType;
+use Modules\Core\Filament\Company\Actions\InsertNoteTemplateAction;
 use Modules\Products\Models\Product;
 use Modules\Quotes\Enums\QuoteStatus;
 use Modules\Quotes\Support\QuoteCalculator;
@@ -217,7 +218,8 @@ class QuoteForm
                     ->schema([
                         MarkdownEditor::make('notes')
                             ->label(trans('ip.notes'))
-                            ->toolbarButtons(['bold', 'italic']),
+                            ->toolbarButtons(['bold', 'italic'])
+                            ->hintAction(InsertNoteTemplateAction::make('notes')),
                     ])
                     ->collapsed()
                     ->columnSpanFull(),

--- a/Modules/Quotes/Filament/Company/Resources/Quotes/Schemas/QuoteForm.php
+++ b/Modules/Quotes/Filament/Company/Resources/Quotes/Schemas/QuoteForm.php
@@ -218,7 +218,6 @@ class QuoteForm
                     ->schema([
                         MarkdownEditor::make('notes')
                             ->label(trans('ip.notes'))
-                            ->toolbarButtons(['bold', 'italic'])
                             ->hintAction(InsertNoteTemplateAction::make('notes')),
                     ])
                     ->collapsed()

--- a/Modules/Quotes/Tests/Feature/QuotesTest.php
+++ b/Modules/Quotes/Tests/Feature/QuotesTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use Livewire\Livewire;
 use Modules\Clients\Models\Relation;
 use Modules\Core\Models\Numbering;
+use Modules\Core\Models\NoteTemplate;
 use Modules\Core\Models\TaxRate;
 use Modules\Core\Tests\AbstractCompanyPanelTestCase;
 use Modules\Products\Models\Product;
@@ -15,6 +16,7 @@ use Modules\Products\Models\ProductCategory;
 use Modules\Products\Models\ProductUnit;
 use Modules\Quotes\Enums\QuoteStatus;
 use Modules\Quotes\Filament\Company\Resources\Quotes\Pages\CreateQuote;
+use Modules\Quotes\Filament\Company\Resources\Quotes\Pages\EditQuote;
 use Modules\Quotes\Filament\Company\Resources\Quotes\Pages\ListQuotes;
 use Modules\Quotes\Models\Quote;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -332,6 +334,33 @@ class QuotesTest extends AbstractCompanyPanelTestCase
             'id'           => $quote->id,
             'quote_status' => QuoteStatus::SENT->value,
         ]);
+    }
+    #[Test]
+    #[Group('crud')]
+    public function it_inserts_a_note_template_into_the_notes_field(): void
+    {
+        /* Arrange */
+        $prospect = Relation::factory()->for($this->company)->prospect()->create();
+        $quote    = Quote::factory()->for($this->company)->create([
+            'prospect_id' => $prospect->id,
+            'user_id'     => $this->user->id,
+            'notes'       => null,
+        ]);
+        $template = NoteTemplate::factory()->for($this->company)->create([
+            'template_title' => 'SEO Terms',
+            'template_body'  => 'Payment due Net 30.',
+        ]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(EditQuote::class, ['record' => $quote->id])
+            ->callFormComponentAction('notes', 'insert_note_template_notes', [
+                'note_template_id' => $template->id,
+                'replace_content'  => true,
+            ]);
+
+        /* Assert */
+        $component->assertFormSet(['notes' => 'Payment due Net 30.']);
     }
     # endregion
 


### PR DESCRIPTION
# Pull Request Checklist  

## Checklist  
- [x] My code follows the code formatting guidelines.  
- [x] I have tested my changes locally.  
- [x] I selected the appropriate branch for this PR.  
- [x] I have rebased my changes on top of the selected branch.  
- [ ] I included relevant documentation updates if necessary.  
- [x] I have an accompanying issue ID for this pull request.  

---

## Description  
Adds reusable, company-scoped note/terms templates so admins no longer have to retype the same boilerplate legal/payment text on every invoice or quote.

- New `NoteTemplate` model (table `note_templates`, fields `template_title`/`template_body`), scoped via the existing `BelongsToCompany` trait.
- New "Note Templates" resource in the Company panel under a new **Settings** nav group, with full CRUD gated by the existing `manage-company-settings` permission (same as `NumberingResource`).
- New `InsertNoteTemplateAction` — an "Insert Template" hint-action on `MarkdownEditor` fields that opens a searchable template picker and either appends or replaces the field's content.
- Wired onto Invoice `notes` + `invoice_terms`, and Quote `notes`.
- Expanded the Note Template body editor's toolbar (headings, lists, blockquote, code block, etc.) beyond the initial bold/italic-only set.

## Related Issue(s)  
Closes #389

## Motivation and Context  
Company admins were retyping the same standard terms (e.g. "SEO Project Terms", "Web Dev Payment Terms") into every invoice/quote. This adds a small reusable template library plus a one-click insert action on the notes/terms fields, removing that repetitive work.

## Issue Type (Check one or more)  
- [ ] Bugfix  
- [ ] Improvement of an existing feature  
- [x] New feature  

## Screenshots (If Applicable)  
### New Navigation Menu
- New navigation menu for managing Notes Template resource.

<img width="3450" height="1690" alt="Screenshot 2026-07-14 at 4 40 41 PM" src="https://github.com/user-attachments/assets/92812a28-31da-4c89-a5a4-ceb19ddfd65b" />

- Insert Note template on invoice resource
<img width="3450" height="966" alt="Screenshot 2026-07-14 at 4 41 56 PM" src="https://github.com/user-attachments/assets/c709e993-e355-4948-824e-617326eaa10f" />

- Choosing the Notes Template
<img width="1922" height="718" alt="Screenshot 2026-07-14 at 4 42 33 PM" src="https://github.com/user-attachments/assets/91066e23-30d3-4353-804d-86c10596af0f" />

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added company note templates with title and formatted body content.
  * Added template management under Company Settings, including create, edit, search, and delete actions.
  * Added note template insertion to invoice and quote notes fields, with options to replace or append content.
  * Restricted template access to authorized users and the active company.

* **Tests**
  * Added coverage for template management, company isolation, validation, and insertion into invoices and quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->