### PR TITLE
[IP-694]: Fix recent dashboard widget ordering

### DIFF
--- a/Modules/Expenses/Filament/Company/Widgets/RecentExpensesWidget.php
+++ b/Modules/Expenses/Filament/Company/Widgets/RecentExpensesWidget.php
@@ -30,7 +30,7 @@ class RecentExpensesWidget extends TableWidget
     protected function getTableQuery(): Builder|Relation|null
     {
         /** @var Builder<Expense> $query */
-        $query = Expense::query()->latest()->limit(10);
+        $query = Expense::query()->latest('id')->limit(10);
 
         return $query;
     }

--- a/Modules/Expenses/Tests/Feature/RecentExpensesWidgetTest.php
+++ b/Modules/Expenses/Tests/Feature/RecentExpensesWidgetTest.php
@@ -31,4 +31,26 @@ class RecentExpensesWidgetTest extends AbstractCompanyPanelTestCase
         $component->assertSuccessful();
         $component->assertSee(ExpenseResource::getUrl('index'), false);
     }
+
+    #[Test]
+    #[Group('smoke')]
+    public function it_lists_newer_expenses_before_older_expenses(): void
+    {
+        /* Arrange */
+        $olderExpense = Expense::factory()
+            ->for($this->company)
+            ->create(['expense_number' => 'EXP-OLDER']);
+        $newerExpense = Expense::factory()
+            ->for($this->company)
+            ->create(['expense_number' => 'EXP-NEWER']);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(RecentExpensesWidget::class);
+
+        /* Assert */
+        $component
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$newerExpense, $olderExpense], inOrder: true);
+    }
 }

--- a/Modules/Payments/Filament/Company/Widgets/RecentPaymentsWidget.php
+++ b/Modules/Payments/Filament/Company/Widgets/RecentPaymentsWidget.php
@@ -28,7 +28,7 @@ class RecentPaymentsWidget extends TableWidget
     protected function getTableQuery(): Builder|Relation|null
     {
         /** @var Builder<Payment> $query */
-        $query = Payment::query()->latest()->limit(10);
+        $query = Payment::query()->latest('id')->limit(10);
 
         return $query;
     }

--- a/Modules/Payments/Tests/Feature/RecentPaymentsWidgetTest.php
+++ b/Modules/Payments/Tests/Feature/RecentPaymentsWidgetTest.php
@@ -45,4 +45,41 @@ class RecentPaymentsWidgetTest extends AbstractCompanyPanelTestCase
         $component->assertSuccessful();
         $component->assertSee(PaymentResource::getUrl('index'), false);
     }
+
+    #[Test]
+    #[Group('smoke')]
+    public function it_lists_newer_payments_before_older_payments(): void
+    {
+        /* Arrange */
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+        $invoice  = Invoice::factory()
+            ->for($this->company)
+            ->create([
+                'customer_id' => $customer->id,
+                'user_id'     => $this->user->id,
+            ]);
+        $olderPayment = Payment::factory()
+            ->for($this->company)
+            ->create([
+                'payment_number' => 'PAY-OLDER',
+                'customer_id'    => $customer->id,
+                'invoice_id'     => $invoice->id,
+            ]);
+        $newerPayment = Payment::factory()
+            ->for($this->company)
+            ->create([
+                'payment_number' => 'PAY-NEWER',
+                'customer_id'    => $customer->id,
+                'invoice_id'     => $invoice->id,
+            ]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(RecentPaymentsWidget::class);
+
+        /* Assert */
+        $component
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$newerPayment, $olderPayment], inOrder: true);
+    }
 }

--- a/Modules/Projects/Filament/Company/Widgets/RecentProjectsWidget.php
+++ b/Modules/Projects/Filament/Company/Widgets/RecentProjectsWidget.php
@@ -30,7 +30,7 @@ class RecentProjectsWidget extends TableWidget
     protected function getTableQuery(): Builder|Relation|null
     {
         /** @var Builder<Project> $query */
-        $query = Project::query()->latest()->limit(10);
+        $query = Project::query()->latest('id')->limit(10);
 
         return $query;
     }

