### PR TITLE
[IP-696]: fix: require PHP ^8.4 to match CI and mb_str_functions usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # InvoicePlane v2
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![PHP Version](https://img.shields.io/badge/PHP-8.3%2B-blue.svg)](https://php.net)
+[![PHP Version](https://img.shields.io/badge/PHP-8.4%2B-blue.svg)](https://php.net)
 [![Laravel Version](https://img.shields.io/badge/Laravel-13%2B-red.svg)](https://laravel.com)
 [![Filament Version](https://img.shields.io/badge/Filament-5.x-orange.svg)](https://filamentphp.com)
 
@@ -44,7 +44,7 @@
 
 ## 📦 Requirements
 
-- **PHP** 8.3 or higher
+- **PHP** 8.4 or higher
 - **Composer** 2.x
 - **Node.js** 20+ and Yarn
 - **Database** MariaDB 10.11+ (recommended), MySQL 8.0+, or SQLite (dev only)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "awcodes/mason": "^3.1",
         "doctrine/dbal": ">=4.4",
         "dompdf/dompdf": "^3.1",


### PR DESCRIPTION
## Summary
- `composer.json` declared `"php": "^8.3"`, but `pint.json` enables `mb_str_functions` (`mb_trim`/`mb_ltrim`/`mb_rtrim`, added in PHP 8.4) and every GitHub Actions workflow pins `php-version: '8.4'`.
- Installing on a real PHP 8.3.x runtime (explicitly allowed by `^8.3`) would fatal the first time one of the existing `mb_trim()` call sites executes (`Contact::getFullNameAttribute()`, `Numbering`, `NumberingService`, `InvoicesTable`).
- Bumps the composer constraint to `^8.4` and updates the README's stated PHP requirement to match, so the declared minimum finally reflects what the project actually needs.

## Test plan
- [x] `composer validate` — schema valid; pre-existing lock-file staleness warning is unrelated to this change (reproduces identically on `develop` before this PR, caused by unrelated dependency conflicts: `laravel/pint` pinned to a stale dev-branch ref, and a `dompdf`/`roave/security-advisories` version conflict — out of scope here)
- [x] `composer install --dry-run` succeeds on the current platform
- [x] Existing PHPUnit tests still pass

Fixes #696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented minimum supported PHP version to 8.4.

* **Chores**
  * Updated the project’s platform requirement to require PHP 8.4 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->