--- a/Modules/Projects/Filament/Company/Widgets/RecentTasksWidget.php
+++ b/Modules/Projects/Filament/Company/Widgets/RecentTasksWidget.php
@@ -30,7 +30,7 @@ class RecentTasksWidget extends TableWidget
     protected function getTableQuery(): Builder|Relation|null
     {
         /** @var Builder<Task> $query */
-        $query = Task::query()->latest()->limit(10);
+        $query = Task::query()->latest('id')->limit(10);
 
         return $query;
     }

--- a/Modules/Projects/Tests/Feature/RecentProjectsWidgetTest.php
+++ b/Modules/Projects/Tests/Feature/RecentProjectsWidgetTest.php
@@ -37,4 +37,33 @@ class RecentProjectsWidgetTest extends AbstractCompanyPanelTestCase
         $component->assertSuccessful();
         $component->assertSee(ProjectResource::getUrl('index'), false);
     }
+
+    #[Test]
+    #[Group('smoke')]
+    public function it_lists_newer_projects_before_older_projects(): void
+    {
+        /* Arrange */
+        $customer     = Relation::factory()->for($this->company)->customer()->create();
+        $olderProject = Project::factory()
+            ->for($this->company)
+            ->create([
+                'project_number' => 'PRJ-OLDER',
+                'customer_id'    => $customer->id,
+            ]);
+        $newerProject = Project::factory()
+            ->for($this->company)
+            ->create([
+                'project_number' => 'PRJ-NEWER',
+                'customer_id'    => $customer->id,
+            ]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(RecentProjectsWidget::class);
+
+        /* Assert */
+        $component
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$newerProject, $olderProject], inOrder: true);
+    }
 }

--- a/Modules/Projects/Tests/Feature/RecentTasksWidgetTest.php
+++ b/Modules/Projects/Tests/Feature/RecentTasksWidgetTest.php
@@ -31,4 +31,26 @@ class RecentTasksWidgetTest extends AbstractCompanyPanelTestCase
         $component->assertSuccessful();
         $component->assertSee(TaskResource::getUrl('index'), false);
     }
+
+    #[Test]
+    #[Group('smoke')]
+    public function it_lists_newer_tasks_before_older_tasks(): void
+    {
+        /* Arrange */
+        $olderTask = Task::factory()
+            ->for($this->company)
+            ->create(['task_number' => 'TSK-OLDER']);
+        $newerTask = Task::factory()
+            ->for($this->company)
+            ->create(['task_number' => 'TSK-NEWER']);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(RecentTasksWidget::class);
+
+        /* Assert */
+        $component
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$newerTask, $olderTask], inOrder: true);
+    }
 }


### PR DESCRIPTION
## Summary
- order Recent Expenses, Payments, Projects, and Tasks by descending primary key
- avoid Laravel’s default `created_at` ordering on models that disable timestamps
- add ordered-record regression coverage for each widget

## Developer checklist
- [x] References `CHECKLIST.md` rows: expenses, payments, projects, and projects/tasks
- [x] Includes appropriate test coverage
- [x] Follows service/DTO/transformer structure (no new inline logic)
- [x] UI follows Filament & Livewire best practices
- [x] Translations not needed
- [ ] Full `php artisan test` suite not run
- [x] Ran `vendor/bin/pint` for changed files

## Validation
- `php artisan test Modules/Expenses/Tests/Feature/RecentExpensesWidgetTest.php Modules/Payments/Tests/Feature/RecentPaymentsWidgetTest.php Modules/Projects/Tests/Feature/RecentProjectsWidgetTest.php Modules/Projects/Tests/Feature/RecentTasksWidgetTest.php` (8 tests, 16 assertions; existing PHP 8.5 deprecations only)
- `vendor/bin/pint --test` on the eight changed files

Closes #694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recent expenses, payments, projects, and tasks now consistently appear newest first.
  * Widgets display the latest records in the expected order.

* **Tests**
  * Added coverage confirming correct ordering and successful rendering for all recent activity widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->