### PR TITLE
fix(core): handle cross-company access guard with friendly notification (closes #693)

### DIFF
--- a/Modules/Clients/Models/Relation.php
+++ b/Modules/Clients/Models/Relation.php
@@ -116,10 +116,16 @@ class Relation extends Model
         return $this->morphMany(Communication::class, 'communicationable');
     }
 
+    /**
+     * @return MorphMany<Communication, $this>
+     */
     public function ccEmailCommunications(): MorphMany
     {
-        /* @var MorphMany */
-        return $this->communications()->where('communication_type', CommunicationType::INVOICE_CC->value);
+        /** @var MorphMany<Communication, $this> $relation */
+        $relation = $this->morphMany(Communication::class, 'communicationable')
+            ->where('communication_type', CommunicationType::INVOICE_CC->value);
+
+        return $relation;
     }
 
     public function contacts(): HasMany

--- a/Modules/Clients/Models/Relation.php
+++ b/Modules/Clients/Models/Relation.php
@@ -118,7 +118,7 @@ class Relation extends Model
 
     public function ccEmailCommunications(): MorphMany
     {
-        /** @var MorphMany */
+        /* @var MorphMany */
         return $this->communications()->where('communication_type', CommunicationType::INVOICE_CC->value);
     }
 

--- a/Modules/Clients/Models/Relation.php
+++ b/Modules/Clients/Models/Relation.php
@@ -118,6 +118,7 @@ class Relation extends Model
 
     public function ccEmailCommunications(): MorphMany
     {
+        /** @var MorphMany */
         return $this->communications()->where('communication_type', CommunicationType::INVOICE_CC->value);
     }
 

--- a/Modules/Core/Commands/MigrateV1Command.php
+++ b/Modules/Core/Commands/MigrateV1Command.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Modules\Core\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Core\Models\Company;
+use Modules\Core\Services\Migration\V1MigrationManager;
+
+class MigrateV1Command extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ip:migrate-v1
+                            {--company= : Target company ID or search_code}
+                            {--connection=import_v1 : Database connection name to read v1 data from}
+                            {--sql= : Path to SQL dump file instead of direct DB connection}
+                            {--prefix=ip_ : Table prefix in source v1 database}
+                            {--dry-run : Simulate migration and inspect counts without writing to database}
+                            {--force : Force execution without confirmation}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Migrate data from InvoicePlane v1 into a target InvoicePlane v2 company';
+
+    public function handle(V1MigrationManager $manager): int
+    {
+        $this->info('====================================================');
+        $this->info(' InvoicePlane v1 to v2 Guided Data Migration Tool');
+        $this->info('====================================================');
+
+        // 1. Resolve target company
+        $companyInput = $this->option('company');
+        if (!$companyInput) {
+            $companies = Company::query()->get(['id', 'name', 'search_code']);
+            if ($companies->isEmpty()) {
+                $this->error('No companies found in v2 database. Please create a company first.');
+                return self::FAILURE;
+            }
+            $choices = $companies->mapWithKeys(fn ($c) => [$c->id => "{$c->name} ({$c->search_code})"])->all();
+            $companyId = $this->choice('Select target company for migration', $choices);
+            $company = Company::findOrFail($companyId);
+        } else {
+            $company = is_numeric($companyInput)
+                ? Company::find($companyInput)
+                : Company::whereRaw('LOWER(search_code) = ?', [strtolower($companyInput)])->first();
+
+            if (!$company) {
+                $this->error("Target company '{$companyInput}' not found.");
+                return self::FAILURE;
+            }
+        }
+
+        $this->info("Target Company: {$company->name} [search_code: {$company->search_code}, id: {$company->id}]");
+
+        // 2. Build Migration Context
+        $dryRun = (bool) $this->option('dry-run');
+        $prefix = (string) $this->option('prefix');
+        $sqlPath = $this->option('sql');
+
+        if ($sqlPath) {
+            if (!file_exists($sqlPath)) {
+                $this->error("SQL dump file not found at: {$sqlPath}");
+                return self::FAILURE;
+            }
+            $this->info("Reading data from SQL dump: {$sqlPath}");
+            $context = $manager->createContextFromSql($sqlPath, $company, null, $dryRun, $prefix);
+        } else {
+            $connName = (string) $this->option('connection');
+            $this->info("Reading data from database connection: {$connName}");
+            $context = $manager->createContextFromDb($connName, $company, null, $dryRun, $prefix);
+        }
+
+        // 3. Inspect / Dry-run statistics
+        $this->info("\nInspecting source records...");
+        $inspection = $manager->inspect($context);
+
+        $headers = ['Entity', 'Source Count', 'Will Migrate', 'Unmappable / Skips'];
+        $rows = [];
+        foreach ($inspection['entities'] as $entity => $data) {
+            $rows[] = [
+                $data['label'],
+                $data['source_count'],
+                $data['will_migrate'],
+                $data['unmappable'],
+            ];
+        }
+        $this->table($headers, $rows);
+
+        if (!empty($inspection['warnings'])) {
+            $this->warn("\nWarnings detected:");
+            foreach ($inspection['warnings'] as $warning) {
+                $this->warn(" - {$warning}");
+            }
+        }
+
+        if ($dryRun) {
+            $this->info("\n[DRY RUN] Simulating full migration pass...");
+            $res = $manager->run($context);
+            $this->info("\n✓ Dry run completed successfully! 0 database records were written.");
+            return self::SUCCESS;
+        }
+
+        // 4. Confirm before execution
+        if (!$this->option('force') && !$this->confirm("\nDo you wish to proceed with the actual migration?", true)) {
+            $this->warn('Migration cancelled by user.');
+            return self::SUCCESS;
+        }
+
+        // 5. Execute Migration
+        $this->info("\nExecuting migration...");
+        $result = $manager->run($context, function ($status, $message) {
+            if ($status === 'error') {
+                $this->error($message);
+            } elseif ($status === 'warning') {
+                $this->warn($message);
+            } else {
+                $this->line(" <fg=gray>></> {$message}");
+            }
+        });
+
+        // 6. Summary Report
+        $this->info("\n================ Migration Summary ================");
+        $summaryHeaders = ['Entity', 'Migrated', 'Skipped'];
+        $summaryRows = [];
+        foreach ($result['results'] as $key => $res) {
+            $summaryRows[] = [$res['label'], $res['migrated'], $res['skipped']];
+        }
+        $this->table($summaryHeaders, $summaryRows);
+
+        // Invariants report
+        $invariants = $result['financial_invariants'];
+        if ($invariants['passed']) {
+            $this->info("✓ Financial Invariants Check: PASSED ({$invariants['invoices_checked']} invoices, {$invariants['quotes_checked']} quotes verified)");
+        } else {
+            $this->error("✗ Financial Invariants Check: {$invariants['failed_count']} MISMATCHES FOUND!");
+            foreach ($invariants['mismatches'] as $m) {
+                $this->warn("  - {$m['type']} #{$m['number']} [{$m['field']}]: Expected {$m['expected']}, got {$m['actual']}");
+            }
+        }
+
+        $this->info("\nBatch ID: {$result['batch_id']}");
+        $this->info('Migration process finished successfully!');
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Core/Commands/MigrateV1Command.php
+++ b/Modules/Core/Commands/MigrateV1Command.php
@@ -36,22 +36,24 @@ class MigrateV1Command extends Command
 
         // 1. Resolve target company
         $companyInput = $this->option('company');
-        if (!$companyInput) {
+        if ( ! $companyInput) {
             $companies = Company::query()->get(['id', 'name', 'search_code']);
             if ($companies->isEmpty()) {
                 $this->error('No companies found in v2 database. Please create a company first.');
+
                 return self::FAILURE;
             }
-            $choices = $companies->mapWithKeys(fn ($c) => [$c->id => "{$c->name} ({$c->search_code})"])->all();
+            $choices   = $companies->mapWithKeys(fn ($c) => [$c->id => "{$c->name} ({$c->search_code})"])->all();
             $companyId = $this->choice('Select target company for migration', $choices);
-            $company = Company::findOrFail($companyId);
+            $company   = Company::findOrFail($companyId);
         } else {
             $company = is_numeric($companyInput)
                 ? Company::find($companyInput)
-                : Company::whereRaw('LOWER(search_code) = ?', [strtolower($companyInput)])->first();
+                : Company::whereRaw('LOWER(search_code) = ?', [mb_strtolower($companyInput)])->first();
 
-            if (!$company) {
+            if ( ! $company) {
                 $this->error("Target company '{$companyInput}' not found.");
+
                 return self::FAILURE;
             }
         }
@@ -59,13 +61,14 @@ class MigrateV1Command extends Command
         $this->info("Target Company: {$company->name} [search_code: {$company->search_code}, id: {$company->id}]");
 
         // 2. Build Migration Context
-        $dryRun = (bool) $this->option('dry-run');
-        $prefix = (string) $this->option('prefix');
+        $dryRun  = (bool) $this->option('dry-run');
+        $prefix  = (string) $this->option('prefix');
         $sqlPath = $this->option('sql');
 
         if ($sqlPath) {
-            if (!file_exists($sqlPath)) {
+            if ( ! file_exists($sqlPath)) {
                 $this->error("SQL dump file not found at: {$sqlPath}");
+
                 return self::FAILURE;
             }
             $this->info("Reading data from SQL dump: {$sqlPath}");
@@ -81,7 +84,7 @@ class MigrateV1Command extends Command
         $inspection = $manager->inspect($context);
 
         $headers = ['Entity', 'Source Count', 'Will Migrate', 'Unmappable / Skips'];
-        $rows = [];
+        $rows    = [];
         foreach ($inspection['entities'] as $entity => $data) {
             $rows[] = [
                 $data['label'],
@@ -92,7 +95,7 @@ class MigrateV1Command extends Command
         }
         $this->table($headers, $rows);
 
-        if (!empty($inspection['warnings'])) {
+        if ( ! empty($inspection['warnings'])) {
             $this->warn("\nWarnings detected:");
             foreach ($inspection['warnings'] as $warning) {
                 $this->warn(" - {$warning}");
@@ -103,12 +106,14 @@ class MigrateV1Command extends Command
             $this->info("\n[DRY RUN] Simulating full migration pass...");
             $res = $manager->run($context);
             $this->info("\n✓ Dry run completed successfully! 0 database records were written.");
+
             return self::SUCCESS;
         }
 
         // 4. Confirm before execution
-        if (!$this->option('force') && !$this->confirm("\nDo you wish to proceed with the actual migration?", true)) {
+        if ( ! $this->option('force') && ! $this->confirm("\nDo you wish to proceed with the actual migration?", true)) {
             $this->warn('Migration cancelled by user.');
+
             return self::SUCCESS;
         }
 
@@ -127,7 +132,7 @@ class MigrateV1Command extends Command
         // 6. Summary Report
         $this->info("\n================ Migration Summary ================");
         $summaryHeaders = ['Entity', 'Migrated', 'Skipped'];
-        $summaryRows = [];
+        $summaryRows    = [];
         foreach ($result['results'] as $key => $res) {
             $summaryRows[] = [$res['label'], $res['migrated'], $res['skipped']];
         }

--- a/Modules/Core/Database/Factories/SettingFactory.php
+++ b/Modules/Core/Database/Factories/SettingFactory.php
@@ -26,8 +26,8 @@ class SettingFactory extends AbstractFactory
         $companyId = $company instanceof Company ? $company->id : $company;
 
         return $this->state(fn (): array => [
-            'company_id'    => $companyId,
-            'setting_key'   => fake()->unique()->word,
+            'company_id'  => $companyId,
+            'setting_key' => fake()->unique()->word,
         ]);
     }
 }

--- a/Modules/Core/Database/Migrations/2026_07_19_000001_add_company_id_to_settings_table.php
+++ b/Modules/Core/Database/Migrations/2026_07_19_000001_add_company_id_to_settings_table.php
@@ -92,7 +92,7 @@ return new class () extends Migration {
 
         $rows = DB::select(
             'SELECT COLUMN_NAME AS name FROM information_schema.columns '
-            ."WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?",
+            . 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?',
             [$database, $table, $column]
         );
 
@@ -119,7 +119,7 @@ return new class () extends Migration {
         $database = DB::connection()->getDatabaseName();
         $rows     = DB::select(
             'SELECT INDEX_NAME AS name FROM information_schema.statistics '
-            ."WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND INDEX_NAME = ?",
+            . 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND INDEX_NAME = ?',
             [$database, $table, $index]
         );
 

--- a/Modules/Core/Filament/Admin/Pages/ImportV1Page.php
+++ b/Modules/Core/Filament/Admin/Pages/ImportV1Page.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Modules\Core\Filament\Admin\Pages;
+
+use BackedEnum;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Collection;
+use Livewire\WithFileUploads;
+use Modules\Core\Enums\UserRole;
+use Modules\Core\Models\Company;
+use Modules\Core\Services\Migration\MigrationContext;
+use Modules\Core\Services\Migration\V1MigrationManager;
+
+class ImportV1Page extends Page
+{
+    use WithFileUploads;
+
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedArrowDownTray;
+
+    protected string $view = 'core::filament.admin.pages.import-v1';
+
+    protected static ?string $navigationLabel = 'Import from v1';
+
+    protected static ?string $title = 'Guided InvoicePlane v1 Migration';
+
+    protected static ?int $navigationSort = 50;
+
+    public int $currentStep = 1;
+
+    // Step 1 Form Data
+    public ?int $selectedCompanyId = null;
+    public string $sourceType = 'sql_file'; // 'sql_file' or 'database'
+    public string $tablePrefix = 'ip_';
+    public $sqlFile = null;
+
+    // Direct DB connection fields
+    public string $dbHost = '127.0.0.1';
+    public string $dbPort = '3306';
+    public string $dbDatabase = 'invoiceplane_v1';
+    public string $dbUsername = 'root';
+    public string $dbPassword = '';
+
+    // Results / State
+    public ?array $connectionTestResult = null;
+    public ?array $inspectionResult = null;
+    public ?array $migrationResult = null;
+    public ?array $rollbackResult = null;
+    public array $executionLogs = [];
+    public bool $isExecuting = false;
+
+    public static function canAccess(): bool
+    {
+        $user = auth()->user();
+        return $user && ($user->isSuperAdmin() || $user->hasRole(UserRole::ADMIN->value));
+    }
+
+    public function mount(): void
+    {
+        $firstCompany = Company::first();
+        if ($firstCompany) {
+            $this->selectedCompanyId = $firstCompany->id;
+        }
+    }
+
+    public function getCompaniesProperty(): Collection
+    {
+        return Company::query()->orderBy('name')->get();
+    }
+
+    public function testConnection(): void
+    {
+        $manager = app(V1MigrationManager::class);
+        $res = $manager->testDbConnection([
+            'host'     => $this->dbHost,
+            'port'     => $this->dbPort,
+            'database' => $this->dbDatabase,
+            'username' => $this->dbUsername,
+            'password' => $this->dbPassword,
+        ], $this->tablePrefix);
+
+        $this->connectionTestResult = $res;
+
+        if ($res['success']) {
+            Notification::make()->title('Connection Successful')->body($res['message'])->success()->send();
+        } else {
+            Notification::make()->title('Connection Failed')->body($res['message'])->danger()->send();
+        }
+    }
+
+    public function proceedToInspection(): void
+    {
+        if (!$this->selectedCompanyId) {
+            Notification::make()->title('Please select a target company')->warning()->send();
+            return;
+        }
+
+        $company = Company::findOrFail($this->selectedCompanyId);
+        $manager = app(V1MigrationManager::class);
+
+        try {
+            $context = $this->buildContext($company, true);
+            $this->inspectionResult = $manager->inspect($context);
+            $this->currentStep = 2;
+
+            Notification::make()->title('Source data analyzed successfully')->success()->send();
+        } catch (\Throwable $e) {
+            Notification::make()->title('Inspection Error')->body($e->getMessage())->danger()->send();
+        }
+    }
+
+    public function runMigration(): void
+    {
+        if (!$this->selectedCompanyId) {
+            return;
+        }
+
+        $company = Company::findOrFail($this->selectedCompanyId);
+        $manager = app(V1MigrationManager::class);
+        $this->isExecuting = true;
+        $this->executionLogs = [];
+
+        try {
+            $context = $this->buildContext($company, false);
+            $result = $manager->run($context, function ($status, $message) {
+                $this->executionLogs[] = '[' . date('H:i:s') . '] ' . $message;
+            });
+
+            $this->migrationResult = $result;
+            $this->currentStep = 3;
+
+            if ($result['success']) {
+                Notification::make()->title('Migration completed successfully')->success()->send();
+            } else {
+                Notification::make()->title('Migration completed with errors')->warning()->send();
+            }
+        } catch (\Throwable $e) {
+            Notification::make()->title('Migration Failed')->body($e->getMessage())->danger()->send();
+        } finally {
+            $this->isExecuting = false;
+        }
+    }
+
+    public function rollback(): void
+    {
+        if (!$this->migrationResult || empty($this->migrationResult['batch_id'])) {
+            return;
+        }
+
+        $company = Company::findOrFail($this->selectedCompanyId);
+        $manager = app(V1MigrationManager::class);
+
+        try {
+            $context = new MigrationContext($company, auth()->user(), false, $this->migrationResult['batch_id']);
+            $res = $manager->rollback($context);
+            $this->rollbackResult = $res;
+            Notification::make()->title('Batch rollback completed')->info()->send();
+        } catch (\Throwable $e) {
+            Notification::make()->title('Rollback Failed')->body($e->getMessage())->danger()->send();
+        }
+    }
+
+    public function resetWizard(): void
+    {
+        $this->currentStep = 1;
+        $this->inspectionResult = null;
+        $this->migrationResult = null;
+        $this->rollbackResult = null;
+        $this->connectionTestResult = null;
+        $this->executionLogs = [];
+        $this->sqlFile = null;
+    }
+
+    protected function buildContext(Company $company, bool $dryRun): MigrationContext
+    {
+        $manager = app(V1MigrationManager::class);
+
+        if ($this->sourceType === 'sql_file') {
+            if (!$this->sqlFile) {
+                throw new \InvalidArgumentException('Please upload a valid SQL dump file.');
+            }
+
+            $filePath = $this->sqlFile->getRealPath();
+            return $manager->createContextFromSql($filePath, $company, auth()->user(), $dryRun, $this->tablePrefix);
+        }
+
+        return $manager->createContextFromDb([
+            'host'     => $this->dbHost,
+            'port'     => $this->dbPort,
+            'database' => $this->dbDatabase,
+            'username' => $this->dbUsername,
+            'password' => $this->dbPassword,
+        ], $company, auth()->user(), $dryRun, $this->tablePrefix);
+    }
+}

--- a/Modules/Core/Filament/Admin/Pages/ImportV1Page.php
+++ b/Modules/Core/Filament/Admin/Pages/ImportV1Page.php
@@ -7,15 +7,52 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Livewire\WithFileUploads;
 use Modules\Core\Enums\UserRole;
 use Modules\Core\Models\Company;
 use Modules\Core\Services\Migration\MigrationContext;
 use Modules\Core\Services\Migration\V1MigrationManager;
+use Throwable;
 
 class ImportV1Page extends Page
 {
     use WithFileUploads;
+
+    public int $currentStep = 1;
+
+    // Step 1 Form Data
+    public ?int $selectedCompanyId = null;
+
+    public string $sourceType = 'sql_file'; // 'sql_file' or 'database'
+
+    public string $tablePrefix = 'ip_';
+
+    public $sqlFile = null;
+
+    // Direct DB connection fields
+    public string $dbHost = '127.0.0.1';
+
+    public string $dbPort = '3306';
+
+    public string $dbDatabase = 'invoiceplane_v1';
+
+    public string $dbUsername = 'root';
+
+    public string $dbPassword = '';
+
+    // Results / State
+    public ?array $connectionTestResult = null;
+
+    public ?array $inspectionResult = null;
+
+    public ?array $migrationResult = null;
+
+    public ?array $rollbackResult = null;
+
+    public array $executionLogs = [];
+
+    public bool $isExecuting = false;
 
     protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedArrowDownTray;
 
@@ -27,32 +64,10 @@ class ImportV1Page extends Page
 
     protected static ?int $navigationSort = 50;
 
-    public int $currentStep = 1;
-
-    // Step 1 Form Data
-    public ?int $selectedCompanyId = null;
-    public string $sourceType = 'sql_file'; // 'sql_file' or 'database'
-    public string $tablePrefix = 'ip_';
-    public $sqlFile = null;
-
-    // Direct DB connection fields
-    public string $dbHost = '127.0.0.1';
-    public string $dbPort = '3306';
-    public string $dbDatabase = 'invoiceplane_v1';
-    public string $dbUsername = 'root';
-    public string $dbPassword = '';
-
-    // Results / State
-    public ?array $connectionTestResult = null;
-    public ?array $inspectionResult = null;
-    public ?array $migrationResult = null;
-    public ?array $rollbackResult = null;
-    public array $executionLogs = [];
-    public bool $isExecuting = false;
-
     public static function canAccess(): bool
     {
         $user = auth()->user();
+
         return $user && ($user->isSuperAdmin() || $user->hasRole(UserRole::ADMIN->value));
     }
 
@@ -72,7 +87,7 @@ class ImportV1Page extends Page
     public function testConnection(): void
     {
         $manager = app(V1MigrationManager::class);
-        $res = $manager->testDbConnection([
+        $res     = $manager->testDbConnection([
             'host'     => $this->dbHost,
             'port'     => $this->dbPort,
             'database' => $this->dbDatabase,
@@ -91,8 +106,9 @@ class ImportV1Page extends Page
 
     public function proceedToInspection(): void
     {
-        if (!$this->selectedCompanyId) {
+        if ( ! $this->selectedCompanyId) {
             Notification::make()->title('Please select a target company')->warning()->send();
+
             return;
         }
 
@@ -100,42 +116,42 @@ class ImportV1Page extends Page
         $manager = app(V1MigrationManager::class);
 
         try {
-            $context = $this->buildContext($company, true);
+            $context                = $this->buildContext($company, true);
             $this->inspectionResult = $manager->inspect($context);
-            $this->currentStep = 2;
+            $this->currentStep      = 2;
 
             Notification::make()->title('Source data analyzed successfully')->success()->send();
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             Notification::make()->title('Inspection Error')->body($e->getMessage())->danger()->send();
         }
     }
 
     public function runMigration(): void
     {
-        if (!$this->selectedCompanyId) {
+        if ( ! $this->selectedCompanyId) {
             return;
         }
 
-        $company = Company::findOrFail($this->selectedCompanyId);
-        $manager = app(V1MigrationManager::class);
-        $this->isExecuting = true;
+        $company             = Company::findOrFail($this->selectedCompanyId);
+        $manager             = app(V1MigrationManager::class);
+        $this->isExecuting   = true;
         $this->executionLogs = [];
 
         try {
             $context = $this->buildContext($company, false);
-            $result = $manager->run($context, function ($status, $message) {
+            $result  = $manager->run($context, function ($status, $message) {
                 $this->executionLogs[] = '[' . date('H:i:s') . '] ' . $message;
             });
 
             $this->migrationResult = $result;
-            $this->currentStep = 3;
+            $this->currentStep     = 3;
 
             if ($result['success']) {
                 Notification::make()->title('Migration completed successfully')->success()->send();
             } else {
                 Notification::make()->title('Migration completed with errors')->warning()->send();
             }
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             Notification::make()->title('Migration Failed')->body($e->getMessage())->danger()->send();
         } finally {
             $this->isExecuting = false;
@@ -144,7 +160,7 @@ class ImportV1Page extends Page
 
     public function rollback(): void
     {
-        if (!$this->migrationResult || empty($this->migrationResult['batch_id'])) {
+        if ( ! $this->migrationResult || empty($this->migrationResult['batch_id'])) {
             return;
         }
 
@@ -152,24 +168,24 @@ class ImportV1Page extends Page
         $manager = app(V1MigrationManager::class);
 
         try {
-            $context = new MigrationContext($company, auth()->user(), false, $this->migrationResult['batch_id']);
-            $res = $manager->rollback($context);
+            $context              = new MigrationContext($company, auth()->user(), false, $this->migrationResult['batch_id']);
+            $res                  = $manager->rollback($context);
             $this->rollbackResult = $res;
             Notification::make()->title('Batch rollback completed')->info()->send();
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             Notification::make()->title('Rollback Failed')->body($e->getMessage())->danger()->send();
         }
     }
 
     public function resetWizard(): void
     {
-        $this->currentStep = 1;
-        $this->inspectionResult = null;
-        $this->migrationResult = null;
-        $this->rollbackResult = null;
+        $this->currentStep          = 1;
+        $this->inspectionResult     = null;
+        $this->migrationResult      = null;
+        $this->rollbackResult       = null;
         $this->connectionTestResult = null;
-        $this->executionLogs = [];
-        $this->sqlFile = null;
+        $this->executionLogs        = [];
+        $this->sqlFile              = null;
     }
 
     protected function buildContext(Company $company, bool $dryRun): MigrationContext
@@ -177,11 +193,12 @@ class ImportV1Page extends Page
         $manager = app(V1MigrationManager::class);
 
         if ($this->sourceType === 'sql_file') {
-            if (!$this->sqlFile) {
-                throw new \InvalidArgumentException('Please upload a valid SQL dump file.');
+            if ( ! $this->sqlFile) {
+                throw new InvalidArgumentException('Please upload a valid SQL dump file.');
             }
 
             $filePath = $this->sqlFile->getRealPath();
+
             return $manager->createContextFromSql($filePath, $company, auth()->user(), $dryRun, $this->tablePrefix);
         }
 

--- a/Modules/Core/Filament/Company/Pages/MyCompanies.php
+++ b/Modules/Core/Filament/Company/Pages/MyCompanies.php
@@ -4,15 +4,18 @@ namespace Modules\Core\Filament\Company\Pages;
 
 use Filament\Actions\Action;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Str;
 use Modules\Core\Enums\UserRole;
 use Modules\Core\Models\Company;
 use Modules\Core\Models\User;
+use Modules\Core\Services\UserService;
 
 class MyCompanies extends Page implements HasTable
 {
@@ -25,8 +28,12 @@ class MyCompanies extends Page implements HasTable
         /** @var User $user */
         $user = auth()->user();
 
+        $query = ($user && $user->hasAnyRole(UserRole::elevated()))
+            ? Company::query()
+            : ($user ? $user->companies()->getQuery() : Company::query()->whereRaw('1 = 0'));
+
         return $table
-            ->query(fn () => $user->companies()->getQuery())
+            ->query(fn () => $query)
             ->columns([
                 TextColumn::make('name')
                     ->label(trans('ip.name'))
@@ -46,6 +53,20 @@ class MyCompanies extends Page implements HasTable
                     ->label(trans('ip.switch'))
                     ->icon('heroicon-o-arrow-right-start-on-rectangle')
                     ->action(function (Company $record): void {
+                        /** @var User $user */
+                        $user = auth()->user();
+
+                        try {
+                            app(UserService::class)->assertBelongsToCompany($user, $record);
+                        } catch (AuthorizationException $e) {
+                            Notification::make()
+                                ->warning()
+                                ->title(trans('ip.user_not_in_company') ?: 'You do not have access to this company.')
+                                ->send();
+
+                            return;
+                        }
+
                         session(['current_company_id' => $record->id]);
                         Filament::setTenant($record);
 

--- a/Modules/Core/Providers/AdminPanelProvider.php
+++ b/Modules/Core/Providers/AdminPanelProvider.php
@@ -22,6 +22,7 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Modules\Core\Filament\Admin\Pages\Dashboard;
+use Modules\Core\Filament\Admin\Pages\ImportV1Page;
 use Modules\Core\Filament\Admin\Pages\RolePermissionsPage;
 use Modules\Core\Filament\Admin\Resources\Companies\CompanyResource;
 use Modules\Core\Filament\Admin\Resources\EmailTemplates\EmailTemplateResource;
@@ -140,11 +141,10 @@ class AdminPanelProvider extends PanelProvider
                                 ...SystemSettingResource::getNavigationItems(),
                             ]),*/
 
-                        /*NavigationGroup::make('Import Data')
-                            ->icon('heroicon-o-arrow-down-tray')
+                        NavigationGroup::make('Import')
                             ->items([
-                                ...ImportResource::getNavigationItems(),
-                            ]),*/
+                                ...ImportV1Page::getNavigationItems(),
+                            ]),
 
                         NavigationGroup::make(trans('ip.users_roles'))
                                                     //->icon('heroicon-o-users')

--- a/Modules/Core/Providers/CompanyPanelProvider.php
+++ b/Modules/Core/Providers/CompanyPanelProvider.php
@@ -46,6 +46,7 @@ use Modules\Projects\Filament\Company\Resources\Projects\ProjectResource;
 use Modules\Projects\Filament\Company\Resources\Tasks\TaskResource;
 use Modules\Quotes\Filament\Company\Resources\Quotes\QuoteResource;
 use Modules\Quotes\Filament\Company\Widgets\RecentQuotesWidget;
+use Modules\Subscriptions\Filament\Company\Resources\Subscriptions\SubscriptionResource;
 
 class CompanyPanelProvider extends PanelProvider
 {
@@ -167,6 +168,7 @@ class CompanyPanelProvider extends PanelProvider
                 ExpenseCategoryResource::class,
                 InvoiceResource::class,
                 PaymentResource::class,
+                SubscriptionResource::class,
                 ProductResource::class,
                 ProductUnitResource::class,
                 ProductCategoryResource::class,
@@ -218,6 +220,11 @@ class CompanyPanelProvider extends PanelProvider
                             //->icon('heroicon-o-banknotes')
                             ->items([
                                 ...self::withQuickCreate(InvoiceResource::class),
+                            ]),
+
+                        NavigationGroup::make('Subscriptions')
+                            ->items([
+                                ...self::withQuickCreate(SubscriptionResource::class),
                             ]),
 
                         NavigationGroup::make('Expenses')

--- a/Modules/Core/Providers/CoreServiceProvider.php
+++ b/Modules/Core/Providers/CoreServiceProvider.php
@@ -69,7 +69,11 @@ class CoreServiceProvider extends ServiceProvider
 
     protected function registerCommands(): void
     {
-        $this->commands([]);
+        $this->commands([
+            \Modules\Core\Commands\MigrateV1Command::class,
+            \Modules\Core\Commands\MakeUserCommand::class,
+            \Modules\Core\Commands\GenerateObservers::class,
+        ]);
     }
 
     protected function registerCommandSchedules(): void

--- a/Modules/Core/Services/EmailTemplateVariableResolver.php
+++ b/Modules/Core/Services/EmailTemplateVariableResolver.php
@@ -61,9 +61,11 @@ class EmailTemplateVariableResolver
     {
         $contacts = $client->contacts()->with('communications')->get();
 
-        return $contacts->firstWhere('default_to', true)
+        $contact = $contacts->firstWhere('default_to', true)
             ?? ($client->primary_contact_id ? $contacts->firstWhere('id', $client->primary_contact_id) : null)
             ?? $contacts->first();
+
+        return $contact instanceof Contact ? $contact : null;
     }
 
     protected function invoicingContactEmail(?Relation $client, ?Contact $contact): string

--- a/Modules/Core/Services/Migration/Contracts/EntityMigratorInterface.php
+++ b/Modules/Core/Services/Migration/Contracts/EntityMigratorInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Contracts;
+
+use Modules\Core\Services\Migration\MigrationContext;
+
+interface EntityMigratorInterface
+{
+    /**
+     * Name / identifier of this migrator (e.g. 'tax_rates', 'clients', 'invoices').
+     */
+    public function name(): string;
+
+    /**
+     * Human-readable label for UI / CLI progress reporting.
+     */
+    public function label(): string;
+
+    /**
+     * Inspect source data and count potential records and skipped/unmappable rows.
+     *
+     * @return array{source_count: int, will_migrate: int, unmappable: int, notes: array<string>}
+     */
+    public function inspect(MigrationContext $context): array;
+
+    /**
+     * Execute the migration for this entity.
+     *
+     * @return array{migrated: int, skipped: int, errors: array<string>}
+     */
+    public function migrate(MigrationContext $context): array;
+
+    /**
+     * Rollback records created by this migrator in the specified context batch.
+     */
+    public function rollback(MigrationContext $context): int;
+}

--- a/Modules/Core/Services/Migration/MigrationContext.php
+++ b/Modules/Core/Services/Migration/MigrationContext.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Modules\Core\Services\Migration;
+
+use Closure;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Collection;
+use Modules\Core\Models\Company;
+use Modules\Core\Models\User;
+
+class MigrationContext
+{
+    protected Company $company;
+    protected ?User $user = null;
+    protected bool $dryRun = false;
+    protected string $batchId;
+    protected string $tablePrefix = 'ip_';
+
+    /**
+     * @var array<string, array<string|int, int>>
+     */
+    protected array $idMap = [];
+
+    /**
+     * @var array<string, array<int>>
+     */
+    protected array $createdRecords = [];
+
+    /**
+     * @var array<string>
+     */
+    protected array $logs = [];
+
+    /**
+     * @var array<string>
+     */
+    protected array $warnings = [];
+
+    /**
+     * @var array<string>
+     */
+    protected array $errors = [];
+
+    /**
+     * @var array<string, Collection<int, array<string, mixed>>>
+     */
+    protected array $sourceTables = [];
+
+    protected ?ConnectionInterface $dbConnection = null;
+
+    /**
+     * @var ?Closure(string $status, string $message): void
+     */
+    protected ?Closure $progressCallback = null;
+
+    public function __construct(
+        Company $company,
+        ?User $user = null,
+        bool $dryRun = false,
+        ?string $batchId = null,
+        string $tablePrefix = 'ip_'
+    ) {
+        $this->company = $company;
+        $this->user = $user;
+        $this->dryRun = $dryRun;
+        $this->batchId = $batchId ?? ('v1_mig_' . date('YmdHis') . '_' . bin2hex(random_bytes(4)));
+        $this->tablePrefix = $tablePrefix;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function getCompanyId(): int
+    {
+        return $this->company->id;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function getUserId(): int
+    {
+        return $this->user?->id ?? 1;
+    }
+
+    public function isDryRun(): bool
+    {
+        return $this->dryRun;
+    }
+
+    public function setDryRun(bool $dryRun): self
+    {
+        $this->dryRun = $dryRun;
+        return $this;
+    }
+
+    public function getBatchId(): string
+    {
+        return $this->batchId;
+    }
+
+    public function getTablePrefix(): string
+    {
+        return $this->tablePrefix;
+    }
+
+    public function setDbConnection(?ConnectionInterface $connection): self
+    {
+        $this->dbConnection = $connection;
+        return $this;
+    }
+
+    public function getDbConnection(): ?ConnectionInterface
+    {
+        return $this->dbConnection;
+    }
+
+    /**
+     * Set source tables in-memory (e.g. from SQL dump parser).
+     *
+     * @param array<string, Collection<int, array<string, mixed>>|array<array<string, mixed>>> $tables
+     */
+    public function setSourceTables(array $tables): self
+    {
+        $this->sourceTables = [];
+        foreach ($tables as $name => $rows) {
+            $this->sourceTables[$name] = $rows instanceof Collection ? $rows : collect($rows);
+        }
+        return $this;
+    }
+
+    /**
+     * Get records from a source v1 table (without prefix or with prefix).
+     *
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function getSourceTable(string $table): Collection
+    {
+        $cleanName = str_starts_with($table, $this->tablePrefix)
+            ? substr($table, strlen($this->tablePrefix))
+            : $table;
+
+        $fullName = $this->tablePrefix . $cleanName;
+
+        // In-memory parsed tables
+        if (isset($this->sourceTables[$fullName])) {
+            return $this->sourceTables[$fullName];
+        }
+
+        if (isset($this->sourceTables[$cleanName])) {
+            return $this->sourceTables[$cleanName];
+        }
+
+        // Direct DB connection
+        if ($this->dbConnection) {
+            try {
+                $rows = $this->dbConnection->table($fullName)->get();
+                return collect($rows)->map(fn ($r) => (array) $r);
+            } catch (\Throwable $e) {
+                // Try clean name if prefixed failed
+                try {
+                    $rows = $this->dbConnection->table($cleanName)->get();
+                    return collect($rows)->map(fn ($r) => (array) $r);
+                } catch (\Throwable) {
+                    return collect();
+                }
+            }
+        }
+
+        return collect();
+    }
+
+    public function hasSourceTable(string $table): bool
+    {
+        $cleanName = str_starts_with($table, $this->tablePrefix)
+            ? substr($table, strlen($this->tablePrefix))
+            : $table;
+
+        $fullName = $this->tablePrefix . $cleanName;
+
+        if (isset($this->sourceTables[$fullName]) || isset($this->sourceTables[$cleanName])) {
+            return true;
+        }
+
+        if ($this->dbConnection) {
+            try {
+                return $this->dbConnection->getSchemaBuilder()->hasTable($fullName)
+                    || $this->dbConnection->getSchemaBuilder()->hasTable($cleanName);
+            } catch (\Throwable) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    public function mapId(string $entity, int|string $v1Id, int $v2Id): void
+    {
+        $this->idMap[$entity][(string) $v1Id] = $v2Id;
+    }
+
+    public function getId(string $entity, int|string|null $v1Id): ?int
+    {
+        if ($v1Id === null || $v1Id === '') {
+            return null;
+        }
+        return $this->idMap[$entity][(string) $v1Id] ?? null;
+    }
+
+    public function hasId(string $entity, int|string $v1Id): bool
+    {
+        return isset($this->idMap[$entity][(string) $v1Id]);
+    }
+
+    public function recordCreated(string $modelClass, int $id): void
+    {
+        $this->createdRecords[$modelClass][] = $id;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getCreatedIds(string $modelClass): array
+    {
+        return $this->createdRecords[$modelClass] ?? [];
+    }
+
+    /**
+     * @return array<string, array<int>>
+     */
+    public function getAllCreatedRecords(): array
+    {
+        return $this->createdRecords;
+    }
+
+    public function log(string $message): void
+    {
+        $this->logs[] = '[' . date('H:i:s') . '] ' . $message;
+        if ($this->progressCallback) {
+            ($this->progressCallback)('info', $message);
+        }
+    }
+
+    public function warn(string $warning): void
+    {
+        $this->warnings[] = $warning;
+        if ($this->progressCallback) {
+            ($this->progressCallback)('warning', $warning);
+        }
+    }
+
+    public function error(string $error): void
+    {
+        $this->errors[] = $error;
+        if ($this->progressCallback) {
+            ($this->progressCallback)('error', $error);
+        }
+    }
+
+    public function setProgressCallback(?Closure $callback): self
+    {
+        $this->progressCallback = $callback;
+        return $this;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getLogs(): array
+    {
+        return $this->logs;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getWarnings(): array
+    {
+        return $this->warnings;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/Modules/Core/Services/Migration/MigrationContext.php
+++ b/Modules/Core/Services/Migration/MigrationContext.php
@@ -7,13 +7,18 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Collection;
 use Modules\Core\Models\Company;
 use Modules\Core\Models\User;
+use Throwable;
 
 class MigrationContext
 {
     protected Company $company;
+
     protected ?User $user = null;
+
     protected bool $dryRun = false;
+
     protected string $batchId;
+
     protected string $tablePrefix = 'ip_';
 
     /**
@@ -49,7 +54,7 @@ class MigrationContext
     protected ?ConnectionInterface $dbConnection = null;
 
     /**
-     * @var ?Closure(string $status, string $message): void
+     * @var ?Closure(string, string): void
      */
     protected ?Closure $progressCallback = null;
 
@@ -60,10 +65,10 @@ class MigrationContext
         ?string $batchId = null,
         string $tablePrefix = 'ip_'
     ) {
-        $this->company = $company;
-        $this->user = $user;
-        $this->dryRun = $dryRun;
-        $this->batchId = $batchId ?? ('v1_mig_' . date('YmdHis') . '_' . bin2hex(random_bytes(4)));
+        $this->company     = $company;
+        $this->user        = $user;
+        $this->dryRun      = $dryRun;
+        $this->batchId     = $batchId ?? ('v1_mig_' . date('YmdHis') . '_' . bin2hex(random_bytes(4)));
         $this->tablePrefix = $tablePrefix;
     }
 
@@ -95,6 +100,7 @@ class MigrationContext
     public function setDryRun(bool $dryRun): self
     {
         $this->dryRun = $dryRun;
+
         return $this;
     }
 
@@ -111,6 +117,7 @@ class MigrationContext
     public function setDbConnection(?ConnectionInterface $connection): self
     {
         $this->dbConnection = $connection;
+
         return $this;
     }
 
@@ -130,6 +137,7 @@ class MigrationContext
         foreach ($tables as $name => $rows) {
             $this->sourceTables[$name] = $rows instanceof Collection ? $rows : collect($rows);
         }
+
         return $this;
     }
 
@@ -141,7 +149,7 @@ class MigrationContext
     public function getSourceTable(string $table): Collection
     {
         $cleanName = str_starts_with($table, $this->tablePrefix)
-            ? substr($table, strlen($this->tablePrefix))
+            ? mb_substr($table, mb_strlen($this->tablePrefix))
             : $table;
 
         $fullName = $this->tablePrefix . $cleanName;
@@ -159,13 +167,15 @@ class MigrationContext
         if ($this->dbConnection) {
             try {
                 $rows = $this->dbConnection->table($fullName)->get();
+
                 return collect($rows)->map(fn ($r) => (array) $r);
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 // Try clean name if prefixed failed
                 try {
                     $rows = $this->dbConnection->table($cleanName)->get();
+
                     return collect($rows)->map(fn ($r) => (array) $r);
-                } catch (\Throwable) {
+                } catch (Throwable) {
                     return collect();
                 }
             }
@@ -177,7 +187,7 @@ class MigrationContext
     public function hasSourceTable(string $table): bool
     {
         $cleanName = str_starts_with($table, $this->tablePrefix)
-            ? substr($table, strlen($this->tablePrefix))
+            ? mb_substr($table, mb_strlen($this->tablePrefix))
             : $table;
 
         $fullName = $this->tablePrefix . $cleanName;
@@ -190,7 +200,7 @@ class MigrationContext
             try {
                 return $this->dbConnection->getSchemaBuilder()->hasTable($fullName)
                     || $this->dbConnection->getSchemaBuilder()->hasTable($cleanName);
-            } catch (\Throwable) {
+            } catch (Throwable) {
                 return false;
             }
         }
@@ -208,6 +218,7 @@ class MigrationContext
         if ($v1Id === null || $v1Id === '') {
             return null;
         }
+
         return $this->idMap[$entity][(string) $v1Id] ?? null;
     }
 
@@ -264,6 +275,7 @@ class MigrationContext
     public function setProgressCallback(?Closure $callback): self
     {
         $this->progressCallback = $callback;
+
         return $this;
     }
 

--- a/Modules/Core/Services/Migration/Migrators/ClientMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/ClientMigrator.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Migrators;
+
+use Modules\Clients\Enums\RelationStatus;
+use Modules\Clients\Enums\RelationType;
+use Modules\Clients\Models\Address;
+use Modules\Clients\Models\Communication;
+use Modules\Clients\Models\Contact;
+use Modules\Clients\Models\Relation;
+use Modules\Core\Enums\AddressType;
+use Modules\Core\Enums\CommunicationType;
+use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
+use Modules\Core\Services\Migration\MigrationContext;
+
+class ClientMigrator implements EntityMigratorInterface
+{
+    public function name(): string
+    {
+        return 'clients';
+    }
+
+    public function label(): string
+    {
+        return 'Clients';
+    }
+
+    public function inspect(MigrationContext $context): array
+    {
+        $rows = $context->getSourceTable('clients');
+        $notes = [];
+        $willMigrate = 0;
+        $unmappable = 0;
+
+        foreach ($rows as $row) {
+            $name = trim((string) ($row['client_name'] ?? ''));
+            $surname = trim((string) ($row['client_surname'] ?? ''));
+
+            if ($name === '' && $surname === '') {
+                $unmappable++;
+                $notes[] = "Client row #{$row['client_id']} has empty name and surname, will be skipped.";
+            } else {
+                $willMigrate++;
+            }
+        }
+
+        return [
+            'source_count' => $rows->count(),
+            'will_migrate' => $willMigrate,
+            'unmappable'   => $unmappable,
+            'notes'        => $notes,
+        ];
+    }
+
+    public function migrate(MigrationContext $context): array
+    {
+        $rows = $context->getSourceTable('clients');
+        $migrated = 0;
+        $skipped = 0;
+        $errors = [];
+
+        foreach ($rows as $row) {
+            $v1Id = $row['client_id'] ?? null;
+            $name = trim((string) ($row['client_name'] ?? ''));
+            $surname = trim((string) ($row['client_surname'] ?? ''));
+
+            if ($name === '' && $surname === '') {
+                $skipped++;
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                if ($v1Id !== null) {
+                    $context->mapId('clients', $v1Id, (int) $v1Id);
+                }
+                $migrated++;
+                continue;
+            }
+
+            try {
+                $displayName = $name !== '' ? $name : $surname;
+                $active = (bool) ($row['client_active'] ?? true);
+                $vatId = !empty($row['client_vat_id']) ? (string) $row['client_vat_id'] : null;
+                $taxCode = !empty($row['client_tax_code']) ? (string) $row['client_tax_code'] : null;
+                $website = !empty($row['client_web']) ? (string) $row['client_web'] : null;
+                $language = !empty($row['client_language']) ? (string) $row['client_language'] : 'en';
+
+                // Check existing relation by name/number
+                $relation = Relation::withoutGlobalScopes()
+                    ->where('company_id', $context->getCompanyId())
+                    ->where('company_name', $displayName)
+                    ->first();
+
+                if (!$relation) {
+                    $relation = Relation::create([
+                        'company_id'      => $context->getCompanyId(),
+                        'company_name'    => $displayName,
+                        'trading_name'    => $displayName,
+                        'relation_type'   => RelationType::CUSTOMER,
+                        'relation_status' => $active ? RelationStatus::ACTIVE : RelationStatus::INACTIVE,
+                        'relation_number' => 'CST-' . str_pad((string) ($v1Id ?? rand(100, 9999)), 5, '0', STR_PAD_LEFT),
+                        'vat_number'      => $vatId,
+                        'id_number'       => $taxCode,
+                        'language'        => $language,
+                        'registered_at'   => !empty($row['client_date_created']) ? date('Y-m-d', strtotime($row['client_date_created'])) : date('Y-m-d'),
+                    ]);
+                    $context->recordCreated(Relation::class, $relation->id);
+                }
+
+                if ($v1Id !== null) {
+                    $context->mapId('clients', $v1Id, $relation->id);
+                }
+
+                // Create or find Primary Contact
+                $firstName = $name !== '' ? $name : 'Client';
+                $lastName = $surname !== '' ? $surname : ($name !== '' ? $name : 'Client');
+
+                $contact = Contact::withoutGlobalScopes()
+                    ->where('company_id', $context->getCompanyId())
+                    ->where('relation_id', $relation->id)
+                    ->first();
+
+                if (!$contact) {
+                    $contact = Contact::create([
+                        'company_id'  => $context->getCompanyId(),
+                        'relation_id' => $relation->id,
+                        'first_name'  => $firstName,
+                        'last_name'   => $lastName,
+                        'default_to'  => true,
+                    ]);
+                    $context->recordCreated(Contact::class, $contact->id);
+
+                    // Link primary contact on relation
+                    $relation->primary_contact_id = $contact->id;
+                    $relation->saveQuietly();
+                }
+
+                // Communications (email, phone, mobile, fax)
+                $this->syncContactCommunications($context, $contact, $row);
+
+                // Address
+                $this->syncRelationAddress($context, $relation, $row);
+
+                $migrated++;
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate client #{$v1Id} '{$name}': " . $e->getMessage();
+                $skipped++;
+            }
+        }
+
+        $context->log("Migrated {$migrated} clients ({$skipped} skipped).");
+
+        return [
+            'migrated' => $migrated,
+            'skipped'  => $skipped,
+            'errors'   => $errors,
+        ];
+    }
+
+    protected function syncContactCommunications(MigrationContext $context, Contact $contact, array $row): void
+    {
+        $email = trim((string) ($row['client_email'] ?? ''));
+        $phone = trim((string) ($row['client_phone'] ?? ''));
+        $mobile = trim((string) ($row['client_mobile'] ?? ''));
+        $fax = trim((string) ($row['client_fax'] ?? ''));
+
+        if ($email !== '') {
+            $comm = Communication::create([
+                'company_id'             => $context->getCompanyId(),
+                'communicationable_type' => Contact::class,
+                'communicationable_id'   => $contact->id,
+                'communication_type'     => CommunicationType::EMAIL->value,
+                'is_primary'             => true,
+                'communication_value'    => $email,
+            ]);
+            $context->recordCreated(Communication::class, $comm->id);
+        }
+
+        if ($phone !== '') {
+            $comm = Communication::create([
+                'company_id'             => $context->getCompanyId(),
+                'communicationable_type' => Contact::class,
+                'communicationable_id'   => $contact->id,
+                'communication_type'     => CommunicationType::PHONE->value,
+                'is_primary'             => true,
+                'communication_value'    => $phone,
+            ]);
+            $context->recordCreated(Communication::class, $comm->id);
+        }
+
+        if ($mobile !== '') {
+            $comm = Communication::create([
+                'company_id'             => $context->getCompanyId(),
+                'communicationable_type' => Contact::class,
+                'communicationable_id'   => $contact->id,
+                'communication_type'     => CommunicationType::MOBILE->value,
+                'is_primary'             => $phone === '',
+                'communication_value'    => $mobile,
+            ]);
+            $context->recordCreated(Communication::class, $comm->id);
+        }
+
+        if ($fax !== '') {
+            $comm = Communication::create([
+                'company_id'             => $context->getCompanyId(),
+                'communicationable_type' => Contact::class,
+                'communicationable_id'   => $contact->id,
+                'communication_type'     => CommunicationType::FAX->value,
+                'is_primary'             => false,
+                'communication_value'    => $fax,
+            ]);
+            $context->recordCreated(Communication::class, $comm->id);
+        }
+    }
+
+    protected function syncRelationAddress(MigrationContext $context, Relation $relation, array $row): void
+    {
+        $addr1 = trim((string) ($row['client_address_1'] ?? ''));
+        $addr2 = trim((string) ($row['client_address_2'] ?? ''));
+        $city = trim((string) ($row['client_city'] ?? ''));
+        $state = trim((string) ($row['client_state'] ?? ''));
+        $zip = trim((string) ($row['client_zip'] ?? ''));
+        $country = trim((string) ($row['client_country'] ?? ''));
+
+        if ($addr1 !== '' || $city !== '' || $zip !== '' || $country !== '') {
+            $addr = Address::create([
+                'company_id'        => $context->getCompanyId(),
+                'addressable_type'  => Relation::class,
+                'addressable_id'    => $relation->id,
+                'address_type'      => AddressType::BILLING->value,
+                'address_1'         => $addr1 ?: null,
+                'address_2'         => $addr2 ?: null,
+                'city'              => $city ?: 'Unknown',
+                'state_or_province' => $state ?: null,
+                'postal_code'       => $zip ?: '',
+                'country'           => $country ?: 'US',
+                'is_primary'        => true,
+            ]);
+            $context->recordCreated(Address::class, $addr->id);
+        }
+    }
+
+    public function rollback(MigrationContext $context): int
+    {
+        $relationIds = $context->getCreatedIds(Relation::class);
+        $contactIds = $context->getCreatedIds(Contact::class);
+        $addrIds = $context->getCreatedIds(Address::class);
+        $commIds = $context->getCreatedIds(Communication::class);
+
+        if (!empty($commIds)) {
+            Communication::withoutGlobalScopes()->whereIn('id', $commIds)->delete();
+        }
+        if (!empty($addrIds)) {
+            Address::withoutGlobalScopes()->whereIn('id', $addrIds)->delete();
+        }
+        if (!empty($contactIds)) {
+            Contact::withoutGlobalScopes()->whereIn('id', $contactIds)->delete();
+        }
+
+        if (empty($relationIds)) {
+            return 0;
+        }
+
+        return Relation::withoutGlobalScopes()
+            ->whereIn('id', $relationIds)
+            ->where('company_id', $context->getCompanyId())
+            ->forceDelete();
+    }
+}

--- a/Modules/Core/Services/Migration/Migrators/ClientMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/ClientMigrator.php
@@ -12,6 +12,7 @@ use Modules\Core\Enums\AddressType;
 use Modules\Core\Enums\CommunicationType;
 use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
 use Modules\Core\Services\Migration\MigrationContext;
+use Throwable;
 
 class ClientMigrator implements EntityMigratorInterface
 {
@@ -27,14 +28,14 @@ class ClientMigrator implements EntityMigratorInterface
 
     public function inspect(MigrationContext $context): array
     {
-        $rows = $context->getSourceTable('clients');
-        $notes = [];
+        $rows        = $context->getSourceTable('clients');
+        $notes       = [];
         $willMigrate = 0;
-        $unmappable = 0;
+        $unmappable  = 0;
 
         foreach ($rows as $row) {
-            $name = trim((string) ($row['client_name'] ?? ''));
-            $surname = trim((string) ($row['client_surname'] ?? ''));
+            $name    = mb_trim((string) ($row['client_name'] ?? ''));
+            $surname = mb_trim((string) ($row['client_surname'] ?? ''));
 
             if ($name === '' && $surname === '') {
                 $unmappable++;
@@ -54,15 +55,15 @@ class ClientMigrator implements EntityMigratorInterface
 
     public function migrate(MigrationContext $context): array
     {
-        $rows = $context->getSourceTable('clients');
+        $rows     = $context->getSourceTable('clients');
         $migrated = 0;
-        $skipped = 0;
-        $errors = [];
+        $skipped  = 0;
+        $errors   = [];
 
         foreach ($rows as $row) {
-            $v1Id = $row['client_id'] ?? null;
-            $name = trim((string) ($row['client_name'] ?? ''));
-            $surname = trim((string) ($row['client_surname'] ?? ''));
+            $v1Id    = $row['client_id'] ?? null;
+            $name    = mb_trim((string) ($row['client_name'] ?? ''));
+            $surname = mb_trim((string) ($row['client_surname'] ?? ''));
 
             if ($name === '' && $surname === '') {
                 $skipped++;
@@ -79,11 +80,11 @@ class ClientMigrator implements EntityMigratorInterface
 
             try {
                 $displayName = $name !== '' ? $name : $surname;
-                $active = (bool) ($row['client_active'] ?? true);
-                $vatId = !empty($row['client_vat_id']) ? (string) $row['client_vat_id'] : null;
-                $taxCode = !empty($row['client_tax_code']) ? (string) $row['client_tax_code'] : null;
-                $website = !empty($row['client_web']) ? (string) $row['client_web'] : null;
-                $language = !empty($row['client_language']) ? (string) $row['client_language'] : 'en';
+                $active      = (bool) ($row['client_active'] ?? true);
+                $vatId       = ! empty($row['client_vat_id']) ? (string) $row['client_vat_id'] : null;
+                $taxCode     = ! empty($row['client_tax_code']) ? (string) $row['client_tax_code'] : null;
+                $website     = ! empty($row['client_web']) ? (string) $row['client_web'] : null;
+                $language    = ! empty($row['client_language']) ? (string) $row['client_language'] : 'en';
 
                 // Check existing relation by name/number
                 $relation = Relation::withoutGlobalScopes()
@@ -91,18 +92,18 @@ class ClientMigrator implements EntityMigratorInterface
                     ->where('company_name', $displayName)
                     ->first();
 
-                if (!$relation) {
+                if ( ! $relation) {
                     $relation = Relation::create([
                         'company_id'      => $context->getCompanyId(),
                         'company_name'    => $displayName,
                         'trading_name'    => $displayName,
                         'relation_type'   => RelationType::CUSTOMER,
                         'relation_status' => $active ? RelationStatus::ACTIVE : RelationStatus::INACTIVE,
-                        'relation_number' => 'CST-' . str_pad((string) ($v1Id ?? rand(100, 9999)), 5, '0', STR_PAD_LEFT),
+                        'relation_number' => 'CST-' . mb_str_pad((string) ($v1Id ?? rand(100, 9999)), 5, '0', STR_PAD_LEFT),
                         'vat_number'      => $vatId,
                         'id_number'       => $taxCode,
                         'language'        => $language,
-                        'registered_at'   => !empty($row['client_date_created']) ? date('Y-m-d', strtotime($row['client_date_created'])) : date('Y-m-d'),
+                        'registered_at'   => ! empty($row['client_date_created']) ? date('Y-m-d', strtotime($row['client_date_created'])) : date('Y-m-d'),
                     ]);
                     $context->recordCreated(Relation::class, $relation->id);
                 }
@@ -113,14 +114,14 @@ class ClientMigrator implements EntityMigratorInterface
 
                 // Create or find Primary Contact
                 $firstName = $name !== '' ? $name : 'Client';
-                $lastName = $surname !== '' ? $surname : ($name !== '' ? $name : 'Client');
+                $lastName  = $surname !== '' ? $surname : ($name !== '' ? $name : 'Client');
 
                 $contact = Contact::withoutGlobalScopes()
                     ->where('company_id', $context->getCompanyId())
                     ->where('relation_id', $relation->id)
                     ->first();
 
-                if (!$contact) {
+                if ( ! $contact) {
                     $contact = Contact::create([
                         'company_id'  => $context->getCompanyId(),
                         'relation_id' => $relation->id,
@@ -142,7 +143,7 @@ class ClientMigrator implements EntityMigratorInterface
                 $this->syncRelationAddress($context, $relation, $row);
 
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = "Failed to migrate client #{$v1Id} '{$name}': " . $e->getMessage();
                 $skipped++;
             }
@@ -157,12 +158,39 @@ class ClientMigrator implements EntityMigratorInterface
         ];
     }
 
+    public function rollback(MigrationContext $context): int
+    {
+        $relationIds = $context->getCreatedIds(Relation::class);
+        $contactIds  = $context->getCreatedIds(Contact::class);
+        $addrIds     = $context->getCreatedIds(Address::class);
+        $commIds     = $context->getCreatedIds(Communication::class);
+
+        if ( ! empty($commIds)) {
+            Communication::withoutGlobalScopes()->whereIn('id', $commIds)->delete();
+        }
+        if ( ! empty($addrIds)) {
+            Address::withoutGlobalScopes()->whereIn('id', $addrIds)->delete();
+        }
+        if ( ! empty($contactIds)) {
+            Contact::withoutGlobalScopes()->whereIn('id', $contactIds)->delete();
+        }
+
+        if (empty($relationIds)) {
+            return 0;
+        }
+
+        return Relation::withoutGlobalScopes()
+            ->whereIn('id', $relationIds)
+            ->where('company_id', $context->getCompanyId())
+            ->forceDelete();
+    }
+
     protected function syncContactCommunications(MigrationContext $context, Contact $contact, array $row): void
     {
-        $email = trim((string) ($row['client_email'] ?? ''));
-        $phone = trim((string) ($row['client_phone'] ?? ''));
-        $mobile = trim((string) ($row['client_mobile'] ?? ''));
-        $fax = trim((string) ($row['client_fax'] ?? ''));
+        $email  = mb_trim((string) ($row['client_email'] ?? ''));
+        $phone  = mb_trim((string) ($row['client_phone'] ?? ''));
+        $mobile = mb_trim((string) ($row['client_mobile'] ?? ''));
+        $fax    = mb_trim((string) ($row['client_fax'] ?? ''));
 
         if ($email !== '') {
             $comm = Communication::create([
@@ -215,12 +243,12 @@ class ClientMigrator implements EntityMigratorInterface
 
     protected function syncRelationAddress(MigrationContext $context, Relation $relation, array $row): void
     {
-        $addr1 = trim((string) ($row['client_address_1'] ?? ''));
-        $addr2 = trim((string) ($row['client_address_2'] ?? ''));
-        $city = trim((string) ($row['client_city'] ?? ''));
-        $state = trim((string) ($row['client_state'] ?? ''));
-        $zip = trim((string) ($row['client_zip'] ?? ''));
-        $country = trim((string) ($row['client_country'] ?? ''));
+        $addr1   = mb_trim((string) ($row['client_address_1'] ?? ''));
+        $addr2   = mb_trim((string) ($row['client_address_2'] ?? ''));
+        $city    = mb_trim((string) ($row['client_city'] ?? ''));
+        $state   = mb_trim((string) ($row['client_state'] ?? ''));
+        $zip     = mb_trim((string) ($row['client_zip'] ?? ''));
+        $country = mb_trim((string) ($row['client_country'] ?? ''));
 
         if ($addr1 !== '' || $city !== '' || $zip !== '' || $country !== '') {
             $addr = Address::create([
@@ -238,32 +266,5 @@ class ClientMigrator implements EntityMigratorInterface
             ]);
             $context->recordCreated(Address::class, $addr->id);
         }
-    }
-
-    public function rollback(MigrationContext $context): int
-    {
-        $relationIds = $context->getCreatedIds(Relation::class);
-        $contactIds = $context->getCreatedIds(Contact::class);
-        $addrIds = $context->getCreatedIds(Address::class);
-        $commIds = $context->getCreatedIds(Communication::class);
-
-        if (!empty($commIds)) {
-            Communication::withoutGlobalScopes()->whereIn('id', $commIds)->delete();
-        }
-        if (!empty($addrIds)) {
-            Address::withoutGlobalScopes()->whereIn('id', $addrIds)->delete();
-        }
-        if (!empty($contactIds)) {
-            Contact::withoutGlobalScopes()->whereIn('id', $contactIds)->delete();
-        }
-
-        if (empty($relationIds)) {
-            return 0;
-        }
-
-        return Relation::withoutGlobalScopes()
-            ->whereIn('id', $relationIds)
-            ->where('company_id', $context->getCompanyId())
-            ->forceDelete();
     }
 }

--- a/Modules/Core/Services/Migration/Migrators/CustomFieldMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/CustomFieldMigrator.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Migrators;
+
+use Modules\Clients\Models\Relation;
+use Modules\Core\Models\CustomField;
+use Modules\Core\Models\CustomFieldValue;
+use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
+use Modules\Core\Services\Migration\MigrationContext;
+use Modules\Invoices\Models\Invoice;
+use Modules\Quotes\Models\Quote;
+
+class CustomFieldMigrator implements EntityMigratorInterface
+{
+    public function name(): string
+    {
+        return 'custom_fields';
+    }
+
+    public function label(): string
+    {
+        return 'Custom Fields & Values';
+    }
+
+    public function inspect(MigrationContext $context): array
+    {
+        $fields = $context->getSourceTable('custom_fields');
+        return [
+            'source_count' => $fields->count(),
+            'will_migrate' => $fields->count(),
+            'unmappable'   => 0,
+            'notes'        => [],
+        ];
+    }
+
+    public function migrate(MigrationContext $context): array
+    {
+        $fields = $context->getSourceTable('custom_fields');
+        $migrated = 0;
+        $skipped = 0;
+        $errors = [];
+
+        foreach ($fields as $row) {
+            $v1Id = $row['custom_field_id'] ?? null;
+            $table = trim((string) ($row['custom_field_table'] ?? ''));
+            $label = trim((string) ($row['custom_field_label'] ?? ''));
+
+            if ($label === '') {
+                $skipped++;
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                if ($v1Id !== null) {
+                    $context->mapId('custom_fields', $v1Id, (int) $v1Id);
+                }
+                $migrated++;
+                continue;
+            }
+
+            try {
+                $fieldableType = match (strtolower($table)) {
+                    'ip_invoice_custom', 'invoices' => Invoice::class,
+                    'ip_quote_custom', 'quotes'     => Quote::class,
+                    default                         => Relation::class,
+                };
+
+                $customField = CustomField::withoutGlobalScopes()
+                    ->where('company_id', $context->getCompanyId())
+                    ->where('fieldable_type', $fieldableType)
+                    ->where('custom_field_label', $label)
+                    ->first();
+
+                if (!$customField) {
+                    $customField = CustomField::create([
+                        'company_id'         => $context->getCompanyId(),
+                        'fieldable_type'     => $fieldableType,
+                        'custom_field_label' => $label,
+                        'field_type'         => 'text',
+                        'field_order'        => (int) ($row['custom_field_order'] ?? 1),
+                    ]);
+                    $context->recordCreated(CustomField::class, $customField->id);
+                }
+
+                if ($v1Id !== null) {
+                    $context->mapId('custom_fields', $v1Id, $customField->id);
+                }
+
+                $migrated++;
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate custom field '{$label}': " . $e->getMessage();
+                $skipped++;
+            }
+        }
+
+        $context->log("Migrated {$migrated} custom fields ({$skipped} skipped).");
+
+        return [
+            'migrated' => $migrated,
+            'skipped'  => $skipped,
+            'errors'   => $errors,
+        ];
+    }
+
+    public function rollback(MigrationContext $context): int
+    {
+        $valIds = $context->getCreatedIds(CustomFieldValue::class);
+        $fieldIds = $context->getCreatedIds(CustomField::class);
+
+        if (!empty($valIds)) {
+            CustomFieldValue::withoutGlobalScopes()->whereIn('id', $valIds)->delete();
+        }
+
+        if (empty($fieldIds)) {
+            return 0;
+        }
+
+        return CustomField::withoutGlobalScopes()
+            ->whereIn('id', $fieldIds)
+            ->where('company_id', $context->getCompanyId())
+            ->delete();
+    }
+}

--- a/Modules/Core/Services/Migration/Migrators/CustomFieldMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/CustomFieldMigrator.php
@@ -9,6 +9,7 @@ use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
 use Modules\Core\Services\Migration\MigrationContext;
 use Modules\Invoices\Models\Invoice;
 use Modules\Quotes\Models\Quote;
+use Throwable;
 
 class CustomFieldMigrator implements EntityMigratorInterface
 {
@@ -25,6 +26,7 @@ class CustomFieldMigrator implements EntityMigratorInterface
     public function inspect(MigrationContext $context): array
     {
         $fields = $context->getSourceTable('custom_fields');
+
         return [
             'source_count' => $fields->count(),
             'will_migrate' => $fields->count(),
@@ -35,15 +37,15 @@ class CustomFieldMigrator implements EntityMigratorInterface
 
     public function migrate(MigrationContext $context): array
     {
-        $fields = $context->getSourceTable('custom_fields');
+        $fields   = $context->getSourceTable('custom_fields');
         $migrated = 0;
-        $skipped = 0;
-        $errors = [];
+        $skipped  = 0;
+        $errors   = [];
 
         foreach ($fields as $row) {
-            $v1Id = $row['custom_field_id'] ?? null;
-            $table = trim((string) ($row['custom_field_table'] ?? ''));
-            $label = trim((string) ($row['custom_field_label'] ?? ''));
+            $v1Id  = $row['custom_field_id'] ?? null;
+            $table = mb_trim((string) ($row['custom_field_table'] ?? ''));
+            $label = mb_trim((string) ($row['custom_field_label'] ?? ''));
 
             if ($label === '') {
                 $skipped++;
@@ -59,10 +61,10 @@ class CustomFieldMigrator implements EntityMigratorInterface
             }
 
             try {
-                $fieldableType = match (strtolower($table)) {
+                $fieldableType = match (mb_strtolower($table)) {
                     'ip_invoice_custom', 'invoices' => Invoice::class,
-                    'ip_quote_custom', 'quotes'     => Quote::class,
-                    default                         => Relation::class,
+                    'ip_quote_custom', 'quotes' => Quote::class,
+                    default => Relation::class,
                 };
 
                 $customField = CustomField::withoutGlobalScopes()
@@ -71,7 +73,7 @@ class CustomFieldMigrator implements EntityMigratorInterface
                     ->where('custom_field_label', $label)
                     ->first();
 
-                if (!$customField) {
+                if ( ! $customField) {
                     $customField = CustomField::create([
                         'company_id'         => $context->getCompanyId(),
                         'fieldable_type'     => $fieldableType,
@@ -87,7 +89,7 @@ class CustomFieldMigrator implements EntityMigratorInterface
                 }
 
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = "Failed to migrate custom field '{$label}': " . $e->getMessage();
                 $skipped++;
             }
@@ -104,10 +106,10 @@ class CustomFieldMigrator implements EntityMigratorInterface
 
     public function rollback(MigrationContext $context): int
     {
-        $valIds = $context->getCreatedIds(CustomFieldValue::class);
+        $valIds   = $context->getCreatedIds(CustomFieldValue::class);
         $fieldIds = $context->getCreatedIds(CustomField::class);
 
-        if (!empty($valIds)) {
+        if ( ! empty($valIds)) {
             CustomFieldValue::withoutGlobalScopes()->whereIn('id', $valIds)->delete();
         }
 

--- a/Modules/Core/Services/Migration/Migrators/InvoiceMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/InvoiceMigrator.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Migrators;
+
+use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
+use Modules\Core\Services\Migration\MigrationContext;
+use Modules\Invoices\Enums\InvoiceStatus;
+use Modules\Invoices\Models\Invoice;
+use Modules\Invoices\Models\InvoiceItem;
+
+class InvoiceMigrator implements EntityMigratorInterface
+{
+    public function name(): string
+    {
+        return 'invoices';
+    }
+
+    public function label(): string
+    {
+        return 'Invoices & Items';
+    }
+
+    public function inspect(MigrationContext $context): array
+    {
+        $invoices = $context->getSourceTable('invoices');
+        $items = $context->getSourceTable('invoice_items');
+        $notes = [];
+        $willMigrate = 0;
+        $unmappable = 0;
+
+        foreach ($invoices as $row) {
+            $clientId = $row['client_id'] ?? null;
+            if (!$clientId) {
+                $unmappable++;
+                $notes[] = "Invoice #{$row['invoice_number']} has no client_id, will be skipped.";
+            } else {
+                $willMigrate++;
+            }
+        }
+
+        return [
+            'source_count' => $invoices->count(),
+            'will_migrate' => $willMigrate,
+            'unmappable'   => $unmappable,
+            'notes'        => $notes,
+        ];
+    }
+
+    public function migrate(MigrationContext $context): array
+    {
+        $invoices = $context->getSourceTable('invoices');
+        $items = $context->getSourceTable('invoice_items')->groupBy('invoice_id');
+        $amounts = $context->getSourceTable('invoice_amounts')->keyBy('invoice_id');
+        $taxRates = $context->getSourceTable('invoice_tax_rates')->groupBy('invoice_id');
+
+        $migrated = 0;
+        $skipped = 0;
+        $errors = [];
+
+        foreach ($invoices as $row) {
+            $v1Id = $row['invoice_id'] ?? null;
+            $v1ClientId = $row['client_id'] ?? null;
+            $invoiceNumber = trim((string) ($row['invoice_number'] ?? ''));
+
+            $customerId = $context->getId('clients', $v1ClientId);
+            if (!$customerId) {
+                $errors[] = "Invoice #{$invoiceNumber} skipped: client #{$v1ClientId} not found in target company.";
+                $skipped++;
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                if ($v1Id !== null) {
+                    $context->mapId('invoices', $v1Id, (int) $v1Id);
+                }
+                $migrated++;
+                continue;
+            }
+
+            try {
+                $v1Amount = $amounts[$v1Id] ?? [];
+                $status = $this->resolveStatus($row, $v1Amount);
+
+                $itemSubtotal = (float) ($v1Amount['invoice_item_subtotal'] ?? 0.0);
+                $itemTaxTotal = (float) ($v1Amount['invoice_item_tax_total'] ?? 0.0);
+                $taxTotal = (float) ($v1Amount['invoice_tax_total'] ?? 0.0);
+                $total = (float) ($v1Amount['invoice_total'] ?? 0.0);
+
+                // Prevent duplicate invoice number in same company
+                $invoice = Invoice::withoutGlobalScopes()
+                    ->where('company_id', $context->getCompanyId())
+                    ->where('invoice_number', $invoiceNumber)
+                    ->first();
+
+                if (!$invoice) {
+                    $invoice = Invoice::create([
+                        'company_id'               => $context->getCompanyId(),
+                        'customer_id'              => $customerId,
+                        'user_id'                  => $context->getUserId(),
+                        'invoice_number'           => $invoiceNumber ?: ('INV-' . $v1Id),
+                        'invoice_status'           => $status,
+                        'invoice_sign'             => (string) ($v1Amount['invoice_sign'] ?? '1'),
+                        'invoiced_at'              => !empty($row['invoice_date_created']) ? $row['invoice_date_created'] : now(),
+                        'invoice_due_at'           => !empty($row['invoice_date_due']) ? $row['invoice_date_due'] : now()->addDays(30),
+                        'invoice_discount_amount'  => (float) ($row['invoice_discount_amount'] ?? 0.0),
+                        'invoice_discount_percent' => (float) ($row['invoice_discount_percent'] ?? 0.0),
+                        'invoice_item_subtotal'    => $itemSubtotal,
+                        'item_tax_total'           => $itemTaxTotal,
+                        'invoice_tax_total'        => $taxTotal,
+                        'invoice_total'            => $total,
+                        'invoice_password'         => !empty($row['invoice_password']) ? (string) $row['invoice_password'] : null,
+                        'url_key'                  => !empty($row['invoice_url_key']) ? (string) $row['invoice_url_key'] : null,
+                        'is_read_only'             => (bool) ($row['is_read_only'] ?? false),
+                        'terms'                    => !empty($row['invoice_terms']) ? (string) $row['invoice_terms'] : null,
+                    ]);
+                    $context->recordCreated(Invoice::class, $invoice->id);
+                }
+
+                if ($v1Id !== null) {
+                    $context->mapId('invoices', $v1Id, $invoice->id);
+                }
+
+                // Migrate invoice items
+                $invoiceItems = $items[$v1Id] ?? collect();
+                foreach ($invoiceItems as $itemRow) {
+                    $taxRateId = $context->getId('tax_rates', $itemRow['item_tax_rate_id'] ?? null);
+                    $productId = $context->getId('products', $itemRow['item_product_id'] ?? null);
+                    $unitId = $context->getId('product_units', $itemRow['item_product_unit_id'] ?? null);
+
+                    $qty = (float) ($itemRow['item_quantity'] ?? 1.0);
+                    $price = (float) ($itemRow['item_price'] ?? 0.0);
+                    $discount = (float) ($itemRow['item_discount_amount'] ?? 0.0);
+                    $subtotal = (float) ($itemRow['item_subtotal'] ?? ($qty * $price));
+                    $itemTax = (float) ($itemRow['item_tax_total'] ?? 0.0);
+                    $itemTotal = (float) ($itemRow['item_total'] ?? ($subtotal + $itemTax));
+
+                    $item = InvoiceItem::create([
+                        'company_id'      => $context->getCompanyId(),
+                        'invoice_id'      => $invoice->id,
+                        'product_id'      => $productId,
+                        'product_unit_id' => $unitId,
+                        'tax_rate_id'     => $taxRateId,
+                        'item_name'       => !empty($itemRow['item_name']) ? (string) $itemRow['item_name'] : 'Item',
+                        'description'     => !empty($itemRow['item_description']) ? (string) $itemRow['item_description'] : null,
+                        'quantity'        => $qty,
+                        'price'           => $price,
+                        'discount'        => $discount,
+                        'subtotal'        => $subtotal,
+                        'tax_1'           => $itemTax,
+                        'tax_total'       => $itemTax,
+                        'total'           => $itemTotal,
+                        'display_order'   => (int) ($itemRow['item_order'] ?? 1),
+                        'added_at'        => !empty($itemRow['item_date_added']) ? $itemRow['item_date_added'] : $invoice->invoiced_at,
+                    ]);
+                    $context->recordCreated(InvoiceItem::class, $item->id);
+                }
+
+                // Migrate invoice tax rates pivot if applicable
+                $invoiceTaxRows = $taxRates[$v1Id] ?? collect();
+                foreach ($invoiceTaxRows as $taxRow) {
+                    $taxRateId = $context->getId('tax_rates', $taxRow['tax_rate_id'] ?? null);
+                    if ($taxRateId) {
+                        $invoice->taxRates()->syncWithoutDetaching([
+                            $taxRateId => [
+                                'include_item_tax' => (int) ($taxRow['include_item_tax'] ?? 0),
+                                'tax_total'        => (float) ($taxRow['invoice_tax_rate_amount'] ?? 0.0),
+                            ],
+                        ]);
+                    }
+                }
+
+                $migrated++;
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate invoice #{$invoiceNumber}: " . $e->getMessage();
+                $skipped++;
+            }
+        }
+
+        $context->log("Migrated {$migrated} invoices ({$skipped} skipped).");
+
+        return [
+            'migrated' => $migrated,
+            'skipped'  => $skipped,
+            'errors'   => $errors,
+        ];
+    }
+
+    protected function resolveStatus(array $row, array $amount): InvoiceStatus
+    {
+        $statusId = (int) ($row['invoice_status_id'] ?? 1);
+        $balance = (float) ($amount['invoice_balance'] ?? 0.0);
+        $total = (float) ($amount['invoice_total'] ?? 0.0);
+        $paid = (float) ($amount['invoice_paid'] ?? 0.0);
+        $dueDate = !empty($row['invoice_date_due']) ? $row['invoice_date_due'] : null;
+
+        if ($statusId === 4 || ($total > 0 && $balance <= 0.0001)) {
+            return InvoiceStatus::PAID;
+        }
+
+        if ($statusId === 1) {
+            return InvoiceStatus::DRAFT;
+        }
+
+        if ($paid > 0 && $balance > 0.0001) {
+            return InvoiceStatus::PARTIALLY_PAID;
+        }
+
+        if ($dueDate && strtotime($dueDate) < time() && $balance > 0.0001) {
+            return InvoiceStatus::OVERDUE;
+        }
+
+        return match ($statusId) {
+            2       => InvoiceStatus::SENT,
+            3       => InvoiceStatus::VIEWED,
+            default => InvoiceStatus::DRAFT,
+        };
+    }
+
+    public function rollback(MigrationContext $context): int
+    {
+        $itemIds = $context->getCreatedIds(InvoiceItem::class);
+        $invoiceIds = $context->getCreatedIds(Invoice::class);
+
+        if (!empty($itemIds)) {
+            InvoiceItem::withoutGlobalScopes()->whereIn('id', $itemIds)->delete();
+        }
+
+        if (empty($invoiceIds)) {
+            return 0;
+        }
+
+        return Invoice::withoutGlobalScopes()
+            ->whereIn('id', $invoiceIds)
+            ->where('company_id', $context->getCompanyId())
+            ->forceDelete();
+    }
+}

--- a/Modules/Core/Services/Migration/Migrators/InvoiceMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/InvoiceMigrator.php
@@ -7,6 +7,7 @@ use Modules\Core\Services\Migration\MigrationContext;
 use Modules\Invoices\Enums\InvoiceStatus;
 use Modules\Invoices\Models\Invoice;
 use Modules\Invoices\Models\InvoiceItem;
+use Throwable;
 
 class InvoiceMigrator implements EntityMigratorInterface
 {
@@ -22,15 +23,15 @@ class InvoiceMigrator implements EntityMigratorInterface
 
     public function inspect(MigrationContext $context): array
     {
-        $invoices = $context->getSourceTable('invoices');
-        $items = $context->getSourceTable('invoice_items');
-        $notes = [];
+        $invoices    = $context->getSourceTable('invoices');
+        $items       = $context->getSourceTable('invoice_items');
+        $notes       = [];
         $willMigrate = 0;
-        $unmappable = 0;
+        $unmappable  = 0;
 
         foreach ($invoices as $row) {
             $clientId = $row['client_id'] ?? null;
-            if (!$clientId) {
+            if ( ! $clientId) {
                 $unmappable++;
                 $notes[] = "Invoice #{$row['invoice_number']} has no client_id, will be skipped.";
             } else {
@@ -49,21 +50,21 @@ class InvoiceMigrator implements EntityMigratorInterface
     public function migrate(MigrationContext $context): array
     {
         $invoices = $context->getSourceTable('invoices');
-        $items = $context->getSourceTable('invoice_items')->groupBy('invoice_id');
-        $amounts = $context->getSourceTable('invoice_amounts')->keyBy('invoice_id');
+        $items    = $context->getSourceTable('invoice_items')->groupBy('invoice_id');
+        $amounts  = $context->getSourceTable('invoice_amounts')->keyBy('invoice_id');
         $taxRates = $context->getSourceTable('invoice_tax_rates')->groupBy('invoice_id');
 
         $migrated = 0;
-        $skipped = 0;
-        $errors = [];
+        $skipped  = 0;
+        $errors   = [];
 
         foreach ($invoices as $row) {
-            $v1Id = $row['invoice_id'] ?? null;
-            $v1ClientId = $row['client_id'] ?? null;
-            $invoiceNumber = trim((string) ($row['invoice_number'] ?? ''));
+            $v1Id          = $row['invoice_id'] ?? null;
+            $v1ClientId    = $row['client_id'] ?? null;
+            $invoiceNumber = mb_trim((string) ($row['invoice_number'] ?? ''));
 
             $customerId = $context->getId('clients', $v1ClientId);
-            if (!$customerId) {
+            if ( ! $customerId) {
                 $errors[] = "Invoice #{$invoiceNumber} skipped: client #{$v1ClientId} not found in target company.";
                 $skipped++;
                 continue;
@@ -79,12 +80,12 @@ class InvoiceMigrator implements EntityMigratorInterface
 
             try {
                 $v1Amount = $amounts[$v1Id] ?? [];
-                $status = $this->resolveStatus($row, $v1Amount);
+                $status   = $this->resolveStatus($row, $v1Amount);
 
                 $itemSubtotal = (float) ($v1Amount['invoice_item_subtotal'] ?? 0.0);
                 $itemTaxTotal = (float) ($v1Amount['invoice_item_tax_total'] ?? 0.0);
-                $taxTotal = (float) ($v1Amount['invoice_tax_total'] ?? 0.0);
-                $total = (float) ($v1Amount['invoice_total'] ?? 0.0);
+                $taxTotal     = (float) ($v1Amount['invoice_tax_total'] ?? 0.0);
+                $total        = (float) ($v1Amount['invoice_total'] ?? 0.0);
 
                 // Prevent duplicate invoice number in same company
                 $invoice = Invoice::withoutGlobalScopes()
@@ -92,7 +93,7 @@ class InvoiceMigrator implements EntityMigratorInterface
                     ->where('invoice_number', $invoiceNumber)
                     ->first();
 
-                if (!$invoice) {
+                if ( ! $invoice) {
                     $invoice = Invoice::create([
                         'company_id'               => $context->getCompanyId(),
                         'customer_id'              => $customerId,
@@ -100,18 +101,18 @@ class InvoiceMigrator implements EntityMigratorInterface
                         'invoice_number'           => $invoiceNumber ?: ('INV-' . $v1Id),
                         'invoice_status'           => $status,
                         'invoice_sign'             => (string) ($v1Amount['invoice_sign'] ?? '1'),
-                        'invoiced_at'              => !empty($row['invoice_date_created']) ? $row['invoice_date_created'] : now(),
-                        'invoice_due_at'           => !empty($row['invoice_date_due']) ? $row['invoice_date_due'] : now()->addDays(30),
+                        'invoiced_at'              => ! empty($row['invoice_date_created']) ? $row['invoice_date_created'] : now(),
+                        'invoice_due_at'           => ! empty($row['invoice_date_due']) ? $row['invoice_date_due'] : now()->addDays(30),
                         'invoice_discount_amount'  => (float) ($row['invoice_discount_amount'] ?? 0.0),
                         'invoice_discount_percent' => (float) ($row['invoice_discount_percent'] ?? 0.0),
                         'invoice_item_subtotal'    => $itemSubtotal,
                         'item_tax_total'           => $itemTaxTotal,
                         'invoice_tax_total'        => $taxTotal,
                         'invoice_total'            => $total,
-                        'invoice_password'         => !empty($row['invoice_password']) ? (string) $row['invoice_password'] : null,
-                        'url_key'                  => !empty($row['invoice_url_key']) ? (string) $row['invoice_url_key'] : null,
+                        'invoice_password'         => ! empty($row['invoice_password']) ? (string) $row['invoice_password'] : null,
+                        'url_key'                  => ! empty($row['invoice_url_key']) ? (string) $row['invoice_url_key'] : null,
                         'is_read_only'             => (bool) ($row['is_read_only'] ?? false),
-                        'terms'                    => !empty($row['invoice_terms']) ? (string) $row['invoice_terms'] : null,
+                        'terms'                    => ! empty($row['invoice_terms']) ? (string) $row['invoice_terms'] : null,
                     ]);
                     $context->recordCreated(Invoice::class, $invoice->id);
                 }
@@ -125,13 +126,13 @@ class InvoiceMigrator implements EntityMigratorInterface
                 foreach ($invoiceItems as $itemRow) {
                     $taxRateId = $context->getId('tax_rates', $itemRow['item_tax_rate_id'] ?? null);
                     $productId = $context->getId('products', $itemRow['item_product_id'] ?? null);
-                    $unitId = $context->getId('product_units', $itemRow['item_product_unit_id'] ?? null);
+                    $unitId    = $context->getId('product_units', $itemRow['item_product_unit_id'] ?? null);
 
-                    $qty = (float) ($itemRow['item_quantity'] ?? 1.0);
-                    $price = (float) ($itemRow['item_price'] ?? 0.0);
-                    $discount = (float) ($itemRow['item_discount_amount'] ?? 0.0);
-                    $subtotal = (float) ($itemRow['item_subtotal'] ?? ($qty * $price));
-                    $itemTax = (float) ($itemRow['item_tax_total'] ?? 0.0);
+                    $qty       = (float) ($itemRow['item_quantity'] ?? 1.0);
+                    $price     = (float) ($itemRow['item_price'] ?? 0.0);
+                    $discount  = (float) ($itemRow['item_discount_amount'] ?? 0.0);
+                    $subtotal  = (float) ($itemRow['item_subtotal'] ?? ($qty * $price));
+                    $itemTax   = (float) ($itemRow['item_tax_total'] ?? 0.0);
                     $itemTotal = (float) ($itemRow['item_total'] ?? ($subtotal + $itemTax));
 
                     $item = InvoiceItem::create([
@@ -140,8 +141,8 @@ class InvoiceMigrator implements EntityMigratorInterface
                         'product_id'      => $productId,
                         'product_unit_id' => $unitId,
                         'tax_rate_id'     => $taxRateId,
-                        'item_name'       => !empty($itemRow['item_name']) ? (string) $itemRow['item_name'] : 'Item',
-                        'description'     => !empty($itemRow['item_description']) ? (string) $itemRow['item_description'] : null,
+                        'item_name'       => ! empty($itemRow['item_name']) ? (string) $itemRow['item_name'] : 'Item',
+                        'description'     => ! empty($itemRow['item_description']) ? (string) $itemRow['item_description'] : null,
                         'quantity'        => $qty,
                         'price'           => $price,
                         'discount'        => $discount,
@@ -150,7 +151,7 @@ class InvoiceMigrator implements EntityMigratorInterface
                         'tax_total'       => $itemTax,
                         'total'           => $itemTotal,
                         'display_order'   => (int) ($itemRow['item_order'] ?? 1),
-                        'added_at'        => !empty($itemRow['item_date_added']) ? $itemRow['item_date_added'] : $invoice->invoiced_at,
+                        'added_at'        => ! empty($itemRow['item_date_added']) ? $itemRow['item_date_added'] : $invoice->invoiced_at,
                     ]);
                     $context->recordCreated(InvoiceItem::class, $item->id);
                 }
@@ -170,7 +171,7 @@ class InvoiceMigrator implements EntityMigratorInterface
                 }
 
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = "Failed to migrate invoice #{$invoiceNumber}: " . $e->getMessage();
                 $skipped++;
             }
@@ -185,13 +186,32 @@ class InvoiceMigrator implements EntityMigratorInterface
         ];
     }
 
+    public function rollback(MigrationContext $context): int
+    {
+        $itemIds    = $context->getCreatedIds(InvoiceItem::class);
+        $invoiceIds = $context->getCreatedIds(Invoice::class);
+
+        if ( ! empty($itemIds)) {
+            InvoiceItem::withoutGlobalScopes()->whereIn('id', $itemIds)->delete();
+        }
+
+        if (empty($invoiceIds)) {
+            return 0;
+        }
+
+        return Invoice::withoutGlobalScopes()
+            ->whereIn('id', $invoiceIds)
+            ->where('company_id', $context->getCompanyId())
+            ->forceDelete();
+    }
+
     protected function resolveStatus(array $row, array $amount): InvoiceStatus
     {
         $statusId = (int) ($row['invoice_status_id'] ?? 1);
-        $balance = (float) ($amount['invoice_balance'] ?? 0.0);
-        $total = (float) ($amount['invoice_total'] ?? 0.0);
-        $paid = (float) ($amount['invoice_paid'] ?? 0.0);
-        $dueDate = !empty($row['invoice_date_due']) ? $row['invoice_date_due'] : null;
+        $balance  = (float) ($amount['invoice_balance'] ?? 0.0);
+        $total    = (float) ($amount['invoice_total'] ?? 0.0);
+        $paid     = (float) ($amount['invoice_paid'] ?? 0.0);
+        $dueDate  = ! empty($row['invoice_date_due']) ? $row['invoice_date_due'] : null;
 
         if ($statusId === 4 || ($total > 0 && $balance <= 0.0001)) {
             return InvoiceStatus::PAID;
@@ -214,24 +234,5 @@ class InvoiceMigrator implements EntityMigratorInterface
             3       => InvoiceStatus::VIEWED,
             default => InvoiceStatus::DRAFT,
         };
-    }
-
-    public function rollback(MigrationContext $context): int
-    {
-        $itemIds = $context->getCreatedIds(InvoiceItem::class);
-        $invoiceIds = $context->getCreatedIds(Invoice::class);
-
-        if (!empty($itemIds)) {
-            InvoiceItem::withoutGlobalScopes()->whereIn('id', $itemIds)->delete();
-        }
-
-        if (empty($invoiceIds)) {
-            return 0;
-        }
-
-        return Invoice::withoutGlobalScopes()
-            ->whereIn('id', $invoiceIds)
-            ->where('company_id', $context->getCompanyId())
-            ->forceDelete();
     }
 }

--- a/Modules/Core/Services/Migration/Migrators/PaymentMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/PaymentMigrator.php
@@ -8,6 +8,7 @@ use Modules\Invoices\Models\Invoice;
 use Modules\Payments\Enums\PaymentMethod;
 use Modules\Payments\Enums\PaymentStatus;
 use Modules\Payments\Models\Payment;
+use Throwable;
 
 class PaymentMigrator implements EntityMigratorInterface
 {
@@ -23,14 +24,14 @@ class PaymentMigrator implements EntityMigratorInterface
 
     public function inspect(MigrationContext $context): array
     {
-        $payments = $context->getSourceTable('payments');
-        $notes = [];
+        $payments    = $context->getSourceTable('payments');
+        $notes       = [];
         $willMigrate = 0;
-        $unmappable = 0;
+        $unmappable  = 0;
 
         foreach ($payments as $row) {
             $invoiceId = $row['invoice_id'] ?? null;
-            if (!$invoiceId) {
+            if ( ! $invoiceId) {
                 $unmappable++;
                 $notes[] = "Payment row #{$row['payment_id']} has no invoice_id, will be skipped.";
             } else {
@@ -48,20 +49,20 @@ class PaymentMigrator implements EntityMigratorInterface
 
     public function migrate(MigrationContext $context): array
     {
-        $payments = $context->getSourceTable('payments');
+        $payments       = $context->getSourceTable('payments');
         $paymentMethods = $context->getSourceTable('payment_methods')->keyBy('payment_method_id');
 
         $migrated = 0;
-        $skipped = 0;
-        $errors = [];
+        $skipped  = 0;
+        $errors   = [];
 
         foreach ($payments as $row) {
-            $v1Id = $row['payment_id'] ?? null;
+            $v1Id        = $row['payment_id'] ?? null;
             $v1InvoiceId = $row['invoice_id'] ?? null;
-            $v1MethodId = $row['payment_method_id'] ?? null;
+            $v1MethodId  = $row['payment_method_id'] ?? null;
 
             $v2InvoiceId = $context->getId('invoices', $v1InvoiceId);
-            if (!$v2InvoiceId) {
+            if ( ! $v2InvoiceId) {
                 $errors[] = "Payment #{$v1Id} skipped: invoice #{$v1InvoiceId} not migrated.";
                 $skipped++;
                 continue;
@@ -74,7 +75,7 @@ class PaymentMigrator implements EntityMigratorInterface
 
             try {
                 $invoice = Invoice::withoutGlobalScopes()->find($v2InvoiceId);
-                if (!$invoice) {
+                if ( ! $invoice) {
                     $errors[] = "Payment #{$v1Id} skipped: invoice ID {$v2InvoiceId} not found in database.";
                     $skipped++;
                     continue;
@@ -84,14 +85,14 @@ class PaymentMigrator implements EntityMigratorInterface
                 $methodEnum = $this->resolvePaymentMethod($methodName);
 
                 $amount = (float) ($row['payment_amount'] ?? 0.0);
-                $paidAt = !empty($row['payment_date']) ? $row['payment_date'] : now();
-                $note = !empty($row['payment_note']) ? (string) $row['payment_note'] : null;
+                $paidAt = ! empty($row['payment_date']) ? $row['payment_date'] : now();
+                $note   = ! empty($row['payment_note']) ? (string) $row['payment_note'] : null;
 
                 $payment = Payment::create([
                     'company_id'     => $context->getCompanyId(),
                     'customer_id'    => $invoice->customer_id,
                     'invoice_id'     => $invoice->id,
-                    'payment_number' => 'PAY-' . str_pad((string) ($v1Id ?? rand(100, 9999)), 5, '0', STR_PAD_LEFT),
+                    'payment_number' => 'PAY-' . mb_str_pad((string) ($v1Id ?? rand(100, 9999)), 5, '0', STR_PAD_LEFT),
                     'payment_method' => $methodEnum,
                     'payment_status' => PaymentStatus::COMPLETED,
                     'paid_at'        => $paidAt,
@@ -105,7 +106,7 @@ class PaymentMigrator implements EntityMigratorInterface
                 }
 
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = "Failed to migrate payment #{$v1Id}: " . $e->getMessage();
                 $skipped++;
             }
@@ -120,9 +121,22 @@ class PaymentMigrator implements EntityMigratorInterface
         ];
     }
 
+    public function rollback(MigrationContext $context): int
+    {
+        $paymentIds = $context->getCreatedIds(Payment::class);
+        if (empty($paymentIds)) {
+            return 0;
+        }
+
+        return Payment::withoutGlobalScopes()
+            ->whereIn('id', $paymentIds)
+            ->where('company_id', $context->getCompanyId())
+            ->delete();
+    }
+
     protected function resolvePaymentMethod(string $name): PaymentMethod
     {
-        $normalized = strtolower(trim($name));
+        $normalized = mb_strtolower(mb_trim($name));
 
         if (str_contains($normalized, 'cash')) {
             return PaymentMethod::CASH;
@@ -138,18 +152,5 @@ class PaymentMigrator implements EntityMigratorInterface
         }
 
         return PaymentMethod::BANK_TRANSFER;
-    }
-
-    public function rollback(MigrationContext $context): int
-    {
-        $paymentIds = $context->getCreatedIds(Payment::class);
-        if (empty($paymentIds)) {
-            return 0;
-        }
-
-        return Payment::withoutGlobalScopes()
-            ->whereIn('id', $paymentIds)
-            ->where('company_id', $context->getCompanyId())
-            ->delete();
     }
 }

--- a/Modules/Core/Services/Migration/Migrators/PaymentMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/PaymentMigrator.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Migrators;
+
+use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
+use Modules\Core\Services\Migration\MigrationContext;
+use Modules\Invoices\Models\Invoice;
+use Modules\Payments\Enums\PaymentMethod;
+use Modules\Payments\Enums\PaymentStatus;
+use Modules\Payments\Models\Payment;
+
+class PaymentMigrator implements EntityMigratorInterface
+{
+    public function name(): string
+    {
+        return 'payments';
+    }
+
+    public function label(): string
+    {
+        return 'Payments';
+    }
+
+    public function inspect(MigrationContext $context): array
+    {
+        $payments = $context->getSourceTable('payments');
+        $notes = [];
+        $willMigrate = 0;
+        $unmappable = 0;
+
+        foreach ($payments as $row) {
+            $invoiceId = $row['invoice_id'] ?? null;
+            if (!$invoiceId) {
+                $unmappable++;
+                $notes[] = "Payment row #{$row['payment_id']} has no invoice_id, will be skipped.";
+            } else {
+                $willMigrate++;
+            }
+        }
+
+        return [
+            'source_count' => $payments->count(),
+            'will_migrate' => $willMigrate,
+            'unmappable'   => $unmappable,
+            'notes'        => $notes,
+        ];
+    }
+
+    public function migrate(MigrationContext $context): array
+    {
+        $payments = $context->getSourceTable('payments');
+        $paymentMethods = $context->getSourceTable('payment_methods')->keyBy('payment_method_id');
+
+        $migrated = 0;
+        $skipped = 0;
+        $errors = [];
+
+        foreach ($payments as $row) {
+            $v1Id = $row['payment_id'] ?? null;
+            $v1InvoiceId = $row['invoice_id'] ?? null;
+            $v1MethodId = $row['payment_method_id'] ?? null;
+
+            $v2InvoiceId = $context->getId('invoices', $v1InvoiceId);
+            if (!$v2InvoiceId) {
+                $errors[] = "Payment #{$v1Id} skipped: invoice #{$v1InvoiceId} not migrated.";
+                $skipped++;
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                $migrated++;
+                continue;
+            }
+
+            try {
+                $invoice = Invoice::withoutGlobalScopes()->find($v2InvoiceId);
+                if (!$invoice) {
+                    $errors[] = "Payment #{$v1Id} skipped: invoice ID {$v2InvoiceId} not found in database.";
+                    $skipped++;
+                    continue;
+                }
+
+                $methodName = $paymentMethods[$v1MethodId]['payment_method_name'] ?? '';
+                $methodEnum = $this->resolvePaymentMethod($methodName);
+
+                $amount = (float) ($row['payment_amount'] ?? 0.0);
+                $paidAt = !empty($row['payment_date']) ? $row['payment_date'] : now();
+                $note = !empty($row['payment_note']) ? (string) $row['payment_note'] : null;
+
+                $payment = Payment::create([
+                    'company_id'     => $context->getCompanyId(),
+                    'customer_id'    => $invoice->customer_id,
+                    'invoice_id'     => $invoice->id,
+                    'payment_number' => 'PAY-' . str_pad((string) ($v1Id ?? rand(100, 9999)), 5, '0', STR_PAD_LEFT),
+                    'payment_method' => $methodEnum,
+                    'payment_status' => PaymentStatus::COMPLETED,
+                    'paid_at'        => $paidAt,
+                    'payment_amount' => $amount,
+                    'notes'          => $note,
+                ]);
+
+                $context->recordCreated(Payment::class, $payment->id);
+                if ($v1Id !== null) {
+                    $context->mapId('payments', $v1Id, $payment->id);
+                }
+
+                $migrated++;
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate payment #{$v1Id}: " . $e->getMessage();
+                $skipped++;
+            }
+        }
+
+        $context->log("Migrated {$migrated} payments ({$skipped} skipped).");
+
+        return [
+            'migrated' => $migrated,
+            'skipped'  => $skipped,
+            'errors'   => $errors,
+        ];
+    }
+
+    protected function resolvePaymentMethod(string $name): PaymentMethod
+    {
+        $normalized = strtolower(trim($name));
+
+        if (str_contains($normalized, 'cash')) {
+            return PaymentMethod::CASH;
+        }
+        if (str_contains($normalized, 'card') || str_contains($normalized, 'credit') || str_contains($normalized, 'debit')) {
+            return PaymentMethod::CREDIT_CARD;
+        }
+        if (str_contains($normalized, 'paypal')) {
+            return PaymentMethod::PAYPAL;
+        }
+        if (str_contains($normalized, 'stripe')) {
+            return PaymentMethod::STRIPE;
+        }
+
+        return PaymentMethod::BANK_TRANSFER;
+    }
+
+    public function rollback(MigrationContext $context): int
+    {
+        $paymentIds = $context->getCreatedIds(Payment::class);
+        if (empty($paymentIds)) {
+            return 0;
+        }
+
+        return Payment::withoutGlobalScopes()
+            ->whereIn('id', $paymentIds)
+            ->where('company_id', $context->getCompanyId())
+            ->delete();
+    }
+}

--- a/Modules/Core/Services/Migration/Migrators/ProductMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/ProductMigrator.php
@@ -8,6 +8,7 @@ use Modules\Products\Enums\ProductType;
 use Modules\Products\Models\Product;
 use Modules\Products\Models\ProductCategory;
 use Modules\Products\Models\ProductUnit;
+use Throwable;
 
 class ProductMigrator implements EntityMigratorInterface
 {
@@ -24,15 +25,15 @@ class ProductMigrator implements EntityMigratorInterface
     public function inspect(MigrationContext $context): array
     {
         $families = $context->getSourceTable('families');
-        $units = $context->getSourceTable('units');
+        $units    = $context->getSourceTable('units');
         $products = $context->getSourceTable('products');
 
-        $notes = [];
+        $notes       = [];
         $willMigrate = 0;
-        $unmappable = 0;
+        $unmappable  = 0;
 
         foreach ($products as $row) {
-            $name = trim((string) ($row['product_name'] ?? ''));
+            $name = mb_trim((string) ($row['product_name'] ?? ''));
             if ($name === '') {
                 $unmappable++;
                 $notes[] = "Product row #{$row['product_id']} has empty name, will be skipped.";
@@ -52,14 +53,14 @@ class ProductMigrator implements EntityMigratorInterface
     public function migrate(MigrationContext $context): array
     {
         $migrated = 0;
-        $skipped = 0;
-        $errors = [];
+        $skipped  = 0;
+        $errors   = [];
 
         // 1. Families -> ProductCategory
         $families = $context->getSourceTable('families');
         foreach ($families as $row) {
             $v1Id = $row['family_id'] ?? null;
-            $name = trim((string) ($row['family_name'] ?? ''));
+            $name = mb_trim((string) ($row['family_name'] ?? ''));
             if ($name === '') {
                 $skipped++;
                 continue;
@@ -79,7 +80,7 @@ class ProductMigrator implements EntityMigratorInterface
                     ->where('category_name', $name)
                     ->first();
 
-                if (!$category) {
+                if ( ! $category) {
                     $category = ProductCategory::create([
                         'company_id'    => $context->getCompanyId(),
                         'category_name' => $name,
@@ -91,7 +92,7 @@ class ProductMigrator implements EntityMigratorInterface
                     $context->mapId('product_categories', $v1Id, $category->id);
                 }
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = "Failed to migrate product category '{$name}': " . $e->getMessage();
                 $skipped++;
             }
@@ -100,9 +101,9 @@ class ProductMigrator implements EntityMigratorInterface
         // 2. Units -> ProductUnit
         $units = $context->getSourceTable('units');
         foreach ($units as $row) {
-            $v1Id = $row['unit_id'] ?? null;
-            $name = trim((string) ($row['unit_name'] ?? ''));
-            $namePlural = trim((string) ($row['unit_name_plrl'] ?? ''));
+            $v1Id       = $row['unit_id'] ?? null;
+            $name       = mb_trim((string) ($row['unit_name'] ?? ''));
+            $namePlural = mb_trim((string) ($row['unit_name_plrl'] ?? ''));
             if ($name === '') {
                 $skipped++;
                 continue;
@@ -122,7 +123,7 @@ class ProductMigrator implements EntityMigratorInterface
                     ->where('unit_name', $name)
                     ->first();
 
-                if (!$unit) {
+                if ( ! $unit) {
                     $unit = ProductUnit::create([
                         'company_id'     => $context->getCompanyId(),
                         'unit_name'      => $name,
@@ -135,7 +136,7 @@ class ProductMigrator implements EntityMigratorInterface
                     $context->mapId('product_units', $v1Id, $unit->id);
                 }
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = "Failed to migrate product unit '{$name}': " . $e->getMessage();
                 $skipped++;
             }
@@ -145,7 +146,7 @@ class ProductMigrator implements EntityMigratorInterface
         $products = $context->getSourceTable('products');
         foreach ($products as $row) {
             $v1Id = $row['product_id'] ?? null;
-            $name = trim((string) ($row['product_name'] ?? ''));
+            $name = mb_trim((string) ($row['product_name'] ?? ''));
             if ($name === '') {
                 $skipped++;
                 continue;
@@ -161,13 +162,13 @@ class ProductMigrator implements EntityMigratorInterface
 
             try {
                 $categoryId = $context->getId('product_categories', $row['family_id'] ?? null);
-                if (!$categoryId) {
+                if ( ! $categoryId) {
                     // Get or create a default category
                     $defaultCategory = ProductCategory::withoutGlobalScopes()
                         ->where('company_id', $context->getCompanyId())
                         ->first();
 
-                    if (!$defaultCategory) {
+                    if ( ! $defaultCategory) {
                         $defaultCategory = ProductCategory::create([
                             'company_id'    => $context->getCompanyId(),
                             'category_name' => 'General',
@@ -177,7 +178,7 @@ class ProductMigrator implements EntityMigratorInterface
                     $categoryId = $defaultCategory->id;
                 }
 
-                $unitId = $context->getId('product_units', $row['unit_id'] ?? null);
+                $unitId    = $context->getId('product_units', $row['unit_id'] ?? null);
                 $taxRateId = $context->getId('tax_rates', $row['tax_rate_id'] ?? null);
 
                 $product = Product::withoutGlobalScopes()
@@ -185,19 +186,19 @@ class ProductMigrator implements EntityMigratorInterface
                     ->where('product_name', $name)
                     ->first();
 
-                if (!$product) {
+                if ( ! $product) {
                     $product = Product::create([
                         'company_id'     => $context->getCompanyId(),
                         'category_id'    => $categoryId,
                         'unit_id'        => $unitId,
                         'tax_rate_id'    => $taxRateId,
                         'type'           => ProductType::PRODUCT,
-                        'code'           => !empty($row['product_sku']) ? (string) $row['product_sku'] : null,
+                        'code'           => ! empty($row['product_sku']) ? (string) $row['product_sku'] : null,
                         'product_name'   => $name,
-                        'description'    => !empty($row['product_description']) ? (string) $row['product_description'] : null,
+                        'description'    => ! empty($row['product_description']) ? (string) $row['product_description'] : null,
                         'price'          => (float) ($row['product_price'] ?? 0.0),
                         'cost_price'     => (float) ($row['purchase_price'] ?? 0.0),
-                        'product_tariff' => !empty($row['product_tariff']) ? (int) $row['product_tariff'] : null,
+                        'product_tariff' => ! empty($row['product_tariff']) ? (int) $row['product_tariff'] : null,
                     ]);
                     $context->recordCreated(Product::class, $product->id);
                 }
@@ -206,7 +207,7 @@ class ProductMigrator implements EntityMigratorInterface
                     $context->mapId('products', $v1Id, $product->id);
                 }
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = "Failed to migrate product #{$v1Id} '{$name}': " . $e->getMessage();
                 $skipped++;
             }
@@ -223,18 +224,18 @@ class ProductMigrator implements EntityMigratorInterface
 
     public function rollback(MigrationContext $context): int
     {
-        $productIds = $context->getCreatedIds(Product::class);
+        $productIds  = $context->getCreatedIds(Product::class);
         $categoryIds = $context->getCreatedIds(ProductCategory::class);
-        $unitIds = $context->getCreatedIds(ProductUnit::class);
+        $unitIds     = $context->getCreatedIds(ProductUnit::class);
 
         $deleted = 0;
-        if (!empty($productIds)) {
+        if ( ! empty($productIds)) {
             $deleted += Product::withoutGlobalScopes()->whereIn('id', $productIds)->delete();
         }
-        if (!empty($categoryIds)) {
+        if ( ! empty($categoryIds)) {
             $deleted += ProductCategory::withoutGlobalScopes()->whereIn('id', $categoryIds)->delete();
         }
-        if (!empty($unitIds)) {
+        if ( ! empty($unitIds)) {
             $deleted += ProductUnit::withoutGlobalScopes()->whereIn('id', $unitIds)->delete();
         }
 

--- a/Modules/Core/Services/Migration/Migrators/ProductMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/ProductMigrator.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Migrators;
+
+use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
+use Modules\Core\Services\Migration\MigrationContext;
+use Modules\Products\Enums\ProductType;
+use Modules\Products\Models\Product;
+use Modules\Products\Models\ProductCategory;
+use Modules\Products\Models\ProductUnit;
+
+class ProductMigrator implements EntityMigratorInterface
+{
+    public function name(): string
+    {
+        return 'products';
+    }
+
+    public function label(): string
+    {
+        return 'Products & Categories';
+    }
+
+    public function inspect(MigrationContext $context): array
+    {
+        $families = $context->getSourceTable('families');
+        $units = $context->getSourceTable('units');
+        $products = $context->getSourceTable('products');
+
+        $notes = [];
+        $willMigrate = 0;
+        $unmappable = 0;
+
+        foreach ($products as $row) {
+            $name = trim((string) ($row['product_name'] ?? ''));
+            if ($name === '') {
+                $unmappable++;
+                $notes[] = "Product row #{$row['product_id']} has empty name, will be skipped.";
+            } else {
+                $willMigrate++;
+            }
+        }
+
+        return [
+            'source_count' => $families->count() + $units->count() + $products->count(),
+            'will_migrate' => $families->count() + $units->count() + $willMigrate,
+            'unmappable'   => $unmappable,
+            'notes'        => $notes,
+        ];
+    }
+
+    public function migrate(MigrationContext $context): array
+    {
+        $migrated = 0;
+        $skipped = 0;
+        $errors = [];
+
+        // 1. Families -> ProductCategory
+        $families = $context->getSourceTable('families');
+        foreach ($families as $row) {
+            $v1Id = $row['family_id'] ?? null;
+            $name = trim((string) ($row['family_name'] ?? ''));
+            if ($name === '') {
+                $skipped++;
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                if ($v1Id !== null) {
+                    $context->mapId('product_categories', $v1Id, (int) $v1Id);
+                }
+                $migrated++;
+                continue;
+            }
+
+            try {
+                $category = ProductCategory::withoutGlobalScopes()
+                    ->where('company_id', $context->getCompanyId())
+                    ->where('category_name', $name)
+                    ->first();
+
+                if (!$category) {
+                    $category = ProductCategory::create([
+                        'company_id'    => $context->getCompanyId(),
+                        'category_name' => $name,
+                    ]);
+                    $context->recordCreated(ProductCategory::class, $category->id);
+                }
+
+                if ($v1Id !== null) {
+                    $context->mapId('product_categories', $v1Id, $category->id);
+                }
+                $migrated++;
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate product category '{$name}': " . $e->getMessage();
+                $skipped++;
+            }
+        }
+
+        // 2. Units -> ProductUnit
+        $units = $context->getSourceTable('units');
+        foreach ($units as $row) {
+            $v1Id = $row['unit_id'] ?? null;
+            $name = trim((string) ($row['unit_name'] ?? ''));
+            $namePlural = trim((string) ($row['unit_name_plrl'] ?? ''));
+            if ($name === '') {
+                $skipped++;
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                if ($v1Id !== null) {
+                    $context->mapId('product_units', $v1Id, (int) $v1Id);
+                }
+                $migrated++;
+                continue;
+            }
+
+            try {
+                $unit = ProductUnit::withoutGlobalScopes()
+                    ->where('company_id', $context->getCompanyId())
+                    ->where('unit_name', $name)
+                    ->first();
+
+                if (!$unit) {
+                    $unit = ProductUnit::create([
+                        'company_id'     => $context->getCompanyId(),
+                        'unit_name'      => $name,
+                        'unit_name_plrl' => $namePlural ?: $name,
+                    ]);
+                    $context->recordCreated(ProductUnit::class, $unit->id);
+                }
+
+                if ($v1Id !== null) {
+                    $context->mapId('product_units', $v1Id, $unit->id);
+                }
+                $migrated++;
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate product unit '{$name}': " . $e->getMessage();
+                $skipped++;
+            }
+        }
+
+        // 3. Products -> Product
+        $products = $context->getSourceTable('products');
+        foreach ($products as $row) {
+            $v1Id = $row['product_id'] ?? null;
+            $name = trim((string) ($row['product_name'] ?? ''));
+            if ($name === '') {
+                $skipped++;
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                if ($v1Id !== null) {
+                    $context->mapId('products', $v1Id, (int) $v1Id);
+                }
+                $migrated++;
+                continue;
+            }
+
+            try {
+                $categoryId = $context->getId('product_categories', $row['family_id'] ?? null);
+                if (!$categoryId) {
+                    // Get or create a default category
+                    $defaultCategory = ProductCategory::withoutGlobalScopes()
+                        ->where('company_id', $context->getCompanyId())
+                        ->first();
+
+                    if (!$defaultCategory) {
+                        $defaultCategory = ProductCategory::create([
+                            'company_id'    => $context->getCompanyId(),
+                            'category_name' => 'General',
+                        ]);
+                        $context->recordCreated(ProductCategory::class, $defaultCategory->id);
+                    }
+                    $categoryId = $defaultCategory->id;
+                }
+
+                $unitId = $context->getId('product_units', $row['unit_id'] ?? null);
+                $taxRateId = $context->getId('tax_rates', $row['tax_rate_id'] ?? null);
+
+                $product = Product::withoutGlobalScopes()
+                    ->where('company_id', $context->getCompanyId())
+                    ->where('product_name', $name)
+                    ->first();
+
+                if (!$product) {
+                    $product = Product::create([
+                        'company_id'     => $context->getCompanyId(),
+                        'category_id'    => $categoryId,
+                        'unit_id'        => $unitId,
+                        'tax_rate_id'    => $taxRateId,
+                        'type'           => ProductType::PRODUCT,
+                        'code'           => !empty($row['product_sku']) ? (string) $row['product_sku'] : null,
+                        'product_name'   => $name,
+                        'description'    => !empty($row['product_description']) ? (string) $row['product_description'] : null,
+                        'price'          => (float) ($row['product_price'] ?? 0.0),
+                        'cost_price'     => (float) ($row['purchase_price'] ?? 0.0),
+                        'product_tariff' => !empty($row['product_tariff']) ? (int) $row['product_tariff'] : null,
+                    ]);
+                    $context->recordCreated(Product::class, $product->id);
+                }
+
+                if ($v1Id !== null) {
+                    $context->mapId('products', $v1Id, $product->id);
+                }
+                $migrated++;
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate product #{$v1Id} '{$name}': " . $e->getMessage();
+                $skipped++;
+            }
+        }
+
+        $context->log("Migrated {$migrated} product items ({$skipped} skipped).");
+
+        return [
+            'migrated' => $migrated,
+            'skipped'  => $skipped,
+            'errors'   => $errors,
+        ];
+    }
+
+    public function rollback(MigrationContext $context): int
+    {
+        $productIds = $context->getCreatedIds(Product::class);
+        $categoryIds = $context->getCreatedIds(ProductCategory::class);
+        $unitIds = $context->getCreatedIds(ProductUnit::class);
+
+        $deleted = 0;
+        if (!empty($productIds)) {
+            $deleted += Product::withoutGlobalScopes()->whereIn('id', $productIds)->delete();
+        }
+        if (!empty($categoryIds)) {
+            $deleted += ProductCategory::withoutGlobalScopes()->whereIn('id', $categoryIds)->delete();
+        }
+        if (!empty($unitIds)) {
+            $deleted += ProductUnit::withoutGlobalScopes()->whereIn('id', $unitIds)->delete();
+        }
+
+        return $deleted;
+    }
+}

--- a/Modules/Core/Services/Migration/Migrators/ProjectMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/ProjectMigrator.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Migrators;
+
+use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
+use Modules\Core\Services\Migration\MigrationContext;
+use Modules\Projects\Enums\ProjectStatus;
+use Modules\Projects\Enums\TaskStatus;
+use Modules\Projects\Models\Project;
+use Modules\Projects\Models\Task;
+
+class ProjectMigrator implements EntityMigratorInterface
+{
+    public function name(): string
+    {
+        return 'projects';
+    }
+
+    public function label(): string
+    {
+        return 'Projects & Tasks';
+    }
+
+    public function inspect(MigrationContext $context): array
+    {
+        $projects = $context->getSourceTable('projects');
+        $tasks = $context->getSourceTable('tasks');
+        $notes = [];
+        $willMigrate = 0;
+        $unmappable = 0;
+
+        foreach ($projects as $row) {
+            $name = trim((string) ($row['project_name'] ?? ''));
+            if ($name === '') {
+                $unmappable++;
+                $notes[] = "Project row #{$row['project_id']} has empty name, will be skipped.";
+            } else {
+                $willMigrate++;
+            }
+        }
+
+        return [
+            'source_count' => $projects->count() + $tasks->count(),
+            'will_migrate' => $willMigrate + $tasks->count(),
+            'unmappable'   => $unmappable,
+            'notes'        => $notes,
+        ];
+    }
+
+    public function migrate(MigrationContext $context): array
+    {
+        $projects = $context->getSourceTable('projects');
+        $tasks = $context->getSourceTable('tasks')->groupBy('project_id');
+
+        $migrated = 0;
+        $skipped = 0;
+        $errors = [];
+
+        foreach ($projects as $row) {
+            $v1Id = $row['project_id'] ?? null;
+            $name = trim((string) ($row['project_name'] ?? ''));
+            $v1ClientId = $row['client_id'] ?? null;
+
+            if ($name === '') {
+                $skipped++;
+                continue;
+            }
+
+            $customerId = $context->getId('clients', $v1ClientId);
+            if (!$customerId) {
+                // If client not mapped, find first client in company
+                $firstClient = $context->getCompany()->relations()->first();
+                $customerId = $firstClient?->id;
+            }
+
+            if (!$customerId) {
+                $errors[] = "Project #{$v1Id} '{$name}' skipped: no customer available.";
+                $skipped++;
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                if ($v1Id !== null) {
+                    $context->mapId('projects', $v1Id, (int) $v1Id);
+                }
+                $migrated++;
+                continue;
+            }
+
+            try {
+                $project = Project::withoutGlobalScopes()
+                    ->where('company_id', $context->getCompanyId())
+                    ->where('project_name', $name)
+                    ->first();
+
+                if (!$project) {
+                    $project = Project::create([
+                        'company_id'     => $context->getCompanyId(),
+                        'customer_id'    => $customerId,
+                        'project_name'   => $name,
+                        'project_number' => 'PRJ-' . str_pad((string) ($v1Id ?? rand(100, 9999)), 5, '0', STR_PAD_LEFT),
+                        'project_status' => ProjectStatus::ACTIVE,
+                    ]);
+                    $context->recordCreated(Project::class, $project->id);
+                }
+
+                if ($v1Id !== null) {
+                    $context->mapId('projects', $v1Id, $project->id);
+                }
+
+                // Migrate tasks under project
+                $projectTasks = $tasks[$v1Id] ?? collect();
+                foreach ($projectTasks as $taskRow) {
+                    $v1TaskId = $taskRow['task_id'] ?? null;
+                    $taskName = trim((string) ($taskRow['task_name'] ?? 'Task'));
+                    $status = $this->resolveTaskStatus($taskRow);
+                    $taxRateId = $context->getId('tax_rates', $taskRow['tax_rate_id'] ?? null);
+
+                    $task = Task::create([
+                        'company_id'       => $context->getCompanyId(),
+                        'customer_id'      => $customerId,
+                        'project_id'       => $project->id,
+                        'tax_rate_id'      => $taxRateId,
+                        'task_name'        => $taskName,
+                        'description'      => !empty($taskRow['task_description']) ? (string) $taskRow['task_description'] : null,
+                        'task_price'       => (float) ($taskRow['task_price'] ?? 0.0),
+                        'task_status'      => $status,
+                        'due_at'           => !empty($taskRow['task_finish_date']) ? $taskRow['task_finish_date'] : null,
+                    ]);
+                    $context->recordCreated(Task::class, $task->id);
+                    if ($v1TaskId !== null) {
+                        $context->mapId('tasks', $v1TaskId, $task->id);
+                    }
+                }
+
+                $migrated++;
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate project #{$v1Id} '{$name}': " . $e->getMessage();
+                $skipped++;
+            }
+        }
+
+        // Also handle orphan tasks (tasks without project_id)
+        $orphanTasks = $tasks[''] ?? $tasks[0] ?? collect();
+        foreach ($orphanTasks as $taskRow) {
+            if ($context->isDryRun()) {
+                continue;
+            }
+
+            try {
+                $v1TaskId = $taskRow['task_id'] ?? null;
+                $taskName = trim((string) ($taskRow['task_name'] ?? 'Task'));
+                $status = $this->resolveTaskStatus($taskRow);
+                $taxRateId = $context->getId('tax_rates', $taskRow['tax_rate_id'] ?? null);
+                $firstClient = $context->getCompany()->relations()->first();
+
+                if ($firstClient) {
+                    $task = Task::create([
+                        'company_id'       => $context->getCompanyId(),
+                        'customer_id'      => $firstClient->id,
+                        'project_id'       => null,
+                        'tax_rate_id'      => $taxRateId,
+                        'task_name'        => $taskName,
+                        'description'      => !empty($taskRow['task_description']) ? (string) $taskRow['task_description'] : null,
+                        'task_price'       => (float) ($taskRow['task_price'] ?? 0.0),
+                        'task_status'      => $status,
+                        'due_at'           => !empty($taskRow['task_finish_date']) ? $taskRow['task_finish_date'] : null,
+                    ]);
+                    $context->recordCreated(Task::class, $task->id);
+                    if ($v1TaskId !== null) {
+                        $context->mapId('tasks', $v1TaskId, $task->id);
+                    }
+                }
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate task: " . $e->getMessage();
+            }
+        }
+
+        $context->log("Migrated {$migrated} projects ({$skipped} skipped).");
+
+        return [
+            'migrated' => $migrated,
+            'skipped'  => $skipped,
+            'errors'   => $errors,
+        ];
+    }
+
+    protected function resolveTaskStatus(array $row): TaskStatus
+    {
+        $status = (int) ($row['task_status'] ?? 1);
+        return match ($status) {
+            2       => TaskStatus::IN_PROGRESS,
+            3       => TaskStatus::COMPLETED,
+            4       => TaskStatus::PAID,
+            default => TaskStatus::NOT_STARTED,
+        };
+    }
+
+    public function rollback(MigrationContext $context): int
+    {
+        $taskIds = $context->getCreatedIds(Task::class);
+        $projectIds = $context->getCreatedIds(Project::class);
+
+        if (!empty($taskIds)) {
+            Task::withoutGlobalScopes()->whereIn('id', $taskIds)->delete();
+        }
+
+        if (empty($projectIds)) {
+            return 0;
+        }
+
+        return Project::withoutGlobalScopes()
+            ->whereIn('id', $projectIds)
+            ->where('company_id', $context->getCompanyId())
+            ->delete();
+    }
+}

--- a/Modules/Core/Services/Migration/Migrators/ProjectMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/ProjectMigrator.php
@@ -8,6 +8,7 @@ use Modules\Projects\Enums\ProjectStatus;
 use Modules\Projects\Enums\TaskStatus;
 use Modules\Projects\Models\Project;
 use Modules\Projects\Models\Task;
+use Throwable;
 
 class ProjectMigrator implements EntityMigratorInterface
 {
@@ -23,14 +24,14 @@ class ProjectMigrator implements EntityMigratorInterface
 
     public function inspect(MigrationContext $context): array
     {
-        $projects = $context->getSourceTable('projects');
-        $tasks = $context->getSourceTable('tasks');
-        $notes = [];
+        $projects    = $context->getSourceTable('projects');
+        $tasks       = $context->getSourceTable('tasks');
+        $notes       = [];
         $willMigrate = 0;
-        $unmappable = 0;
+        $unmappable  = 0;
 
         foreach ($projects as $row) {
-            $name = trim((string) ($row['project_name'] ?? ''));
+            $name = mb_trim((string) ($row['project_name'] ?? ''));
             if ($name === '') {
                 $unmappable++;
                 $notes[] = "Project row #{$row['project_id']} has empty name, will be skipped.";
@@ -50,15 +51,15 @@ class ProjectMigrator implements EntityMigratorInterface
     public function migrate(MigrationContext $context): array
     {
         $projects = $context->getSourceTable('projects');
-        $tasks = $context->getSourceTable('tasks')->groupBy('project_id');
+        $tasks    = $context->getSourceTable('tasks')->groupBy('project_id');
 
         $migrated = 0;
-        $skipped = 0;
-        $errors = [];
+        $skipped  = 0;
+        $errors   = [];
 
         foreach ($projects as $row) {
-            $v1Id = $row['project_id'] ?? null;
-            $name = trim((string) ($row['project_name'] ?? ''));
+            $v1Id       = $row['project_id'] ?? null;
+            $name       = mb_trim((string) ($row['project_name'] ?? ''));
             $v1ClientId = $row['client_id'] ?? null;
 
             if ($name === '') {
@@ -67,13 +68,13 @@ class ProjectMigrator implements EntityMigratorInterface
             }
 
             $customerId = $context->getId('clients', $v1ClientId);
-            if (!$customerId) {
+            if ( ! $customerId) {
                 // If client not mapped, find first client in company
                 $firstClient = $context->getCompany()->relations()->first();
-                $customerId = $firstClient?->id;
+                $customerId  = $firstClient?->id;
             }
 
-            if (!$customerId) {
+            if ( ! $customerId) {
                 $errors[] = "Project #{$v1Id} '{$name}' skipped: no customer available.";
                 $skipped++;
                 continue;
@@ -93,12 +94,12 @@ class ProjectMigrator implements EntityMigratorInterface
                     ->where('project_name', $name)
                     ->first();
 
-                if (!$project) {
+                if ( ! $project) {
                     $project = Project::create([
                         'company_id'     => $context->getCompanyId(),
                         'customer_id'    => $customerId,
                         'project_name'   => $name,
-                        'project_number' => 'PRJ-' . str_pad((string) ($v1Id ?? rand(100, 9999)), 5, '0', STR_PAD_LEFT),
+                        'project_number' => 'PRJ-' . mb_str_pad((string) ($v1Id ?? rand(100, 9999)), 5, '0', STR_PAD_LEFT),
                         'project_status' => ProjectStatus::ACTIVE,
                     ]);
                     $context->recordCreated(Project::class, $project->id);
@@ -111,21 +112,21 @@ class ProjectMigrator implements EntityMigratorInterface
                 // Migrate tasks under project
                 $projectTasks = $tasks[$v1Id] ?? collect();
                 foreach ($projectTasks as $taskRow) {
-                    $v1TaskId = $taskRow['task_id'] ?? null;
-                    $taskName = trim((string) ($taskRow['task_name'] ?? 'Task'));
-                    $status = $this->resolveTaskStatus($taskRow);
+                    $v1TaskId  = $taskRow['task_id'] ?? null;
+                    $taskName  = mb_trim((string) ($taskRow['task_name'] ?? 'Task'));
+                    $status    = $this->resolveTaskStatus($taskRow);
                     $taxRateId = $context->getId('tax_rates', $taskRow['tax_rate_id'] ?? null);
 
                     $task = Task::create([
-                        'company_id'       => $context->getCompanyId(),
-                        'customer_id'      => $customerId,
-                        'project_id'       => $project->id,
-                        'tax_rate_id'      => $taxRateId,
-                        'task_name'        => $taskName,
-                        'description'      => !empty($taskRow['task_description']) ? (string) $taskRow['task_description'] : null,
-                        'task_price'       => (float) ($taskRow['task_price'] ?? 0.0),
-                        'task_status'      => $status,
-                        'due_at'           => !empty($taskRow['task_finish_date']) ? $taskRow['task_finish_date'] : null,
+                        'company_id'  => $context->getCompanyId(),
+                        'customer_id' => $customerId,
+                        'project_id'  => $project->id,
+                        'tax_rate_id' => $taxRateId,
+                        'task_name'   => $taskName,
+                        'description' => ! empty($taskRow['task_description']) ? (string) $taskRow['task_description'] : null,
+                        'task_price'  => (float) ($taskRow['task_price'] ?? 0.0),
+                        'task_status' => $status,
+                        'due_at'      => ! empty($taskRow['task_finish_date']) ? $taskRow['task_finish_date'] : null,
                     ]);
                     $context->recordCreated(Task::class, $task->id);
                     if ($v1TaskId !== null) {
@@ -134,7 +135,7 @@ class ProjectMigrator implements EntityMigratorInterface
                 }
 
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = "Failed to migrate project #{$v1Id} '{$name}': " . $e->getMessage();
                 $skipped++;
             }
@@ -148,31 +149,31 @@ class ProjectMigrator implements EntityMigratorInterface
             }
 
             try {
-                $v1TaskId = $taskRow['task_id'] ?? null;
-                $taskName = trim((string) ($taskRow['task_name'] ?? 'Task'));
-                $status = $this->resolveTaskStatus($taskRow);
-                $taxRateId = $context->getId('tax_rates', $taskRow['tax_rate_id'] ?? null);
+                $v1TaskId    = $taskRow['task_id'] ?? null;
+                $taskName    = mb_trim((string) ($taskRow['task_name'] ?? 'Task'));
+                $status      = $this->resolveTaskStatus($taskRow);
+                $taxRateId   = $context->getId('tax_rates', $taskRow['tax_rate_id'] ?? null);
                 $firstClient = $context->getCompany()->relations()->first();
 
                 if ($firstClient) {
                     $task = Task::create([
-                        'company_id'       => $context->getCompanyId(),
-                        'customer_id'      => $firstClient->id,
-                        'project_id'       => null,
-                        'tax_rate_id'      => $taxRateId,
-                        'task_name'        => $taskName,
-                        'description'      => !empty($taskRow['task_description']) ? (string) $taskRow['task_description'] : null,
-                        'task_price'       => (float) ($taskRow['task_price'] ?? 0.0),
-                        'task_status'      => $status,
-                        'due_at'           => !empty($taskRow['task_finish_date']) ? $taskRow['task_finish_date'] : null,
+                        'company_id'  => $context->getCompanyId(),
+                        'customer_id' => $firstClient->id,
+                        'project_id'  => null,
+                        'tax_rate_id' => $taxRateId,
+                        'task_name'   => $taskName,
+                        'description' => ! empty($taskRow['task_description']) ? (string) $taskRow['task_description'] : null,
+                        'task_price'  => (float) ($taskRow['task_price'] ?? 0.0),
+                        'task_status' => $status,
+                        'due_at'      => ! empty($taskRow['task_finish_date']) ? $taskRow['task_finish_date'] : null,
                     ]);
                     $context->recordCreated(Task::class, $task->id);
                     if ($v1TaskId !== null) {
                         $context->mapId('tasks', $v1TaskId, $task->id);
                     }
                 }
-            } catch (\Throwable $e) {
-                $errors[] = "Failed to migrate task: " . $e->getMessage();
+            } catch (Throwable $e) {
+                $errors[] = 'Failed to migrate task: ' . $e->getMessage();
             }
         }
 
@@ -185,23 +186,12 @@ class ProjectMigrator implements EntityMigratorInterface
         ];
     }
 
-    protected function resolveTaskStatus(array $row): TaskStatus
-    {
-        $status = (int) ($row['task_status'] ?? 1);
-        return match ($status) {
-            2       => TaskStatus::IN_PROGRESS,
-            3       => TaskStatus::COMPLETED,
-            4       => TaskStatus::PAID,
-            default => TaskStatus::NOT_STARTED,
-        };
-    }
-
     public function rollback(MigrationContext $context): int
     {
-        $taskIds = $context->getCreatedIds(Task::class);
+        $taskIds    = $context->getCreatedIds(Task::class);
         $projectIds = $context->getCreatedIds(Project::class);
 
-        if (!empty($taskIds)) {
+        if ( ! empty($taskIds)) {
             Task::withoutGlobalScopes()->whereIn('id', $taskIds)->delete();
         }
 
@@ -213,5 +203,17 @@ class ProjectMigrator implements EntityMigratorInterface
             ->whereIn('id', $projectIds)
             ->where('company_id', $context->getCompanyId())
             ->delete();
+    }
+
+    protected function resolveTaskStatus(array $row): TaskStatus
+    {
+        $status = (int) ($row['task_status'] ?? 1);
+
+        return match ($status) {
+            2       => TaskStatus::IN_PROGRESS,
+            3       => TaskStatus::COMPLETED,
+            4       => TaskStatus::PAID,
+            default => TaskStatus::NOT_STARTED,
+        };
     }
 }

--- a/Modules/Core/Services/Migration/Migrators/QuoteMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/QuoteMigrator.php
@@ -7,6 +7,7 @@ use Modules\Core\Services\Migration\MigrationContext;
 use Modules\Quotes\Enums\QuoteStatus;
 use Modules\Quotes\Models\Quote;
 use Modules\Quotes\Models\QuoteItem;
+use Throwable;
 
 class QuoteMigrator implements EntityMigratorInterface
 {
@@ -22,14 +23,14 @@ class QuoteMigrator implements EntityMigratorInterface
 
     public function inspect(MigrationContext $context): array
     {
-        $quotes = $context->getSourceTable('quotes');
-        $notes = [];
+        $quotes      = $context->getSourceTable('quotes');
+        $notes       = [];
         $willMigrate = 0;
-        $unmappable = 0;
+        $unmappable  = 0;
 
         foreach ($quotes as $row) {
             $clientId = $row['client_id'] ?? null;
-            if (!$clientId) {
+            if ( ! $clientId) {
                 $unmappable++;
                 $notes[] = "Quote #{$row['quote_number']} has no client_id, will be skipped.";
             } else {
@@ -47,21 +48,21 @@ class QuoteMigrator implements EntityMigratorInterface
 
     public function migrate(MigrationContext $context): array
     {
-        $quotes = $context->getSourceTable('quotes');
-        $items = $context->getSourceTable('quote_items')->groupBy('quote_id');
+        $quotes  = $context->getSourceTable('quotes');
+        $items   = $context->getSourceTable('quote_items')->groupBy('quote_id');
         $amounts = $context->getSourceTable('quote_amounts')->keyBy('quote_id');
 
         $migrated = 0;
-        $skipped = 0;
-        $errors = [];
+        $skipped  = 0;
+        $errors   = [];
 
         foreach ($quotes as $row) {
-            $v1Id = $row['quote_id'] ?? null;
-            $v1ClientId = $row['client_id'] ?? null;
-            $quoteNumber = trim((string) ($row['quote_number'] ?? ''));
+            $v1Id        = $row['quote_id'] ?? null;
+            $v1ClientId  = $row['client_id'] ?? null;
+            $quoteNumber = mb_trim((string) ($row['quote_number'] ?? ''));
 
             $prospectId = $context->getId('clients', $v1ClientId);
-            if (!$prospectId) {
+            if ( ! $prospectId) {
                 $errors[] = "Quote #{$quoteNumber} skipped: client #{$v1ClientId} not found in target company.";
                 $skipped++;
                 continue;
@@ -77,35 +78,35 @@ class QuoteMigrator implements EntityMigratorInterface
 
             try {
                 $v1Amount = $amounts[$v1Id] ?? [];
-                $status = $this->resolveStatus($row);
+                $status   = $this->resolveStatus($row);
 
                 $itemSubtotal = (float) ($v1Amount['quote_item_subtotal'] ?? 0.0);
                 $itemTaxTotal = (float) ($v1Amount['quote_item_tax_total'] ?? 0.0);
-                $taxTotal = (float) ($v1Amount['quote_tax_total'] ?? 0.0);
-                $total = (float) ($v1Amount['quote_total'] ?? 0.0);
+                $taxTotal     = (float) ($v1Amount['quote_tax_total'] ?? 0.0);
+                $total        = (float) ($v1Amount['quote_total'] ?? 0.0);
 
                 $quote = Quote::withoutGlobalScopes()
                     ->where('company_id', $context->getCompanyId())
                     ->where('quote_number', $quoteNumber)
                     ->first();
 
-                if (!$quote) {
+                if ( ! $quote) {
                     $quote = Quote::create([
                         'company_id'             => $context->getCompanyId(),
                         'prospect_id'            => $prospectId,
                         'user_id'                => $context->getUserId(),
                         'quote_number'           => $quoteNumber ?: ('QUO-' . $v1Id),
                         'quote_status'           => $status,
-                        'quoted_at'              => !empty($row['quote_date_created']) ? $row['quote_date_created'] : now(),
-                        'quote_expires_at'       => !empty($row['quote_date_expires']) ? $row['quote_date_expires'] : now()->addDays(30),
+                        'quoted_at'              => ! empty($row['quote_date_created']) ? $row['quote_date_created'] : now(),
+                        'quote_expires_at'       => ! empty($row['quote_date_expires']) ? $row['quote_date_expires'] : now()->addDays(30),
                         'quote_discount_amount'  => (float) ($row['quote_discount_amount'] ?? 0.0),
                         'quote_discount_percent' => (float) ($row['quote_discount_percent'] ?? 0.0),
                         'quote_item_subtotal'    => $itemSubtotal,
                         'item_tax_total'         => $itemTaxTotal,
                         'quote_tax_total'        => $taxTotal,
                         'quote_total'            => $total,
-                        'quote_password'         => !empty($row['quote_password']) ? (string) $row['quote_password'] : null,
-                        'url_key'                => !empty($row['quote_url_key']) ? (string) $row['quote_url_key'] : null,
+                        'quote_password'         => ! empty($row['quote_password']) ? (string) $row['quote_password'] : null,
+                        'url_key'                => ! empty($row['quote_url_key']) ? (string) $row['quote_url_key'] : null,
                     ]);
                     $context->recordCreated(Quote::class, $quote->id);
                 }
@@ -120,11 +121,11 @@ class QuoteMigrator implements EntityMigratorInterface
                     $taxRateId = $context->getId('tax_rates', $itemRow['item_tax_rate_id'] ?? null);
                     $productId = $context->getId('products', $itemRow['item_product_id'] ?? null);
 
-                    $qty = (float) ($itemRow['item_quantity'] ?? 1.0);
-                    $price = (float) ($itemRow['item_price'] ?? 0.0);
-                    $discount = (float) ($itemRow['item_discount_amount'] ?? 0.0);
-                    $subtotal = (float) ($itemRow['item_subtotal'] ?? ($qty * $price));
-                    $itemTax = (float) ($itemRow['item_tax_total'] ?? 0.0);
+                    $qty       = (float) ($itemRow['item_quantity'] ?? 1.0);
+                    $price     = (float) ($itemRow['item_price'] ?? 0.0);
+                    $discount  = (float) ($itemRow['item_discount_amount'] ?? 0.0);
+                    $subtotal  = (float) ($itemRow['item_subtotal'] ?? ($qty * $price));
+                    $itemTax   = (float) ($itemRow['item_tax_total'] ?? 0.0);
                     $itemTotal = (float) ($itemRow['item_total'] ?? ($subtotal + $itemTax));
 
                     $item = QuoteItem::create([
@@ -132,8 +133,8 @@ class QuoteMigrator implements EntityMigratorInterface
                         'quote_id'      => $quote->id,
                         'product_id'    => $productId,
                         'tax_rate_id'   => $taxRateId,
-                        'item_name'     => !empty($itemRow['item_name']) ? (string) $itemRow['item_name'] : 'Item',
-                        'description'   => !empty($itemRow['item_description']) ? (string) $itemRow['item_description'] : null,
+                        'item_name'     => ! empty($itemRow['item_name']) ? (string) $itemRow['item_name'] : 'Item',
+                        'description'   => ! empty($itemRow['item_description']) ? (string) $itemRow['item_description'] : null,
                         'quantity'      => $qty,
                         'price'         => $price,
                         'discount'      => $discount,
@@ -142,13 +143,13 @@ class QuoteMigrator implements EntityMigratorInterface
                         'tax_total'     => $itemTax,
                         'total'         => $itemTotal,
                         'display_order' => (int) ($itemRow['item_order'] ?? 1),
-                        'added_at'      => !empty($itemRow['item_date_added']) ? $itemRow['item_date_added'] : $quote->quoted_at,
+                        'added_at'      => ! empty($itemRow['item_date_added']) ? $itemRow['item_date_added'] : $quote->quoted_at,
                     ]);
                     $context->recordCreated(QuoteItem::class, $item->id);
                 }
 
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = "Failed to migrate quote #{$quoteNumber}: " . $e->getMessage();
                 $skipped++;
             }
@@ -163,31 +164,12 @@ class QuoteMigrator implements EntityMigratorInterface
         ];
     }
 
-    protected function resolveStatus(array $row): QuoteStatus
-    {
-        $statusId = (int) ($row['quote_status_id'] ?? 1);
-        $invoiceId = $row['invoice_id'] ?? null;
-
-        if (!empty($invoiceId)) {
-            return QuoteStatus::CONVERTED;
-        }
-
-        return match ($statusId) {
-            2       => QuoteStatus::SENT,
-            3       => QuoteStatus::VIEWED,
-            4       => QuoteStatus::APPROVED,
-            5       => QuoteStatus::REJECTED,
-            6       => QuoteStatus::CONVERTED,
-            default => QuoteStatus::DRAFT,
-        };
-    }
-
     public function rollback(MigrationContext $context): int
     {
-        $itemIds = $context->getCreatedIds(QuoteItem::class);
+        $itemIds  = $context->getCreatedIds(QuoteItem::class);
         $quoteIds = $context->getCreatedIds(Quote::class);
 
-        if (!empty($itemIds)) {
+        if ( ! empty($itemIds)) {
             QuoteItem::withoutGlobalScopes()->whereIn('id', $itemIds)->delete();
         }
 
@@ -199,5 +181,24 @@ class QuoteMigrator implements EntityMigratorInterface
             ->whereIn('id', $quoteIds)
             ->where('company_id', $context->getCompanyId())
             ->forceDelete();
+    }
+
+    protected function resolveStatus(array $row): QuoteStatus
+    {
+        $statusId  = (int) ($row['quote_status_id'] ?? 1);
+        $invoiceId = $row['invoice_id'] ?? null;
+
+        if ( ! empty($invoiceId)) {
+            return QuoteStatus::CONVERTED;
+        }
+
+        return match ($statusId) {
+            2       => QuoteStatus::SENT,
+            3       => QuoteStatus::VIEWED,
+            4       => QuoteStatus::APPROVED,
+            5       => QuoteStatus::REJECTED,
+            6       => QuoteStatus::CONVERTED,
+            default => QuoteStatus::DRAFT,
+        };
     }
 }

--- a/Modules/Core/Services/Migration/Migrators/QuoteMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/QuoteMigrator.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Migrators;
+
+use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
+use Modules\Core\Services\Migration\MigrationContext;
+use Modules\Quotes\Enums\QuoteStatus;
+use Modules\Quotes\Models\Quote;
+use Modules\Quotes\Models\QuoteItem;
+
+class QuoteMigrator implements EntityMigratorInterface
+{
+    public function name(): string
+    {
+        return 'quotes';
+    }
+
+    public function label(): string
+    {
+        return 'Quotes & Items';
+    }
+
+    public function inspect(MigrationContext $context): array
+    {
+        $quotes = $context->getSourceTable('quotes');
+        $notes = [];
+        $willMigrate = 0;
+        $unmappable = 0;
+
+        foreach ($quotes as $row) {
+            $clientId = $row['client_id'] ?? null;
+            if (!$clientId) {
+                $unmappable++;
+                $notes[] = "Quote #{$row['quote_number']} has no client_id, will be skipped.";
+            } else {
+                $willMigrate++;
+            }
+        }
+
+        return [
+            'source_count' => $quotes->count(),
+            'will_migrate' => $willMigrate,
+            'unmappable'   => $unmappable,
+            'notes'        => $notes,
+        ];
+    }
+
+    public function migrate(MigrationContext $context): array
+    {
+        $quotes = $context->getSourceTable('quotes');
+        $items = $context->getSourceTable('quote_items')->groupBy('quote_id');
+        $amounts = $context->getSourceTable('quote_amounts')->keyBy('quote_id');
+
+        $migrated = 0;
+        $skipped = 0;
+        $errors = [];
+
+        foreach ($quotes as $row) {
+            $v1Id = $row['quote_id'] ?? null;
+            $v1ClientId = $row['client_id'] ?? null;
+            $quoteNumber = trim((string) ($row['quote_number'] ?? ''));
+
+            $prospectId = $context->getId('clients', $v1ClientId);
+            if (!$prospectId) {
+                $errors[] = "Quote #{$quoteNumber} skipped: client #{$v1ClientId} not found in target company.";
+                $skipped++;
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                if ($v1Id !== null) {
+                    $context->mapId('quotes', $v1Id, (int) $v1Id);
+                }
+                $migrated++;
+                continue;
+            }
+
+            try {
+                $v1Amount = $amounts[$v1Id] ?? [];
+                $status = $this->resolveStatus($row);
+
+                $itemSubtotal = (float) ($v1Amount['quote_item_subtotal'] ?? 0.0);
+                $itemTaxTotal = (float) ($v1Amount['quote_item_tax_total'] ?? 0.0);
+                $taxTotal = (float) ($v1Amount['quote_tax_total'] ?? 0.0);
+                $total = (float) ($v1Amount['quote_total'] ?? 0.0);
+
+                $quote = Quote::withoutGlobalScopes()
+                    ->where('company_id', $context->getCompanyId())
+                    ->where('quote_number', $quoteNumber)
+                    ->first();
+
+                if (!$quote) {
+                    $quote = Quote::create([
+                        'company_id'             => $context->getCompanyId(),
+                        'prospect_id'            => $prospectId,
+                        'user_id'                => $context->getUserId(),
+                        'quote_number'           => $quoteNumber ?: ('QUO-' . $v1Id),
+                        'quote_status'           => $status,
+                        'quoted_at'              => !empty($row['quote_date_created']) ? $row['quote_date_created'] : now(),
+                        'quote_expires_at'       => !empty($row['quote_date_expires']) ? $row['quote_date_expires'] : now()->addDays(30),
+                        'quote_discount_amount'  => (float) ($row['quote_discount_amount'] ?? 0.0),
+                        'quote_discount_percent' => (float) ($row['quote_discount_percent'] ?? 0.0),
+                        'quote_item_subtotal'    => $itemSubtotal,
+                        'item_tax_total'         => $itemTaxTotal,
+                        'quote_tax_total'        => $taxTotal,
+                        'quote_total'            => $total,
+                        'quote_password'         => !empty($row['quote_password']) ? (string) $row['quote_password'] : null,
+                        'url_key'                => !empty($row['quote_url_key']) ? (string) $row['quote_url_key'] : null,
+                    ]);
+                    $context->recordCreated(Quote::class, $quote->id);
+                }
+
+                if ($v1Id !== null) {
+                    $context->mapId('quotes', $v1Id, $quote->id);
+                }
+
+                // Migrate quote items
+                $quoteItems = $items[$v1Id] ?? collect();
+                foreach ($quoteItems as $itemRow) {
+                    $taxRateId = $context->getId('tax_rates', $itemRow['item_tax_rate_id'] ?? null);
+                    $productId = $context->getId('products', $itemRow['item_product_id'] ?? null);
+
+                    $qty = (float) ($itemRow['item_quantity'] ?? 1.0);
+                    $price = (float) ($itemRow['item_price'] ?? 0.0);
+                    $discount = (float) ($itemRow['item_discount_amount'] ?? 0.0);
+                    $subtotal = (float) ($itemRow['item_subtotal'] ?? ($qty * $price));
+                    $itemTax = (float) ($itemRow['item_tax_total'] ?? 0.0);
+                    $itemTotal = (float) ($itemRow['item_total'] ?? ($subtotal + $itemTax));
+
+                    $item = QuoteItem::create([
+                        'company_id'    => $context->getCompanyId(),
+                        'quote_id'      => $quote->id,
+                        'product_id'    => $productId,
+                        'tax_rate_id'   => $taxRateId,
+                        'item_name'     => !empty($itemRow['item_name']) ? (string) $itemRow['item_name'] : 'Item',
+                        'description'   => !empty($itemRow['item_description']) ? (string) $itemRow['item_description'] : null,
+                        'quantity'      => $qty,
+                        'price'         => $price,
+                        'discount'      => $discount,
+                        'subtotal'      => $subtotal,
+                        'tax_1'         => $itemTax,
+                        'tax_total'     => $itemTax,
+                        'total'         => $itemTotal,
+                        'display_order' => (int) ($itemRow['item_order'] ?? 1),
+                        'added_at'      => !empty($itemRow['item_date_added']) ? $itemRow['item_date_added'] : $quote->quoted_at,
+                    ]);
+                    $context->recordCreated(QuoteItem::class, $item->id);
+                }
+
+                $migrated++;
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate quote #{$quoteNumber}: " . $e->getMessage();
+                $skipped++;
+            }
+        }
+
+        $context->log("Migrated {$migrated} quotes ({$skipped} skipped).");
+
+        return [
+            'migrated' => $migrated,
+            'skipped'  => $skipped,
+            'errors'   => $errors,
+        ];
+    }
+
+    protected function resolveStatus(array $row): QuoteStatus
+    {
+        $statusId = (int) ($row['quote_status_id'] ?? 1);
+        $invoiceId = $row['invoice_id'] ?? null;
+
+        if (!empty($invoiceId)) {
+            return QuoteStatus::CONVERTED;
+        }
+
+        return match ($statusId) {
+            2       => QuoteStatus::SENT,
+            3       => QuoteStatus::VIEWED,
+            4       => QuoteStatus::APPROVED,
+            5       => QuoteStatus::REJECTED,
+            6       => QuoteStatus::CONVERTED,
+            default => QuoteStatus::DRAFT,
+        };
+    }
+
+    public function rollback(MigrationContext $context): int
+    {
+        $itemIds = $context->getCreatedIds(QuoteItem::class);
+        $quoteIds = $context->getCreatedIds(Quote::class);
+
+        if (!empty($itemIds)) {
+            QuoteItem::withoutGlobalScopes()->whereIn('id', $itemIds)->delete();
+        }
+
+        if (empty($quoteIds)) {
+            return 0;
+        }
+
+        return Quote::withoutGlobalScopes()
+            ->whereIn('id', $quoteIds)
+            ->where('company_id', $context->getCompanyId())
+            ->forceDelete();
+    }
+}

--- a/Modules/Core/Services/Migration/Migrators/TaxRateMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/TaxRateMigrator.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Migrators;
+
+use Modules\Core\Enums\TaxRateType;
+use Modules\Core\Models\TaxRate;
+use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
+use Modules\Core\Services\Migration\MigrationContext;
+
+class TaxRateMigrator implements EntityMigratorInterface
+{
+    public function name(): string
+    {
+        return 'tax_rates';
+    }
+
+    public function label(): string
+    {
+        return 'Tax Rates';
+    }
+
+    public function inspect(MigrationContext $context): array
+    {
+        $rows = $context->getSourceTable('tax_rates');
+        $notes = [];
+
+        $willMigrate = 0;
+        $unmappable = 0;
+
+        foreach ($rows as $row) {
+            $name = trim((string) ($row['tax_rate_name'] ?? ''));
+            if ($name === '') {
+                $unmappable++;
+                $notes[] = "Tax rate row #{$row['tax_rate_id']} has empty name, will be skipped.";
+            } else {
+                $willMigrate++;
+            }
+        }
+
+        return [
+            'source_count' => $rows->count(),
+            'will_migrate' => $willMigrate,
+            'unmappable'   => $unmappable,
+            'notes'        => $notes,
+        ];
+    }
+
+    public function migrate(MigrationContext $context): array
+    {
+        $rows = $context->getSourceTable('tax_rates');
+        $migrated = 0;
+        $skipped = 0;
+        $errors = [];
+
+        foreach ($rows as $row) {
+            $v1Id = $row['tax_rate_id'] ?? null;
+            $name = trim((string) ($row['tax_rate_name'] ?? ''));
+            $rate = (float) ($row['tax_rate_percent'] ?? 0.0);
+            $code = !empty($row['tax_rate_code']) ? (string) $row['tax_rate_code'] : strtoupper(substr(preg_replace('/[^a-zA-Z0-9]/', '', $name) ?: 'TAX', 0, 10));
+
+            if ($name === '') {
+                $skipped++;
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                if ($v1Id !== null) {
+                    $context->mapId('tax_rates', $v1Id, (int) $v1Id);
+                }
+                $migrated++;
+                continue;
+            }
+
+            try {
+                // Idempotency check: see if a tax rate with same name/rate exists for company
+                $taxRate = TaxRate::withoutGlobalScopes()
+                    ->where('company_id', $context->getCompanyId())
+                    ->where('name', $name)
+                    ->first();
+
+                if (!$taxRate) {
+                    $taxRate = TaxRate::create([
+                        'company_id'    => $context->getCompanyId(),
+                        'name'          => $name,
+                        'rate'          => $rate,
+                        'code'          => $code,
+                        'is_active'     => true,
+                        'is_compound'   => (bool) ($row['tax_rate_is_compound'] ?? false),
+                        'calculate_vat' => (bool) ($row['tax_rate_calculate_vat'] ?? false),
+                        'tax_rate_type' => TaxRateType::EXCLUSIVE,
+                    ]);
+                    $context->recordCreated(TaxRate::class, $taxRate->id);
+                } else {
+                    $taxRate->update([
+                        'rate'          => $rate,
+                        'code'          => $code,
+                        'is_compound'   => (bool) ($row['tax_rate_is_compound'] ?? false),
+                        'calculate_vat' => (bool) ($row['tax_rate_calculate_vat'] ?? false),
+                    ]);
+                }
+
+                if ($v1Id !== null) {
+                    $context->mapId('tax_rates', $v1Id, $taxRate->id);
+                }
+
+                $migrated++;
+            } catch (\Throwable $e) {
+                $errors[] = "Failed to migrate tax rate '{$name}': " . $e->getMessage();
+                $skipped++;
+            }
+        }
+
+        $context->log("Migrated {$migrated} tax rates ({$skipped} skipped).");
+
+        return [
+            'migrated' => $migrated,
+            'skipped'  => $skipped,
+            'errors'   => $errors,
+        ];
+    }
+
+    public function rollback(MigrationContext $context): int
+    {
+        $ids = $context->getCreatedIds(TaxRate::class);
+        if (empty($ids)) {
+            return 0;
+        }
+
+        return TaxRate::withoutGlobalScopes()
+            ->whereIn('id', $ids)
+            ->where('company_id', $context->getCompanyId())
+            ->delete();
+    }
+}

--- a/Modules/Core/Services/Migration/Migrators/TaxRateMigrator.php
+++ b/Modules/Core/Services/Migration/Migrators/TaxRateMigrator.php
@@ -6,6 +6,7 @@ use Modules\Core\Enums\TaxRateType;
 use Modules\Core\Models\TaxRate;
 use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
 use Modules\Core\Services\Migration\MigrationContext;
+use Throwable;
 
 class TaxRateMigrator implements EntityMigratorInterface
 {
@@ -21,14 +22,14 @@ class TaxRateMigrator implements EntityMigratorInterface
 
     public function inspect(MigrationContext $context): array
     {
-        $rows = $context->getSourceTable('tax_rates');
+        $rows  = $context->getSourceTable('tax_rates');
         $notes = [];
 
         $willMigrate = 0;
-        $unmappable = 0;
+        $unmappable  = 0;
 
         foreach ($rows as $row) {
-            $name = trim((string) ($row['tax_rate_name'] ?? ''));
+            $name = mb_trim((string) ($row['tax_rate_name'] ?? ''));
             if ($name === '') {
                 $unmappable++;
                 $notes[] = "Tax rate row #{$row['tax_rate_id']} has empty name, will be skipped.";
@@ -47,16 +48,16 @@ class TaxRateMigrator implements EntityMigratorInterface
 
     public function migrate(MigrationContext $context): array
     {
-        $rows = $context->getSourceTable('tax_rates');
+        $rows     = $context->getSourceTable('tax_rates');
         $migrated = 0;
-        $skipped = 0;
-        $errors = [];
+        $skipped  = 0;
+        $errors   = [];
 
         foreach ($rows as $row) {
             $v1Id = $row['tax_rate_id'] ?? null;
-            $name = trim((string) ($row['tax_rate_name'] ?? ''));
+            $name = mb_trim((string) ($row['tax_rate_name'] ?? ''));
             $rate = (float) ($row['tax_rate_percent'] ?? 0.0);
-            $code = !empty($row['tax_rate_code']) ? (string) $row['tax_rate_code'] : strtoupper(substr(preg_replace('/[^a-zA-Z0-9]/', '', $name) ?: 'TAX', 0, 10));
+            $code = ! empty($row['tax_rate_code']) ? (string) $row['tax_rate_code'] : mb_strtoupper(mb_substr(preg_replace('/[^a-zA-Z0-9]/', '', $name) ?: 'TAX', 0, 10));
 
             if ($name === '') {
                 $skipped++;
@@ -78,7 +79,7 @@ class TaxRateMigrator implements EntityMigratorInterface
                     ->where('name', $name)
                     ->first();
 
-                if (!$taxRate) {
+                if ( ! $taxRate) {
                     $taxRate = TaxRate::create([
                         'company_id'    => $context->getCompanyId(),
                         'name'          => $name,
@@ -104,7 +105,7 @@ class TaxRateMigrator implements EntityMigratorInterface
                 }
 
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = "Failed to migrate tax rate '{$name}': " . $e->getMessage();
                 $skipped++;
             }

--- a/Modules/Core/Services/Migration/Support/FinancialInvariantValidator.php
+++ b/Modules/Core/Services/Migration/Support/FinancialInvariantValidator.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Support;
+
+use Modules\Core\Services\Migration\MigrationContext;
+use Modules\Invoices\Models\Invoice;
+use Modules\Quotes\Models\Quote;
+
+class FinancialInvariantValidator
+{
+    /**
+     * Validate financial invariants for all migrated invoices and quotes.
+     *
+     * @return array{
+     *     passed: bool,
+     *     invoices_checked: int,
+     *     quotes_checked: int,
+     *     passed_count: int,
+     *     failed_count: int,
+     *     mismatches: array<array{type: string, id: int, number: string, field: string, expected: float, actual: float}>
+     * }
+     */
+    public function validate(MigrationContext $context): array
+    {
+        $mismatches = [];
+        $invoicesChecked = 0;
+        $quotesChecked = 0;
+        $passedCount = 0;
+        $failedCount = 0;
+
+        // Validate Invoices
+        $invoiceAmounts = $context->getSourceTable('invoice_amounts')->keyBy('invoice_id');
+        $createdInvoiceIds = $context->getCreatedIds(Invoice::class);
+
+        foreach ($createdInvoiceIds as $v2InvoiceId) {
+            $invoice = Invoice::withoutGlobalScopes()->find($v2InvoiceId);
+            if (!$invoice) {
+                continue;
+            }
+
+            // Find corresponding v1 ID
+            $v1Id = null;
+            foreach ($context->getSourceTable('invoices') as $v1Row) {
+                if ($context->getId('invoices', $v1Row['invoice_id'] ?? null) === $v2InvoiceId) {
+                    $v1Id = $v1Row['invoice_id'];
+                    break;
+                }
+            }
+
+            if ($v1Id === null || !isset($invoiceAmounts[$v1Id])) {
+                continue;
+            }
+
+            $v1Amount = $invoiceAmounts[$v1Id];
+            $invoicesChecked++;
+            $invoicePassed = true;
+
+            $checks = [
+                'invoice_item_subtotal' => [(float) ($v1Amount['invoice_item_subtotal'] ?? 0), (float) ($invoice->invoice_item_subtotal ?? 0)],
+                'invoice_tax_total'     => [(float) ($v1Amount['invoice_tax_total'] ?? 0), (float) ($invoice->invoice_tax_total ?? 0)],
+                'invoice_total'         => [(float) ($v1Amount['invoice_total'] ?? 0), (float) ($invoice->invoice_total ?? 0)],
+                'invoice_paid'          => [(float) ($v1Amount['invoice_paid'] ?? 0), (float) ($invoice->payments()->sum('payment_amount') ?? 0)],
+            ];
+
+            // In v1, balance = invoice_total - invoice_paid
+            $expectedBalance = (float) ($v1Amount['invoice_balance'] ?? 0);
+            $actualBalance = (float) $invoice->invoice_total - (float) $invoice->payments()->sum('payment_amount');
+            $checks['invoice_balance'] = [$expectedBalance, $actualBalance];
+
+            foreach ($checks as $field => [$expected, $actual]) {
+                if (abs($expected - $actual) > 0.01) {
+                    $invoicePassed = false;
+                    $mismatches[] = [
+                        'type'     => 'invoice',
+                        'id'       => $invoice->id,
+                        'number'   => (string) ($invoice->invoice_number ?? $invoice->id),
+                        'field'    => $field,
+                        'expected' => round($expected, 2),
+                        'actual'   => round($actual, 2),
+                    ];
+                }
+            }
+
+            if ($invoicePassed) {
+                $passedCount++;
+            } else {
+                $failedCount++;
+            }
+        }
+
+        // Validate Quotes
+        $quoteAmounts = $context->getSourceTable('quote_amounts')->keyBy('quote_id');
+        $createdQuoteIds = $context->getCreatedIds(Quote::class);
+
+        foreach ($createdQuoteIds as $v2QuoteId) {
+            $quote = Quote::withoutGlobalScopes()->find($v2QuoteId);
+            if (!$quote) {
+                continue;
+            }
+
+            $v1Id = null;
+            foreach ($context->getSourceTable('quotes') as $v1Row) {
+                if ($context->getId('quotes', $v1Row['quote_id'] ?? null) === $v2QuoteId) {
+                    $v1Id = $v1Row['quote_id'];
+                    break;
+                }
+            }
+
+            if ($v1Id === null || !isset($quoteAmounts[$v1Id])) {
+                continue;
+            }
+
+            $v1Amount = $quoteAmounts[$v1Id];
+            $quotesChecked++;
+            $quotePassed = true;
+
+            $checks = [
+                'quote_item_subtotal' => [(float) ($v1Amount['quote_item_subtotal'] ?? 0), (float) ($quote->quote_item_subtotal ?? 0)],
+                'quote_tax_total'     => [(float) ($v1Amount['quote_tax_total'] ?? 0), (float) ($quote->quote_tax_total ?? 0)],
+                'quote_total'         => [(float) ($v1Amount['quote_total'] ?? 0), (float) ($quote->quote_total ?? 0)],
+            ];
+
+            foreach ($checks as $field => [$expected, $actual]) {
+                if (abs($expected - $actual) > 0.01) {
+                    $quotePassed = false;
+                    $mismatches[] = [
+                        'type'     => 'quote',
+                        'id'       => $quote->id,
+                        'number'   => (string) ($quote->quote_number ?? $quote->id),
+                        'field'    => $field,
+                        'expected' => round($expected, 2),
+                        'actual'   => round($actual, 2),
+                    ];
+                }
+            }
+
+            if ($quotePassed) {
+                $passedCount++;
+            } else {
+                $failedCount++;
+            }
+        }
+
+        return [
+            'passed'           => empty($mismatches),
+            'invoices_checked' => $invoicesChecked,
+            'quotes_checked'   => $quotesChecked,
+            'passed_count'     => $passedCount,
+            'failed_count'     => $failedCount,
+            'mismatches'       => $mismatches,
+        ];
+    }
+}

--- a/Modules/Core/Services/Migration/Support/FinancialInvariantValidator.php
+++ b/Modules/Core/Services/Migration/Support/FinancialInvariantValidator.php
@@ -22,19 +22,19 @@ class FinancialInvariantValidator
      */
     public function validate(MigrationContext $context): array
     {
-        $mismatches = [];
+        $mismatches      = [];
         $invoicesChecked = 0;
-        $quotesChecked = 0;
-        $passedCount = 0;
-        $failedCount = 0;
+        $quotesChecked   = 0;
+        $passedCount     = 0;
+        $failedCount     = 0;
 
         // Validate Invoices
-        $invoiceAmounts = $context->getSourceTable('invoice_amounts')->keyBy('invoice_id');
+        $invoiceAmounts    = $context->getSourceTable('invoice_amounts')->keyBy('invoice_id');
         $createdInvoiceIds = $context->getCreatedIds(Invoice::class);
 
         foreach ($createdInvoiceIds as $v2InvoiceId) {
             $invoice = Invoice::withoutGlobalScopes()->find($v2InvoiceId);
-            if (!$invoice) {
+            if ( ! $invoice) {
                 continue;
             }
 
@@ -47,7 +47,7 @@ class FinancialInvariantValidator
                 }
             }
 
-            if ($v1Id === null || !isset($invoiceAmounts[$v1Id])) {
+            if ($v1Id === null || ! isset($invoiceAmounts[$v1Id])) {
                 continue;
             }
 
@@ -63,14 +63,14 @@ class FinancialInvariantValidator
             ];
 
             // In v1, balance = invoice_total - invoice_paid
-            $expectedBalance = (float) ($v1Amount['invoice_balance'] ?? 0);
-            $actualBalance = (float) $invoice->invoice_total - (float) $invoice->payments()->sum('payment_amount');
+            $expectedBalance           = (float) ($v1Amount['invoice_balance'] ?? 0);
+            $actualBalance             = (float) $invoice->invoice_total - (float) $invoice->payments()->sum('payment_amount');
             $checks['invoice_balance'] = [$expectedBalance, $actualBalance];
 
             foreach ($checks as $field => [$expected, $actual]) {
                 if (abs($expected - $actual) > 0.01) {
                     $invoicePassed = false;
-                    $mismatches[] = [
+                    $mismatches[]  = [
                         'type'     => 'invoice',
                         'id'       => $invoice->id,
                         'number'   => (string) ($invoice->invoice_number ?? $invoice->id),
@@ -89,12 +89,12 @@ class FinancialInvariantValidator
         }
 
         // Validate Quotes
-        $quoteAmounts = $context->getSourceTable('quote_amounts')->keyBy('quote_id');
+        $quoteAmounts    = $context->getSourceTable('quote_amounts')->keyBy('quote_id');
         $createdQuoteIds = $context->getCreatedIds(Quote::class);
 
         foreach ($createdQuoteIds as $v2QuoteId) {
             $quote = Quote::withoutGlobalScopes()->find($v2QuoteId);
-            if (!$quote) {
+            if ( ! $quote) {
                 continue;
             }
 
@@ -106,7 +106,7 @@ class FinancialInvariantValidator
                 }
             }
 
-            if ($v1Id === null || !isset($quoteAmounts[$v1Id])) {
+            if ($v1Id === null || ! isset($quoteAmounts[$v1Id])) {
                 continue;
             }
 
@@ -122,7 +122,7 @@ class FinancialInvariantValidator
 
             foreach ($checks as $field => [$expected, $actual]) {
                 if (abs($expected - $actual) > 0.01) {
-                    $quotePassed = false;
+                    $quotePassed  = false;
                     $mismatches[] = [
                         'type'     => 'quote',
                         'id'       => $quote->id,

--- a/Modules/Core/Services/Migration/Support/V1SqlDumpParser.php
+++ b/Modules/Core/Services/Migration/Support/V1SqlDumpParser.php
@@ -8,6 +8,7 @@ class V1SqlDumpParser
      * Parse SQL file or raw SQL string into structured table rows.
      *
      * @param string $sqlOrPath Path to .sql file or raw SQL content
+     *
      * @return array<string, array<int, array<string, mixed>>> Keyed by table name
      */
     public function parse(string $sqlOrPath): array
@@ -17,7 +18,7 @@ class V1SqlDumpParser
             return [];
         }
 
-        $tables = [];
+        $tables       = [];
         $tableColumns = [];
 
         // 1. First pass: find CREATE TABLE statements to get column orders if INSERT doesn't specify columns
@@ -30,109 +31,20 @@ class V1SqlDumpParser
     }
 
     /**
-     * Extract table schemas from CREATE TABLE definitions.
-     *
-     * @param array<string, array<int, string>> $tableColumns
-     */
-    protected function extractCreateTables(string $content, array &$tableColumns): void
-    {
-        $pattern = '/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\.)?[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\s*\((.*?)\)\s*(?:ENGINE|DEFAULT|AUTO_INCREMENT|CHARSET|COLLATE|;)/is';
-
-        if (preg_match_all($pattern, $content, $matches, PREG_SET_ORDER)) {
-            foreach ($matches as $match) {
-                $tableName = !empty($match[2]) ? $match[2] : $match[1];
-                $body = $match[3];
-
-                $cols = [];
-                $lines = explode("\n", $body);
-                foreach ($lines as $line) {
-                    $trimmed = trim($line);
-                    if ($trimmed === '' || str_starts_with($trimmed, '--') || str_starts_with($trimmed, '/*')) {
-                        continue;
-                    }
-
-                    // Check if line defines a column (not KEY, PRIMARY KEY, CONSTRAINT, etc.)
-                    if (preg_match('/^[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\s+(?:int|varchar|char|text|datetime|date|decimal|tinyint|smallint|bigint|mediumtext|longtext|enum|float|double|timestamp)/i', $trimmed, $colMatch)) {
-                        $colName = $colMatch[1];
-                        if (!in_array(strtoupper($colName), ['PRIMARY', 'KEY', 'UNIQUE', 'CONSTRAINT', 'FOREIGN', 'CHECK', 'INDEX'])) {
-                            $cols[] = $colName;
-                        }
-                    }
-                }
-
-                if (!empty($cols)) {
-                    $tableColumns[$tableName] = $cols;
-                }
-            }
-        }
-    }
-
-    /**
-     * Extract and parse INSERT INTO statements.
-     *
-     * @param array<string, array<int, string>> $tableColumns
-     * @param array<string, array<int, array<string, mixed>>> $tables
-     */
-    protected function extractInserts(string $content, array $tableColumns, array &$tables): void
-    {
-        // Match INSERT INTO `tableName` (`col1`, `col2`) VALUES (...) or INSERT INTO `tableName` VALUES (...)
-        $insertPattern = '/INSERT\s+INTO\s+[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\s*(?:\((.*?)\))?\s*VALUES\s*(.*?)(\s*;\s*(?:\r?\n|$))/is';
-
-        if (preg_match_all($insertPattern, $content, $matches, PREG_SET_ORDER)) {
-            foreach ($matches as $match) {
-                $tableName = $match[1];
-                $columnsRaw = trim($match[2] ?? '');
-                $valuesRaw = trim($match[3] ?? '');
-
-                $columns = [];
-                if ($columnsRaw !== '') {
-                    // Parse column list e.g. `col1`, `col2`
-                    preg_match_all('/[`\'"]?([a-zA-Z0-9_]+)[`\'"]?/', $columnsRaw, $colMatches);
-                    $columns = array_filter($colMatches[1] ?? [], fn ($c) => $c !== '');
-                } elseif (isset($tableColumns[$tableName])) {
-                    $columns = $tableColumns[$tableName];
-                }
-
-                if (!isset($tables[$tableName])) {
-                    $tables[$tableName] = [];
-                }
-
-                // Parse value tuples (val1, val2), (val3, val4)
-                $tuples = $this->parseValueTuples($valuesRaw);
-                foreach ($tuples as $tuple) {
-                    $row = [];
-                    if (!empty($columns)) {
-                        $colKeys = array_values($columns);
-                        foreach ($tuple as $i => $val) {
-                            $colName = $colKeys[$i] ?? ('col_' . $i);
-                            $row[$colName] = $val;
-                        }
-                    } else {
-                        foreach ($tuple as $i => $val) {
-                            $row['col_' . $i] = $val;
-                        }
-                    }
-                    $tables[$tableName][] = $row;
-                }
-            }
-        }
-    }
-
-    /**
-     * Robust tokenizer for SQL value tuples like: (1, 'hello', NULL, 12.34), (2, 'world, with \'quote\'', '2026-01-01')
+     * Robust tokenizer for SQL value tuples like: (1, 'hello', NULL, 12.34), (2, 'world, with \'quote\'', '2026-01-01').
      *
      * @return array<int, array<int, mixed>>
      */
     public function parseValueTuples(string $valuesString): array
     {
-        $tuples = [];
-        $length = strlen($valuesString);
-        $inTuple = false;
-        $inString = false;
-        $quoteChar = '';
+        $tuples       = [];
+        $length       = mb_strlen($valuesString);
+        $inTuple      = false;
+        $inString     = false;
+        $quoteChar    = '';
         $currentValue = '';
         $currentTuple = [];
-        $isEscaped = false;
+        $isEscaped    = false;
 
         for ($i = 0; $i < $length; $i++) {
             $char = $valuesString[$i];
@@ -158,30 +70,30 @@ class V1SqlDumpParser
             }
 
             if ($char === '\'' || $char === '"') {
-                $inString = true;
+                $inString  = true;
                 $quoteChar = $char;
                 continue;
             }
 
-            if ($char === '(' && !$inTuple) {
-                $inTuple = true;
+            if ($char === '(' && ! $inTuple) {
+                $inTuple      = true;
                 $currentTuple = [];
                 $currentValue = '';
                 continue;
             }
 
             if ($char === ')' && $inTuple) {
-                $currentTuple[] = $this->castSqlValue(trim($currentValue));
-                $tuples[] = $currentTuple;
-                $currentTuple = [];
-                $currentValue = '';
-                $inTuple = false;
+                $currentTuple[] = $this->castSqlValue(mb_trim($currentValue));
+                $tuples[]       = $currentTuple;
+                $currentTuple   = [];
+                $currentValue   = '';
+                $inTuple        = false;
                 continue;
             }
 
             if ($char === ',' && $inTuple) {
-                $currentTuple[] = $this->castSqlValue(trim($currentValue));
-                $currentValue = '';
+                $currentTuple[] = $this->castSqlValue(mb_trim($currentValue));
+                $currentValue   = '';
                 continue;
             }
 
@@ -193,23 +105,112 @@ class V1SqlDumpParser
         return $tuples;
     }
 
+    /**
+     * Extract table schemas from CREATE TABLE definitions.
+     *
+     * @param array<string, array<int, string>> $tableColumns
+     */
+    protected function extractCreateTables(string $content, array &$tableColumns): void
+    {
+        $pattern = '/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\.)?[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\s*\((.*?)\)\s*(?:ENGINE|DEFAULT|AUTO_INCREMENT|CHARSET|COLLATE|;)/is';
+
+        if (preg_match_all($pattern, $content, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $tableName = ! empty($match[2]) ? $match[2] : $match[1];
+                $body      = $match[3];
+
+                $cols  = [];
+                $lines = explode("\n", $body);
+                foreach ($lines as $line) {
+                    $trimmed = mb_trim($line);
+                    if ($trimmed === '' || str_starts_with($trimmed, '--') || str_starts_with($trimmed, '/*')) {
+                        continue;
+                    }
+
+                    // Check if line defines a column (not KEY, PRIMARY KEY, CONSTRAINT, etc.)
+                    if (preg_match('/^[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\s+(?:int|varchar|char|text|datetime|date|decimal|tinyint|smallint|bigint|mediumtext|longtext|enum|float|double|timestamp)/i', $trimmed, $colMatch)) {
+                        $colName = $colMatch[1];
+                        if ( ! in_array(mb_strtoupper($colName), ['PRIMARY', 'KEY', 'UNIQUE', 'CONSTRAINT', 'FOREIGN', 'CHECK', 'INDEX'])) {
+                            $cols[] = $colName;
+                        }
+                    }
+                }
+
+                if ( ! empty($cols)) {
+                    $tableColumns[$tableName] = $cols;
+                }
+            }
+        }
+    }
+
+    /**
+     * Extract and parse INSERT INTO statements.
+     *
+     * @param array<string, array<int, string>>               $tableColumns
+     * @param array<string, array<int, array<string, mixed>>> $tables
+     */
+    protected function extractInserts(string $content, array $tableColumns, array &$tables): void
+    {
+        // Match INSERT INTO `tableName` (`col1`, `col2`) VALUES (...) or INSERT INTO `tableName` VALUES (...)
+        $insertPattern = '/INSERT\s+INTO\s+[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\s*(?:\((.*?)\))?\s*VALUES\s*(.*?)(\s*;\s*(?:\r?\n|$))/is';
+
+        if (preg_match_all($insertPattern, $content, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $tableName  = $match[1];
+                $columnsRaw = mb_trim($match[2] ?? '');
+                $valuesRaw  = mb_trim($match[3] ?? '');
+
+                $columns = [];
+                if ($columnsRaw !== '') {
+                    // Parse column list e.g. `col1`, `col2`
+                    preg_match_all('/[`\'"]?([a-zA-Z0-9_]+)[`\'"]?/', $columnsRaw, $colMatches);
+                    $columns = array_filter($colMatches[1] ?? [], fn ($c) => $c !== '');
+                } elseif (isset($tableColumns[$tableName])) {
+                    $columns = $tableColumns[$tableName];
+                }
+
+                if ( ! isset($tables[$tableName])) {
+                    $tables[$tableName] = [];
+                }
+
+                // Parse value tuples (val1, val2), (val3, val4)
+                $tuples = $this->parseValueTuples($valuesRaw);
+                foreach ($tuples as $tuple) {
+                    $row = [];
+                    if ( ! empty($columns)) {
+                        $colKeys = array_values($columns);
+                        foreach ($tuple as $i => $val) {
+                            $colName       = $colKeys[$i] ?? ('col_' . $i);
+                            $row[$colName] = $val;
+                        }
+                    } else {
+                        foreach ($tuple as $i => $val) {
+                            $row['col_' . $i] = $val;
+                        }
+                    }
+                    $tables[$tableName][] = $row;
+                }
+            }
+        }
+    }
+
     protected function unescapeChar(string $char): string
     {
         return match ($char) {
-            'n' => "\n",
-            'r' => "\r",
-            't' => "\t",
-            '\\' => '\\',
-            '\'' => '\'',
-            '"' => '"',
-            '0' => "\0",
+            'n'     => "\n",
+            'r'     => "\r",
+            't'     => "\t",
+            '\\'    => '\\',
+            '\''    => '\'',
+            '"'     => '"',
+            '0'     => "\0",
             default => $char,
         };
     }
 
     protected function castSqlValue(string $val): mixed
     {
-        $upper = strtoupper($val);
+        $upper = mb_strtoupper($val);
         if ($upper === 'NULL') {
             return null;
         }
@@ -222,6 +223,7 @@ class V1SqlDumpParser
         if (is_numeric($val)) {
             return str_contains($val, '.') ? (float) $val : (int) $val;
         }
+
         return $val;
     }
 }

--- a/Modules/Core/Services/Migration/Support/V1SqlDumpParser.php
+++ b/Modules/Core/Services/Migration/Support/V1SqlDumpParser.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Modules\Core\Services\Migration\Support;
+
+class V1SqlDumpParser
+{
+    /**
+     * Parse SQL file or raw SQL string into structured table rows.
+     *
+     * @param string $sqlOrPath Path to .sql file or raw SQL content
+     * @return array<string, array<int, array<string, mixed>>> Keyed by table name
+     */
+    public function parse(string $sqlOrPath): array
+    {
+        $content = file_exists($sqlOrPath) ? file_get_contents($sqlOrPath) : $sqlOrPath;
+        if ($content === false) {
+            return [];
+        }
+
+        $tables = [];
+        $tableColumns = [];
+
+        // 1. First pass: find CREATE TABLE statements to get column orders if INSERT doesn't specify columns
+        $this->extractCreateTables($content, $tableColumns);
+
+        // 2. Parse INSERT statements
+        $this->extractInserts($content, $tableColumns, $tables);
+
+        return $tables;
+    }
+
+    /**
+     * Extract table schemas from CREATE TABLE definitions.
+     *
+     * @param array<string, array<int, string>> $tableColumns
+     */
+    protected function extractCreateTables(string $content, array &$tableColumns): void
+    {
+        $pattern = '/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\.)?[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\s*\((.*?)\)\s*(?:ENGINE|DEFAULT|AUTO_INCREMENT|CHARSET|COLLATE|;)/is';
+
+        if (preg_match_all($pattern, $content, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $tableName = !empty($match[2]) ? $match[2] : $match[1];
+                $body = $match[3];
+
+                $cols = [];
+                $lines = explode("\n", $body);
+                foreach ($lines as $line) {
+                    $trimmed = trim($line);
+                    if ($trimmed === '' || str_starts_with($trimmed, '--') || str_starts_with($trimmed, '/*')) {
+                        continue;
+                    }
+
+                    // Check if line defines a column (not KEY, PRIMARY KEY, CONSTRAINT, etc.)
+                    if (preg_match('/^[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\s+(?:int|varchar|char|text|datetime|date|decimal|tinyint|smallint|bigint|mediumtext|longtext|enum|float|double|timestamp)/i', $trimmed, $colMatch)) {
+                        $colName = $colMatch[1];
+                        if (!in_array(strtoupper($colName), ['PRIMARY', 'KEY', 'UNIQUE', 'CONSTRAINT', 'FOREIGN', 'CHECK', 'INDEX'])) {
+                            $cols[] = $colName;
+                        }
+                    }
+                }
+
+                if (!empty($cols)) {
+                    $tableColumns[$tableName] = $cols;
+                }
+            }
+        }
+    }
+
+    /**
+     * Extract and parse INSERT INTO statements.
+     *
+     * @param array<string, array<int, string>> $tableColumns
+     * @param array<string, array<int, array<string, mixed>>> $tables
+     */
+    protected function extractInserts(string $content, array $tableColumns, array &$tables): void
+    {
+        // Match INSERT INTO `tableName` (`col1`, `col2`) VALUES (...) or INSERT INTO `tableName` VALUES (...)
+        $insertPattern = '/INSERT\s+INTO\s+[`\'"]?([a-zA-Z0-9_]+)[`\'"]?\s*(?:\((.*?)\))?\s*VALUES\s*(.*?)(\s*;\s*(?:\r?\n|$))/is';
+
+        if (preg_match_all($insertPattern, $content, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $tableName = $match[1];
+                $columnsRaw = trim($match[2] ?? '');
+                $valuesRaw = trim($match[3] ?? '');
+
+                $columns = [];
+                if ($columnsRaw !== '') {
+                    // Parse column list e.g. `col1`, `col2`
+                    preg_match_all('/[`\'"]?([a-zA-Z0-9_]+)[`\'"]?/', $columnsRaw, $colMatches);
+                    $columns = array_filter($colMatches[1] ?? [], fn ($c) => $c !== '');
+                } elseif (isset($tableColumns[$tableName])) {
+                    $columns = $tableColumns[$tableName];
+                }
+
+                if (!isset($tables[$tableName])) {
+                    $tables[$tableName] = [];
+                }
+
+                // Parse value tuples (val1, val2), (val3, val4)
+                $tuples = $this->parseValueTuples($valuesRaw);
+                foreach ($tuples as $tuple) {
+                    $row = [];
+                    if (!empty($columns)) {
+                        $colKeys = array_values($columns);
+                        foreach ($tuple as $i => $val) {
+                            $colName = $colKeys[$i] ?? ('col_' . $i);
+                            $row[$colName] = $val;
+                        }
+                    } else {
+                        foreach ($tuple as $i => $val) {
+                            $row['col_' . $i] = $val;
+                        }
+                    }
+                    $tables[$tableName][] = $row;
+                }
+            }
+        }
+    }
+
+    /**
+     * Robust tokenizer for SQL value tuples like: (1, 'hello', NULL, 12.34), (2, 'world, with \'quote\'', '2026-01-01')
+     *
+     * @return array<int, array<int, mixed>>
+     */
+    public function parseValueTuples(string $valuesString): array
+    {
+        $tuples = [];
+        $length = strlen($valuesString);
+        $inTuple = false;
+        $inString = false;
+        $quoteChar = '';
+        $currentValue = '';
+        $currentTuple = [];
+        $isEscaped = false;
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $valuesString[$i];
+
+            if ($inString) {
+                if ($isEscaped) {
+                    $currentValue .= $this->unescapeChar($char);
+                    $isEscaped = false;
+                } elseif ($char === '\\') {
+                    $isEscaped = true;
+                } elseif ($char === $quoteChar) {
+                    // Check for SQL double quote escape e.g. ''
+                    if ($i + 1 < $length && $valuesString[$i + 1] === $quoteChar) {
+                        $currentValue .= $quoteChar;
+                        $i++; // skip next quote
+                    } else {
+                        $inString = false;
+                    }
+                } else {
+                    $currentValue .= $char;
+                }
+                continue;
+            }
+
+            if ($char === '\'' || $char === '"') {
+                $inString = true;
+                $quoteChar = $char;
+                continue;
+            }
+
+            if ($char === '(' && !$inTuple) {
+                $inTuple = true;
+                $currentTuple = [];
+                $currentValue = '';
+                continue;
+            }
+
+            if ($char === ')' && $inTuple) {
+                $currentTuple[] = $this->castSqlValue(trim($currentValue));
+                $tuples[] = $currentTuple;
+                $currentTuple = [];
+                $currentValue = '';
+                $inTuple = false;
+                continue;
+            }
+
+            if ($char === ',' && $inTuple) {
+                $currentTuple[] = $this->castSqlValue(trim($currentValue));
+                $currentValue = '';
+                continue;
+            }
+
+            if ($inTuple) {
+                $currentValue .= $char;
+            }
+        }
+
+        return $tuples;
+    }
+
+    protected function unescapeChar(string $char): string
+    {
+        return match ($char) {
+            'n' => "\n",
+            'r' => "\r",
+            't' => "\t",
+            '\\' => '\\',
+            '\'' => '\'',
+            '"' => '"',
+            '0' => "\0",
+            default => $char,
+        };
+    }
+
+    protected function castSqlValue(string $val): mixed
+    {
+        $upper = strtoupper($val);
+        if ($upper === 'NULL') {
+            return null;
+        }
+        if ($upper === 'TRUE') {
+            return true;
+        }
+        if ($upper === 'FALSE') {
+            return false;
+        }
+        if (is_numeric($val)) {
+            return str_contains($val, '.') ? (float) $val : (int) $val;
+        }
+        return $val;
+    }
+}

--- a/Modules/Core/Services/Migration/V1MigrationManager.php
+++ b/Modules/Core/Services/Migration/V1MigrationManager.php
@@ -241,9 +241,8 @@ class V1MigrationManager extends BaseService
         $context->log($isDryRun ? 'Starting migration DRY RUN...' : 'Starting migration execution...');
 
         $results = [];
-        $hasFatalError = false;
 
-        $executeLogic = function () use ($context, &$results, &$hasFatalError) {
+        $executeLogic = function () use ($context, &$results) {
             foreach ($this->migrators as $migrator) {
                 $context->log("Migrating {$migrator->label()}...");
                 $res = $migrator->migrate($context);
@@ -282,7 +281,7 @@ class V1MigrationManager extends BaseService
         $context->log('Migration ' . ($isDryRun ? 'dry run ' : '') . 'completed successfully.');
 
         return [
-            'success'              => !$hasFatalError && empty($context->getErrors()),
+            'success'              => empty($context->getErrors()),
             'is_dry_run'           => $isDryRun,
             'batch_id'             => $context->getBatchId(),
             'results'              => $results,

--- a/Modules/Core/Services/Migration/V1MigrationManager.php
+++ b/Modules/Core/Services/Migration/V1MigrationManager.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace Modules\Core\Services\Migration;
+
+use Closure;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Modules\Core\Models\Company;
+use Modules\Core\Models\User;
+use Modules\Core\Services\BaseService;
+use Modules\Core\Services\Migration\Contracts\EntityMigratorInterface;
+use Modules\Core\Services\Migration\Migrators\ClientMigrator;
+use Modules\Core\Services\Migration\Migrators\CustomFieldMigrator;
+use Modules\Core\Services\Migration\Migrators\InvoiceMigrator;
+use Modules\Core\Services\Migration\Migrators\PaymentMigrator;
+use Modules\Core\Services\Migration\Migrators\ProductMigrator;
+use Modules\Core\Services\Migration\Migrators\ProjectMigrator;
+use Modules\Core\Services\Migration\Migrators\QuoteMigrator;
+use Modules\Core\Services\Migration\Migrators\TaxRateMigrator;
+use Modules\Core\Services\Migration\Support\FinancialInvariantValidator;
+use Modules\Core\Services\Migration\Support\V1SqlDumpParser;
+
+class V1MigrationManager extends BaseService
+{
+    /**
+     * @var array<EntityMigratorInterface>
+     */
+    protected array $migrators = [];
+
+    protected V1SqlDumpParser $sqlParser;
+    protected FinancialInvariantValidator $invariantValidator;
+
+    public function __construct(\Illuminate\Container\Container $app)
+    {
+        parent::__construct($app);
+        $this->sqlParser = new V1SqlDumpParser();
+        $this->invariantValidator = new FinancialInvariantValidator();
+        $this->registerDefaultMigrators();
+    }
+
+    public function model(): string
+    {
+        return Company::class;
+    }
+
+    protected function registerDefaultMigrators(): void
+    {
+        $this->migrators = [
+            new TaxRateMigrator(),
+            new ClientMigrator(),
+            new ProductMigrator(),
+            new CustomFieldMigrator(),
+            new InvoiceMigrator(),
+            new PaymentMigrator(),
+            new QuoteMigrator(),
+            new ProjectMigrator(),
+        ];
+    }
+
+    /**
+     * @return array<EntityMigratorInterface>
+     */
+    public function getMigrators(): array
+    {
+        return $this->migrators;
+    }
+
+    /**
+     * Build a MigrationContext from an SQL dump file or content.
+     */
+    public function createContextFromSql(
+        string $sqlOrPath,
+        Company $company,
+        ?User $user = null,
+        bool $dryRun = false,
+        string $tablePrefix = 'ip_'
+    ): MigrationContext {
+        $context = new MigrationContext($company, $user, $dryRun, null, $tablePrefix);
+        $tables = $this->sqlParser->parse($sqlOrPath);
+        $context->setSourceTables($tables);
+        return $context;
+    }
+
+    /**
+     * Build a MigrationContext from a database connection name or dynamic config.
+     *
+     * @param string|array<string, mixed> $connectionOrConfig
+     */
+    public function createContextFromDb(
+        string|array $connectionOrConfig,
+        Company $company,
+        ?User $user = null,
+        bool $dryRun = false,
+        string $tablePrefix = 'ip_'
+    ): MigrationContext {
+        $context = new MigrationContext($company, $user, $dryRun, null, $tablePrefix);
+
+        if (is_array($connectionOrConfig)) {
+            $tempConnName = 'v1_import_dynamic_' . uniqid();
+            Config::set("database.connections.{$tempConnName}", [
+                'driver'         => 'mysql',
+                'host'           => $connectionOrConfig['host'] ?? '127.0.0.1',
+                'port'           => $connectionOrConfig['port'] ?? '3306',
+                'database'       => $connectionOrConfig['database'] ?? '',
+                'username'       => $connectionOrConfig['username'] ?? 'root',
+                'password'       => $connectionOrConfig['password'] ?? '',
+                'charset'        => 'utf8mb4',
+                'collation'      => 'utf8mb4_unicode_ci',
+                'prefix'         => '',
+                'prefix_indexes' => true,
+                'strict'         => false,
+            ]);
+            $connection = DB::connection($tempConnName);
+        } else {
+            $connection = DB::connection($connectionOrConfig);
+        }
+
+        $context->setDbConnection($connection);
+        return $context;
+    }
+
+    /**
+     * Test connection credentials to a v1 MySQL database.
+     *
+     * @param array<string, mixed> $config
+     * @return array{success: bool, message: string, tables_found: int}
+     */
+    public function testDbConnection(array $config, string $prefix = 'ip_'): array
+    {
+        $tempConnName = 'v1_test_conn_' . uniqid();
+        Config::set("database.connections.{$tempConnName}", [
+            'driver'   => 'mysql',
+            'host'     => $config['host'] ?? '127.0.0.1',
+            'port'     => $config['port'] ?? '3306',
+            'database' => $config['database'] ?? '',
+            'username' => $config['username'] ?? 'root',
+            'password' => $config['password'] ?? '',
+            'charset'  => 'utf8mb4',
+            'strict'   => false,
+        ]);
+
+        try {
+            $pdo = DB::connection($tempConnName)->getPdo();
+            $tables = DB::connection($tempConnName)->select('SHOW TABLES');
+            $tablesFound = 0;
+            foreach ($tables as $t) {
+                $tableName = array_values((array) $t)[0] ?? '';
+                if ($prefix === '' || str_starts_with($tableName, $prefix)) {
+                    $tablesFound++;
+                }
+            }
+
+            return [
+                'success'      => true,
+                'message'      => "Connected successfully. Found {$tablesFound} matching tables with prefix '{$prefix}'.",
+                'tables_found' => $tablesFound,
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'success'      => false,
+                'message'      => 'Connection failed: ' . $e->getMessage(),
+                'tables_found' => 0,
+            ];
+        }
+    }
+
+    /**
+     * Inspect source data across all entities (Dry Run Analysis).
+     *
+     * @return array{
+     *     total_source_count: int,
+     *     total_will_migrate: int,
+     *     total_unmappable: int,
+     *     entities: array<string, array{label: string, source_count: int, will_migrate: int, unmappable: int, notes: array<string>}>,
+     *     warnings: array<string>
+     * }
+     */
+    public function inspect(MigrationContext $context): array
+    {
+        $entities = [];
+        $totalSource = 0;
+        $totalWillMigrate = 0;
+        $totalUnmappable = 0;
+
+        foreach ($this->migrators as $migrator) {
+            $inspection = $migrator->inspect($context);
+            $entities[$migrator->name()] = [
+                'label'        => $migrator->label(),
+                'source_count' => $inspection['source_count'],
+                'will_migrate' => $inspection['will_migrate'],
+                'unmappable'   => $inspection['unmappable'],
+                'notes'        => $inspection['notes'],
+            ];
+
+            $totalSource += $inspection['source_count'];
+            $totalWillMigrate += $inspection['will_migrate'];
+            $totalUnmappable += $inspection['unmappable'];
+        }
+
+        return [
+            'total_source_count' => $totalSource,
+            'total_will_migrate' => $totalWillMigrate,
+            'total_unmappable'   => $totalUnmappable,
+            'entities'           => $entities,
+            'warnings'           => $context->getWarnings(),
+        ];
+    }
+
+    /**
+     * Run the complete migration (or dry run).
+     *
+     * @param ?Closure(string $status, string $message): void $progressCallback
+     * @return array{
+     *     success: bool,
+     *     is_dry_run: bool,
+     *     batch_id: string,
+     *     results: array<string, array{label: string, migrated: int, skipped: int, errors: array<string>}>,
+     *     financial_invariants: array{passed: bool, invoices_checked: int, quotes_checked: int, passed_count: int, failed_count: int, mismatches: array},
+     *     logs: array<string>,
+     *     warnings: array<string>,
+     *     errors: array<string>
+     * }
+     */
+    public function run(MigrationContext $context, ?Closure $progressCallback = null): array
+    {
+        if ($progressCallback) {
+            $context->setProgressCallback($progressCallback);
+        }
+
+        // Auto scope Filament tenant if panel active
+        if (class_exists(Filament::class)) {
+            try {
+                Filament::setTenant($context->getCompany());
+            } catch (\Throwable) {
+                // Ignore if panel tenant not configured in CLI
+            }
+        }
+
+        $isDryRun = $context->isDryRun();
+        $context->log($isDryRun ? 'Starting migration DRY RUN...' : 'Starting migration execution...');
+
+        $results = [];
+        $hasFatalError = false;
+
+        $executeLogic = function () use ($context, &$results, &$hasFatalError) {
+            foreach ($this->migrators as $migrator) {
+                $context->log("Migrating {$migrator->label()}...");
+                $res = $migrator->migrate($context);
+                $results[$migrator->name()] = [
+                    'label'    => $migrator->label(),
+                    'migrated' => $res['migrated'],
+                    'skipped'  => $res['skipped'],
+                    'errors'   => $res['errors'],
+                ];
+
+                if (!empty($res['errors'])) {
+                    foreach ($res['errors'] as $err) {
+                        $context->error($err);
+                    }
+                }
+            }
+        };
+
+        if ($isDryRun) {
+            $executeLogic();
+        } else {
+            DB::transaction($executeLogic);
+        }
+
+        // Validate financial invariants if not dry run
+        $invariants = $isDryRun
+            ? ['passed' => true, 'invoices_checked' => 0, 'quotes_checked' => 0, 'passed_count' => 0, 'failed_count' => 0, 'mismatches' => []]
+            : $this->invariantValidator->validate($context);
+
+        if (!$invariants['passed']) {
+            $context->warn("Financial invariants validation found {$invariants['failed_count']} mismatches.");
+        } else {
+            $context->log("Financial invariants verified successfully for all {$invariants['invoices_checked']} invoices and {$invariants['quotes_checked']} quotes.");
+        }
+
+        $context->log('Migration ' . ($isDryRun ? 'dry run ' : '') . 'completed successfully.');
+
+        return [
+            'success'              => !$hasFatalError && empty($context->getErrors()),
+            'is_dry_run'           => $isDryRun,
+            'batch_id'             => $context->getBatchId(),
+            'results'              => $results,
+            'financial_invariants' => $invariants,
+            'logs'                 => $context->getLogs(),
+            'warnings'             => $context->getWarnings(),
+            'errors'               => $context->getErrors(),
+        ];
+    }
+
+    /**
+     * Rollback a previously executed migration batch.
+     */
+    public function rollback(MigrationContext $context): array
+    {
+        $context->log("Rolling back batch {$context->getBatchId()}...");
+        $deletedCounts = [];
+
+        // Rollback in reverse dependency order
+        $reverseMigrators = array_reverse($this->migrators);
+        foreach ($reverseMigrators as $migrator) {
+            $count = $migrator->rollback($context);
+            $deletedCounts[$migrator->name()] = $count;
+            $context->log("Rolled back {$count} {$migrator->label()} records.");
+        }
+
+        return [
+            'success'        => true,
+            'batch_id'       => $context->getBatchId(),
+            'deleted_counts' => $deletedCounts,
+            'logs'           => $context->getLogs(),
+        ];
+    }
+}

--- a/Modules/Core/Services/Migration/V1MigrationManager.php
+++ b/Modules/Core/Services/Migration/V1MigrationManager.php
@@ -20,6 +20,7 @@ use Modules\Core\Services\Migration\Migrators\QuoteMigrator;
 use Modules\Core\Services\Migration\Migrators\TaxRateMigrator;
 use Modules\Core\Services\Migration\Support\FinancialInvariantValidator;
 use Modules\Core\Services\Migration\Support\V1SqlDumpParser;
+use Throwable;
 
 class V1MigrationManager extends BaseService
 {
@@ -29,12 +30,13 @@ class V1MigrationManager extends BaseService
     protected array $migrators = [];
 
     protected V1SqlDumpParser $sqlParser;
+
     protected FinancialInvariantValidator $invariantValidator;
 
     public function __construct(\Illuminate\Container\Container $app)
     {
         parent::__construct($app);
-        $this->sqlParser = new V1SqlDumpParser();
+        $this->sqlParser          = new V1SqlDumpParser();
         $this->invariantValidator = new FinancialInvariantValidator();
         $this->registerDefaultMigrators();
     }
@@ -42,20 +44,6 @@ class V1MigrationManager extends BaseService
     public function model(): string
     {
         return Company::class;
-    }
-
-    protected function registerDefaultMigrators(): void
-    {
-        $this->migrators = [
-            new TaxRateMigrator(),
-            new ClientMigrator(),
-            new ProductMigrator(),
-            new CustomFieldMigrator(),
-            new InvoiceMigrator(),
-            new PaymentMigrator(),
-            new QuoteMigrator(),
-            new ProjectMigrator(),
-        ];
     }
 
     /**
@@ -77,8 +65,9 @@ class V1MigrationManager extends BaseService
         string $tablePrefix = 'ip_'
     ): MigrationContext {
         $context = new MigrationContext($company, $user, $dryRun, null, $tablePrefix);
-        $tables = $this->sqlParser->parse($sqlOrPath);
+        $tables  = $this->sqlParser->parse($sqlOrPath);
         $context->setSourceTables($tables);
+
         return $context;
     }
 
@@ -117,6 +106,7 @@ class V1MigrationManager extends BaseService
         }
 
         $context->setDbConnection($connection);
+
         return $context;
     }
 
@@ -124,6 +114,7 @@ class V1MigrationManager extends BaseService
      * Test connection credentials to a v1 MySQL database.
      *
      * @param array<string, mixed> $config
+     *
      * @return array{success: bool, message: string, tables_found: int}
      */
     public function testDbConnection(array $config, string $prefix = 'ip_'): array
@@ -141,8 +132,8 @@ class V1MigrationManager extends BaseService
         ]);
 
         try {
-            $pdo = DB::connection($tempConnName)->getPdo();
-            $tables = DB::connection($tempConnName)->select('SHOW TABLES');
+            $pdo         = DB::connection($tempConnName)->getPdo();
+            $tables      = DB::connection($tempConnName)->select('SHOW TABLES');
             $tablesFound = 0;
             foreach ($tables as $t) {
                 $tableName = array_values((array) $t)[0] ?? '';
@@ -156,7 +147,7 @@ class V1MigrationManager extends BaseService
                 'message'      => "Connected successfully. Found {$tablesFound} matching tables with prefix '{$prefix}'.",
                 'tables_found' => $tablesFound,
             ];
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             return [
                 'success'      => false,
                 'message'      => 'Connection failed: ' . $e->getMessage(),
@@ -178,13 +169,13 @@ class V1MigrationManager extends BaseService
      */
     public function inspect(MigrationContext $context): array
     {
-        $entities = [];
-        $totalSource = 0;
+        $entities         = [];
+        $totalSource      = 0;
         $totalWillMigrate = 0;
-        $totalUnmappable = 0;
+        $totalUnmappable  = 0;
 
         foreach ($this->migrators as $migrator) {
-            $inspection = $migrator->inspect($context);
+            $inspection                  = $migrator->inspect($context);
             $entities[$migrator->name()] = [
                 'label'        => $migrator->label(),
                 'source_count' => $inspection['source_count'],
@@ -211,6 +202,7 @@ class V1MigrationManager extends BaseService
      * Run the complete migration (or dry run).
      *
      * @param ?Closure(string $status, string $message): void $progressCallback
+     *
      * @return array{
      *     success: bool,
      *     is_dry_run: bool,
@@ -232,7 +224,7 @@ class V1MigrationManager extends BaseService
         if (class_exists(Filament::class)) {
             try {
                 Filament::setTenant($context->getCompany());
-            } catch (\Throwable) {
+            } catch (Throwable) {
                 // Ignore if panel tenant not configured in CLI
             }
         }
@@ -245,7 +237,7 @@ class V1MigrationManager extends BaseService
         $executeLogic = function () use ($context, &$results) {
             foreach ($this->migrators as $migrator) {
                 $context->log("Migrating {$migrator->label()}...");
-                $res = $migrator->migrate($context);
+                $res                        = $migrator->migrate($context);
                 $results[$migrator->name()] = [
                     'label'    => $migrator->label(),
                     'migrated' => $res['migrated'],
@@ -253,7 +245,7 @@ class V1MigrationManager extends BaseService
                     'errors'   => $res['errors'],
                 ];
 
-                if (!empty($res['errors'])) {
+                if ( ! empty($res['errors'])) {
                     foreach ($res['errors'] as $err) {
                         $context->error($err);
                     }
@@ -272,7 +264,7 @@ class V1MigrationManager extends BaseService
             ? ['passed' => true, 'invoices_checked' => 0, 'quotes_checked' => 0, 'passed_count' => 0, 'failed_count' => 0, 'mismatches' => []]
             : $this->invariantValidator->validate($context);
 
-        if (!$invariants['passed']) {
+        if ( ! $invariants['passed']) {
             $context->warn("Financial invariants validation found {$invariants['failed_count']} mismatches.");
         } else {
             $context->log("Financial invariants verified successfully for all {$invariants['invoices_checked']} invoices and {$invariants['quotes_checked']} quotes.");
@@ -303,7 +295,7 @@ class V1MigrationManager extends BaseService
         // Rollback in reverse dependency order
         $reverseMigrators = array_reverse($this->migrators);
         foreach ($reverseMigrators as $migrator) {
-            $count = $migrator->rollback($context);
+            $count                            = $migrator->rollback($context);
             $deletedCounts[$migrator->name()] = $count;
             $context->log("Rolled back {$count} {$migrator->label()} records.");
         }
@@ -313,6 +305,20 @@ class V1MigrationManager extends BaseService
             'batch_id'       => $context->getBatchId(),
             'deleted_counts' => $deletedCounts,
             'logs'           => $context->getLogs(),
+        ];
+    }
+
+    protected function registerDefaultMigrators(): void
+    {
+        $this->migrators = [
+            new TaxRateMigrator(),
+            new ClientMigrator(),
+            new ProductMigrator(),
+            new CustomFieldMigrator(),
+            new InvoiceMigrator(),
+            new PaymentMigrator(),
+            new QuoteMigrator(),
+            new ProjectMigrator(),
         ];
     }
 }

--- a/Modules/Core/Services/UserService.php
+++ b/Modules/Core/Services/UserService.php
@@ -7,8 +7,10 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Modules\Core\Enums\UserRole;
 use Modules\Core\Events\UserWasCreated;
 use Modules\Core\Events\UserWasUpdated;
+use Modules\Core\Models\Company;
 use Modules\Core\Models\Upload;
 use Modules\Core\Models\User;
 use Throwable;
@@ -133,5 +135,26 @@ class UserService extends BaseService
         $existing->delete();
 
         return true;
+    }
+
+    /**
+     * Assert that the user has permission/membership to access the specified company.
+     * Elevated roles (super_admin, admin, assist) have access to all companies.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function assertBelongsToCompany(User $user, Company|int $company): void
+    {
+        if ($user->hasAnyRole(UserRole::elevated())) {
+            return;
+        }
+
+        $companyId = $company instanceof Company ? $company->id : $company;
+
+        if ( ! $user->companies()->where('companies.id', $companyId)->exists()) {
+            throw new \Illuminate\Auth\Access\AuthorizationException(
+                trans('ip.user_not_in_company') ?: 'You do not have access to this company.'
+            );
+        }
     }
 }

--- a/Modules/Core/Tests/Feature/EmailTemplateVariablesTest.php
+++ b/Modules/Core/Tests/Feature/EmailTemplateVariablesTest.php
@@ -145,11 +145,15 @@ class EmailTemplateVariablesTest extends AbstractCompanyPanelTestCase
         $client->update(['primary_contact_id' => null]);
         $client->contacts()->delete();
 
-        return $client->fresh();
+        /** @var Relation $fresh */
+        $fresh = $client->fresh();
+
+        return $fresh;
     }
 
     protected function makeContact(Relation $client, array $attributes, ?string $email = null): Contact
     {
+        /** @var Contact $contact */
         $contact = Contact::factory()->create(array_merge([
             'company_id'  => $this->company->id,
             'relation_id' => $client->id,
@@ -170,7 +174,8 @@ class EmailTemplateVariablesTest extends AbstractCompanyPanelTestCase
 
     protected function makeInvoice(Relation $client): Invoice
     {
-        return Invoice::factory()->create([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->create([
             'company_id'     => $this->company->id,
             'customer_id'    => $client->id,
             'user_id'        => $this->user->id,
@@ -178,5 +183,7 @@ class EmailTemplateVariablesTest extends AbstractCompanyPanelTestCase
             'invoiced_at'    => '2026-01-01',
             'invoice_total'  => 250,
         ]);
+
+        return $invoice;
     }
 }

--- a/Modules/Core/Tests/Feature/LoginRedirectTest.php
+++ b/Modules/Core/Tests/Feature/LoginRedirectTest.php
@@ -205,20 +205,26 @@ class LoginRedirectTest extends AbstractCompanyPanelTestCase
 
     private function activeUser(array $overrides = []): User
     {
-        return User::factory()->create(array_merge([
+        /** @var User $user */
+        $user = User::factory()->create(array_merge([
             'is_active'         => true,
             'email_verified_at' => Carbon::now(),
             'password'          => bcrypt('password'),
         ], $overrides));
+
+        return $user;
     }
 
     private function ivplv2Company(): Company
     {
-        return Company::factory()->create([
+        /** @var Company $company */
+        $company = Company::factory()->create([
             'search_code' => 'ivplv2',
             'name'        => 'InvoicePlane Corporation',
             'slug'        => 'invoiceplane-corporation',
         ]);
+
+        return $company;
     }
 
     private function elevatedRole(string $role): void

--- a/Modules/Core/Tests/Feature/LoginResponseTest.php
+++ b/Modules/Core/Tests/Feature/LoginResponseTest.php
@@ -140,8 +140,10 @@ class LoginResponseTest extends AbstractAdminPanelTestCase
 
     private function dispatchResponse(): RedirectResponse
     {
-        /* @var RedirectResponse */
-        return (new LoginResponse())->toResponse(request());
+        /** @var RedirectResponse $response */
+        $response = (new LoginResponse())->toResponse(request());
+
+        return $response;
     }
 
     // endregion

--- a/Modules/Core/Tests/Feature/LoginResponseTest.php
+++ b/Modules/Core/Tests/Feature/LoginResponseTest.php
@@ -140,7 +140,7 @@ class LoginResponseTest extends AbstractAdminPanelTestCase
 
     private function dispatchResponse(): RedirectResponse
     {
-        /** @var RedirectResponse */
+        /* @var RedirectResponse */
         return (new LoginResponse())->toResponse(request());
     }
 

--- a/Modules/Core/Tests/Feature/LoginResponseTest.php
+++ b/Modules/Core/Tests/Feature/LoginResponseTest.php
@@ -129,6 +129,7 @@ class LoginResponseTest extends AbstractAdminPanelTestCase
 
     private function makeUser(Company ...$companies): User
     {
+        /** @var User $user */
         $user = User::factory()->create();
         foreach ($companies as $company) {
             $user->companies()->attach($company);
@@ -139,6 +140,7 @@ class LoginResponseTest extends AbstractAdminPanelTestCase
 
     private function dispatchResponse(): RedirectResponse
     {
+        /** @var RedirectResponse */
         return (new LoginResponse())->toResponse(request());
     }
 

--- a/Modules/Core/Tests/Feature/UserProfileTest.php
+++ b/Modules/Core/Tests/Feature/UserProfileTest.php
@@ -5,6 +5,7 @@ namespace Modules\Core\Tests\Feature;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Modules\Core\Enums\UserRole;
 use Modules\Core\Filament\Company\Pages\Auth\EditProfile;
 use Modules\Core\Filament\Company\Pages\MyCompanies;
 use Modules\Core\Models\Company;
@@ -12,6 +13,7 @@ use Modules\Core\Services\UserService;
 use Modules\Core\Tests\AbstractCompanyPanelTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
 
 #[CoversClass(EditProfile::class)]
 #[CoversClass(MyCompanies::class)]
@@ -130,5 +132,53 @@ class UserProfileTest extends AbstractCompanyPanelTestCase
         ]));
 
         $this->assertSame($otherCompany->id, session('current_company_id'));
+    }
+
+    #[Test]
+    public function it_blocks_switching_and_sends_warning_notification_when_user_does_not_belong_to_target_company(): void
+    {
+        /* Arrange */
+        $otherCompany = Company::factory()->create(['search_code' => 'OTHERCO']);
+        $this->user->companies()->attach($otherCompany);
+
+        $initialCompanyId = $this->company->id;
+        session(['current_company_id' => $initialCompanyId]);
+
+        $this->mock(UserService::class, function ($mock) {
+            $mock->shouldReceive('assertBelongsToCompany')
+                ->once()
+                ->andThrow(new \Illuminate\Auth\Access\AuthorizationException(trans('ip.user_not_in_company')));
+        });
+
+        /* Act */
+        $component = $this->testLivewire(MyCompanies::class)
+            ->callTableAction('switch', $otherCompany);
+
+        /* Assert */
+        $component->assertNotified()
+            ->assertNoRedirect();
+
+        $this->assertSame($initialCompanyId, session('current_company_id'));
+    }
+
+    #[Test]
+    public function it_allows_elevated_user_to_switch_to_any_company_without_explicit_pivot_record(): void
+    {
+        /* Arrange */
+        $superAdminRole = Role::firstOrCreate(['name' => UserRole::SUPER_ADMIN->value, 'guard_name' => 'web']);
+        $this->user->assignRole($superAdminRole);
+
+        $anyCompany = Company::factory()->create(['search_code' => 'ANYCO']);
+
+        /* Act */
+        $component = $this->testLivewire(MyCompanies::class)
+            ->callTableAction('switch', $anyCompany);
+
+        /* Assert */
+        $component->assertRedirect(route('filament.company.pages.dashboard', [
+            'tenant' => Str::lower($anyCompany->search_code),
+        ]));
+
+        $this->assertSame($anyCompany->id, session('current_company_id'));
     }
 }

--- a/Modules/Core/Tests/Feature/V1MigrationTest.php
+++ b/Modules/Core/Tests/Feature/V1MigrationTest.php
@@ -29,13 +29,14 @@ use PHPUnit\Framework\Attributes\Test;
 class V1MigrationTest extends AbstractAdminPanelTestCase
 {
     protected string $fixturePath;
+
     protected V1MigrationManager $manager;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->fixturePath = module_path('Core', 'Tests/Fixtures/v1_fixture.sql');
-        $this->manager = app(V1MigrationManager::class);
+        $this->manager     = app(V1MigrationManager::class);
     }
 
     #[Test]
@@ -263,8 +264,8 @@ class V1MigrationTest extends AbstractAdminPanelTestCase
         $this->manager->run($context1);
 
         $relationCountAfterFirst = Relation::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count();
-        $invoiceCountAfterFirst = Invoice::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count();
-        $quoteCountAfterFirst = Quote::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count();
+        $invoiceCountAfterFirst  = Invoice::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count();
+        $quoteCountAfterFirst    = Quote::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count();
 
         // Run second time on same target company
         $context2 = $this->manager->createContextFromSql(

--- a/Modules/Core/Tests/Feature/V1MigrationTest.php
+++ b/Modules/Core/Tests/Feature/V1MigrationTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Modules\Core\Tests\Feature;
+
+use Modules\Clients\Models\Address;
+use Modules\Clients\Models\Communication;
+use Modules\Clients\Models\Contact;
+use Modules\Clients\Models\Relation;
+use Modules\Core\Models\Company;
+use Modules\Core\Models\CustomField;
+use Modules\Core\Models\TaxRate;
+use Modules\Core\Services\Migration\Support\V1SqlDumpParser;
+use Modules\Core\Services\Migration\V1MigrationManager;
+use Modules\Core\Tests\AbstractAdminPanelTestCase;
+use Modules\Invoices\Enums\InvoiceStatus;
+use Modules\Invoices\Models\Invoice;
+use Modules\Invoices\Models\InvoiceItem;
+use Modules\Payments\Models\Payment;
+use Modules\Products\Models\Product;
+use Modules\Products\Models\ProductCategory;
+use Modules\Products\Models\ProductUnit;
+use Modules\Projects\Models\Project;
+use Modules\Projects\Models\Task;
+use Modules\Quotes\Enums\QuoteStatus;
+use Modules\Quotes\Models\Quote;
+use Modules\Quotes\Models\QuoteItem;
+use PHPUnit\Framework\Attributes\Test;
+
+class V1MigrationTest extends AbstractAdminPanelTestCase
+{
+    protected string $fixturePath;
+    protected V1MigrationManager $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixturePath = module_path('Core', 'Tests/Fixtures/v1_fixture.sql');
+        $this->manager = app(V1MigrationManager::class);
+    }
+
+    #[Test]
+    public function it_correctly_parses_v1_sql_dump_fixture(): void
+    {
+        $parser = new V1SqlDumpParser();
+        $tables = $parser->parse($this->fixturePath);
+
+        $this->assertArrayHasKey('ip_tax_rates', $tables);
+        $this->assertCount(2, $tables['ip_tax_rates']);
+
+        $this->assertArrayHasKey('ip_clients', $tables);
+        $this->assertCount(3, $tables['ip_clients']);
+
+        $this->assertArrayHasKey('ip_products', $tables);
+        $this->assertCount(6, $tables['ip_products']);
+
+        $this->assertArrayHasKey('ip_invoices', $tables);
+        $this->assertCount(5, $tables['ip_invoices']);
+
+        $this->assertArrayHasKey('ip_invoice_items', $tables);
+        $this->assertCount(8, $tables['ip_invoice_items']);
+
+        $this->assertArrayHasKey('ip_payments', $tables);
+        $this->assertCount(4, $tables['ip_payments']);
+
+        $this->assertArrayHasKey('ip_quotes', $tables);
+        $this->assertCount(2, $tables['ip_quotes']);
+
+        $this->assertArrayHasKey('ip_projects', $tables);
+        $this->assertCount(1, $tables['ip_projects']);
+
+        $this->assertArrayHasKey('ip_tasks', $tables);
+        $this->assertCount(2, $tables['ip_tasks']);
+    }
+
+    #[Test]
+    public function it_performs_dry_run_without_writing_database_records(): void
+    {
+        /** @var Company $targetCompany */
+        $targetCompany = Company::factory()->create();
+
+        $context = $this->manager->createContextFromSql(
+            $this->fixturePath,
+            $targetCompany,
+            $this->superAdmin,
+            dryRun: true
+        );
+
+        $inspection = $this->manager->inspect($context);
+
+        $this->assertEquals(2, $inspection['entities']['tax_rates']['source_count']);
+        $this->assertEquals(3, $inspection['entities']['clients']['source_count']);
+        $this->assertEquals(6, $inspection['entities']['products']['source_count'] - 4); // 6 products + 2 families + 2 units
+        $this->assertEquals(5, $inspection['entities']['invoices']['source_count']);
+        $this->assertEquals(4, $inspection['entities']['payments']['source_count']);
+        $this->assertEquals(2, $inspection['entities']['quotes']['source_count']);
+
+        // Run dry run
+        $result = $this->manager->run($context);
+
+        $this->assertTrue($result['success']);
+        $this->assertTrue($result['is_dry_run']);
+
+        // Assert 0 rows were written to target company
+        $this->assertEquals(0, Relation::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+        $this->assertEquals(0, Invoice::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+        $this->assertEquals(0, Quote::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+        $this->assertEquals(0, Product::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+        $this->assertEquals(0, Payment::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+    }
+
+    #[Test]
+    public function it_migrates_all_v1_entities_accurately_into_target_company(): void
+    {
+        /** @var Company $targetCompany */
+        $targetCompany = Company::factory()->create();
+
+        $context = $this->manager->createContextFromSql(
+            $this->fixturePath,
+            $targetCompany,
+            $this->superAdmin,
+            dryRun: false
+        );
+
+        $result = $this->manager->run($context);
+
+        $this->assertTrue($result['success'], 'Migration errors: ' . json_encode($result['errors']));
+        $this->assertFalse($result['is_dry_run']);
+
+        // 1. Tax Rates
+        $taxRates = TaxRate::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertCount(2, $taxRates);
+        $this->assertNotNull($taxRates->firstWhere('name', 'Standard VAT'));
+        $this->assertEquals(20.00, (float) $taxRates->firstWhere('name', 'Standard VAT')->rate);
+
+        // 2. Clients, Contacts, Addresses, Communications
+        $relations = Relation::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertCount(3, $relations);
+
+        $acme = $relations->firstWhere('company_name', 'Acme Corp');
+        $this->assertNotNull($acme);
+        $this->assertEquals('US123456789', $acme->vat_number);
+
+        // Primary contact
+        $acmeContact = Contact::withoutGlobalScopes()->where('relation_id', $acme->id)->first();
+        $this->assertNotNull($acmeContact);
+        $this->assertEquals('Acme Corp', $acmeContact->first_name);
+        $this->assertEquals('Smith', $acmeContact->last_name);
+
+        // Address
+        $acmeAddress = Address::withoutGlobalScopes()->where('addressable_id', $acme->id)->first();
+        $this->assertNotNull($acmeAddress);
+        $this->assertEquals('123 Market St', $acmeAddress->address_1);
+        $this->assertEquals('San Francisco', $acmeAddress->city);
+        $this->assertEquals('94105', $acmeAddress->postal_code);
+
+        // Communications (email/phone)
+        $comms = Communication::withoutGlobalScopes()->where('communicationable_id', $acmeContact->id)->get();
+        $this->assertTrue($comms->contains('communication_value', 'billing@acme.test'));
+        $this->assertTrue($comms->contains('communication_value', '+1-555-0199'));
+
+        // 3. Products, Categories, Units
+        $categories = ProductCategory::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertTrue($categories->contains('category_name', 'Hardware'));
+        $this->assertTrue($categories->contains('category_name', 'Services'));
+
+        $units = ProductUnit::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertTrue($units->contains('unit_name', 'Piece'));
+        $this->assertTrue($units->contains('unit_name', 'Hour'));
+
+        $products = Product::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertCount(6, $products);
+        $this->assertNotNull($products->firstWhere('product_name', 'Wireless Mouse'));
+        $this->assertEquals(25.00, (float) $products->firstWhere('product_name', 'Wireless Mouse')->price);
+
+        // 4. Invoices and Items
+        $invoices = Invoice::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertCount(5, $invoices);
+
+        $invoiceItems = InvoiceItem::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertCount(8, $invoiceItems);
+
+        // Check statuses
+        $inv1 = $invoices->firstWhere('invoice_number', 'INV-1001');
+        $this->assertEquals(InvoiceStatus::PAID, $inv1->invoice_status);
+
+        $inv4 = $invoices->firstWhere('invoice_number', 'INV-1004');
+        $this->assertEquals(InvoiceStatus::DRAFT, $inv4->invoice_status);
+
+        // 5. Payments
+        $payments = Payment::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertCount(4, $payments);
+        $this->assertEquals(162.00, (float) $inv1->payments()->sum('payment_amount'));
+
+        // 6. Quotes and Items
+        $quotes = Quote::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertCount(2, $quotes);
+        $this->assertEquals(2, QuoteItem::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+
+        $quo2 = $quotes->firstWhere('quote_number', 'QUO-2002');
+        $this->assertEquals(QuoteStatus::APPROVED, $quo2->quote_status);
+
+        // 7. Projects & Tasks
+        $projects = Project::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertCount(1, $projects);
+        $this->assertEquals('Infrastructure Overhaul', $projects->first()->project_name);
+
+        $tasks = Task::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertCount(2, $tasks);
+
+        // 8. Custom Fields
+        $customFields = CustomField::withoutGlobalScopes()->where('company_id', $targetCompany->id)->get();
+        $this->assertCount(1, $customFields);
+        $this->assertEquals('Account Manager', $customFields->first()->custom_field_label);
+    }
+
+    #[Test]
+    public function it_verifies_financial_invariants_across_all_migrated_invoices_and_quotes(): void
+    {
+        /** @var Company $targetCompany */
+        $targetCompany = Company::factory()->create();
+
+        $context = $this->manager->createContextFromSql(
+            $this->fixturePath,
+            $targetCompany,
+            $this->superAdmin,
+            dryRun: false
+        );
+
+        $result = $this->manager->run($context);
+
+        $invariants = $result['financial_invariants'];
+        $this->assertTrue($invariants['passed'], 'Financial invariants validation failed: ' . json_encode($invariants['mismatches']));
+        $this->assertEquals(5, $invariants['invoices_checked']);
+        $this->assertEquals(2, $invariants['quotes_checked']);
+        $this->assertEquals(7, $invariants['passed_count']);
+        $this->assertEquals(0, $invariants['failed_count']);
+
+        // Spot check invoice 1: Total 162, Paid 162, Balance 0
+        $inv1 = Invoice::withoutGlobalScopes()->where('company_id', $targetCompany->id)->where('invoice_number', 'INV-1001')->first();
+        $this->assertEquals(162.00, (float) $inv1->invoice_total);
+        $this->assertEquals(162.00, (float) $inv1->payments()->sum('payment_amount'));
+        $this->assertEquals(0.00, (float) $inv1->invoice_total - (float) $inv1->payments()->sum('payment_amount'));
+
+        // Spot check invoice 5: Total 960, Paid 400, Balance 560
+        $inv5 = Invoice::withoutGlobalScopes()->where('company_id', $targetCompany->id)->where('invoice_number', 'INV-1005')->first();
+        $this->assertEquals(960.00, (float) $inv5->invoice_total);
+        $this->assertEquals(400.00, (float) $inv5->payments()->sum('payment_amount'));
+        $this->assertEquals(560.00, (float) $inv5->invoice_total - (float) $inv5->payments()->sum('payment_amount'));
+    }
+
+    #[Test]
+    public function it_is_idempotent_and_does_not_create_duplicate_records(): void
+    {
+        /** @var Company $targetCompany */
+        $targetCompany = Company::factory()->create();
+
+        $context1 = $this->manager->createContextFromSql(
+            $this->fixturePath,
+            $targetCompany,
+            $this->superAdmin,
+            dryRun: false
+        );
+        $this->manager->run($context1);
+
+        $relationCountAfterFirst = Relation::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count();
+        $invoiceCountAfterFirst = Invoice::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count();
+        $quoteCountAfterFirst = Quote::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count();
+
+        // Run second time on same target company
+        $context2 = $this->manager->createContextFromSql(
+            $this->fixturePath,
+            $targetCompany,
+            $this->superAdmin,
+            dryRun: false
+        );
+        $this->manager->run($context2);
+
+        $this->assertEquals($relationCountAfterFirst, Relation::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+        $this->assertEquals($invoiceCountAfterFirst, Invoice::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+        $this->assertEquals($quoteCountAfterFirst, Quote::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+    }
+
+    #[Test]
+    public function it_can_rollback_a_migration_batch(): void
+    {
+        /** @var Company $targetCompany */
+        $targetCompany = Company::factory()->create();
+
+        $context = $this->manager->createContextFromSql(
+            $this->fixturePath,
+            $targetCompany,
+            $this->superAdmin,
+            dryRun: false
+        );
+        $this->manager->run($context);
+
+        $this->assertEquals(3, Relation::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+        $this->assertEquals(5, Invoice::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+
+        // Rollback
+        $rollbackRes = $this->manager->rollback($context);
+        $this->assertTrue($rollbackRes['success']);
+
+        $this->assertEquals(0, Invoice::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+        $this->assertEquals(0, Quote::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+        $this->assertEquals(0, Relation::withoutGlobalScopes()->where('company_id', $targetCompany->id)->count());
+    }
+}

--- a/Modules/Core/Tests/Fixtures/v1_fixture.sql
+++ b/Modules/Core/Tests/Fixtures/v1_fixture.sql
@@ -1,0 +1,309 @@
+-- InvoicePlane v1 Test Fixture Database Dump
+
+-- 1. Tax Rates (2 records)
+CREATE TABLE IF NOT EXISTS `ip_tax_rates` (
+  `tax_rate_id` int(11) NOT NULL AUTO_INCREMENT,
+  `tax_rate_name` varchar(50) NOT NULL,
+  `tax_rate_percent` decimal(5,2) NOT NULL,
+  `tax_rate_code` varchar(20) DEFAULT NULL,
+  `tax_rate_is_compound` int(1) DEFAULT 0,
+  `tax_rate_calculate_vat` int(1) DEFAULT 0,
+  PRIMARY KEY (`tax_rate_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_tax_rates` (`tax_rate_id`, `tax_rate_name`, `tax_rate_percent`, `tax_rate_code`, `tax_rate_is_compound`, `tax_rate_calculate_vat`) VALUES
+(1, 'Standard VAT', 20.00, 'VAT20', 0, 0),
+(2, 'Reduced VAT', 5.00, 'VAT5', 0, 0);
+
+-- 2. Families (Product Categories) (2 records)
+CREATE TABLE IF NOT EXISTS `ip_families` (
+  `family_id` int(11) NOT NULL AUTO_INCREMENT,
+  `family_name` varchar(50) NOT NULL,
+  PRIMARY KEY (`family_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_families` (`family_id`, `family_name`) VALUES
+(1, 'Hardware'),
+(2, 'Services');
+
+-- 3. Units (Product Units) (2 records)
+CREATE TABLE IF NOT EXISTS `ip_units` (
+  `unit_id` int(11) NOT NULL AUTO_INCREMENT,
+  `unit_name` varchar(50) NOT NULL,
+  `unit_name_plrl` varchar(50) NOT NULL,
+  PRIMARY KEY (`unit_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_units` (`unit_id`, `unit_name`, `unit_name_plrl`) VALUES
+(1, 'Piece', 'Pieces'),
+(2, 'Hour', 'Hours');
+
+-- 4. Products (6 records)
+CREATE TABLE IF NOT EXISTS `ip_products` (
+  `product_id` int(11) NOT NULL AUTO_INCREMENT,
+  `family_id` int(11) DEFAULT NULL,
+  `product_sku` varchar(50) DEFAULT NULL,
+  `product_name` varchar(100) NOT NULL,
+  `product_description` text,
+  `product_price` decimal(20,2) NOT NULL,
+  `purchase_price` decimal(20,2) DEFAULT NULL,
+  `unit_id` int(11) DEFAULT NULL,
+  `tax_rate_id` int(11) DEFAULT NULL,
+  `product_tariff` int(11) DEFAULT NULL,
+  PRIMARY KEY (`product_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_products` (`product_id`, `family_id`, `product_sku`, `product_name`, `product_description`, `product_price`, `purchase_price`, `unit_id`, `tax_rate_id`, `product_tariff`) VALUES
+(1, 1, 'HW-001', 'Wireless Mouse', 'Ergonomic optical mouse', 25.00, 12.00, 1, 1, NULL),
+(2, 1, 'HW-002', 'Mechanical Keyboard', 'RGB mechanical gaming keyboard', 85.00, 45.00, 1, 1, NULL),
+(3, 1, 'HW-003', 'USB-C Hub', 'Multiport adapter with 4K HDMI', 40.00, 18.00, 1, 1, NULL),
+(4, 2, 'SRV-001', 'Consulting Hour', 'Senior architecture consulting', 150.00, 0.00, 2, 1, NULL),
+(5, 2, 'SRV-002', 'Website Maintenance', 'Monthly security updates & backups', 200.00, 50.00, 1, 2, NULL),
+(6, 2, 'SRV-003', 'Security Audit', 'Comprehensive vulnerability scan', 500.00, 100.00, 1, 1, NULL);
+
+-- 5. Clients (3 records)
+CREATE TABLE IF NOT EXISTS `ip_clients` (
+  `client_id` int(11) NOT NULL AUTO_INCREMENT,
+  `client_date_created` datetime NOT NULL,
+  `client_date_modified` datetime NOT NULL,
+  `client_name` varchar(100) NOT NULL,
+  `client_surname` varchar(100) DEFAULT NULL,
+  `client_type` int(1) DEFAULT 1,
+  `client_address_1` varchar(100) DEFAULT NULL,
+  `client_address_2` varchar(100) DEFAULT NULL,
+  `client_city` varchar(50) DEFAULT NULL,
+  `client_state` varchar(50) DEFAULT NULL,
+  `client_zip` varchar(20) DEFAULT NULL,
+  `client_country` varchar(50) DEFAULT NULL,
+  `client_phone` varchar(50) DEFAULT NULL,
+  `client_fax` varchar(50) DEFAULT NULL,
+  `client_mobile` varchar(50) DEFAULT NULL,
+  `client_email` varchar(100) DEFAULT NULL,
+  `client_web` varchar(100) DEFAULT NULL,
+  `client_vat_id` varchar(50) DEFAULT NULL,
+  `client_tax_code` varchar(50) DEFAULT NULL,
+  `client_active` int(1) DEFAULT 1,
+  `client_language` varchar(20) DEFAULT 'system',
+  PRIMARY KEY (`client_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_clients` (`client_id`, `client_date_created`, `client_date_modified`, `client_name`, `client_surname`, `client_type`, `client_address_1`, `client_address_2`, `client_city`, `client_state`, `client_zip`, `client_country`, `client_phone`, `client_fax`, `client_mobile`, `client_email`, `client_web`, `client_vat_id`, `client_tax_code`, `client_active`, `client_language`) VALUES
+(1, '2026-01-10 10:00:00', '2026-01-10 10:00:00', 'Acme Corp', 'Smith', 1, '123 Market St', 'Suite 400', 'San Francisco', 'CA', '94105', 'US', '+1-555-0199', NULL, '+1-555-0198', 'billing@acme.test', 'https://acme.test', 'US123456789', 'TX-9901', 1, 'en'),
+(2, '2026-01-15 11:30:00', '2026-01-15 11:30:00', 'Globex International', 'Johnson', 1, '456 King St', NULL, 'Toronto', 'ON', 'M5V 1L7', 'CA', '+1-416-555-0144', NULL, '+1-416-555-0145', 'accounts@globex.test', 'https://globex.test', 'CA987654321', 'TX-9902', 1, 'en'),
+(3, '2026-02-01 09:00:00', '2026-02-01 09:00:00', 'Wayne Enterprises', 'Wayne', 1, '1007 Mountain Drive', NULL, 'Gotham', 'NJ', '07001', 'US', '+1-201-555-0100', NULL, '+1-201-555-0101', 'bruce@wayne.test', 'https://wayne.test', 'US998877665', 'TX-9903', 1, 'en');
+
+-- 6. Payment Methods (3 records)
+CREATE TABLE IF NOT EXISTS `ip_payment_methods` (
+  `payment_method_id` int(11) NOT NULL AUTO_INCREMENT,
+  `payment_method_name` varchar(50) NOT NULL,
+  PRIMARY KEY (`payment_method_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_payment_methods` (`payment_method_id`, `payment_method_name`) VALUES
+(1, 'Bank Transfer'),
+(2, 'Credit Card'),
+(3, 'Cash');
+
+-- 7. Invoices (5 records with mixed statuses)
+-- INV-1001: Paid (Status 4)
+-- INV-1002: Sent (Status 2)
+-- INV-1003: Overdue (Status 2, due past date)
+-- INV-1004: Draft (Status 1)
+-- INV-1005: Partially Paid (Status 2, partial payment)
+CREATE TABLE IF NOT EXISTS `ip_invoices` (
+  `invoice_id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `client_id` int(11) NOT NULL,
+  `invoice_group_id` int(11) DEFAULT 1,
+  `invoice_status_id` int(1) NOT NULL,
+  `invoice_date_created` date NOT NULL,
+  `invoice_date_due` date NOT NULL,
+  `invoice_number` varchar(50) NOT NULL,
+  `invoice_discount_amount` decimal(20,2) DEFAULT 0.00,
+  `invoice_discount_percent` decimal(20,2) DEFAULT 0.00,
+  `invoice_terms` text,
+  `invoice_url_key` varchar(32) DEFAULT NULL,
+  `payment_method` int(11) DEFAULT 0,
+  `creditinvoice_parent_id` int(11) DEFAULT NULL,
+  `is_read_only` int(1) DEFAULT 0,
+  `invoice_password` varchar(100) DEFAULT NULL,
+  `invoice_time_created` time DEFAULT '00:00:00',
+  PRIMARY KEY (`invoice_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_invoices` (`invoice_id`, `user_id`, `client_id`, `invoice_group_id`, `invoice_status_id`, `invoice_date_created`, `invoice_date_due`, `invoice_number`, `invoice_discount_amount`, `invoice_discount_percent`, `invoice_terms`, `invoice_url_key`, `payment_method`, `creditinvoice_parent_id`, `is_read_only`, `invoice_password`, `invoice_time_created`) VALUES
+(1, 1, 1, 1, 4, '2026-01-15', '2026-02-15', 'INV-1001', 0.00, 0.00, 'Payment due within 30 days.', 'urlkey1001', 1, NULL, 0, NULL, '10:00:00'),
+(2, 1, 1, 1, 2, '2026-06-01', '2026-07-01', 'INV-1002', 0.00, 0.00, 'Net 30', 'urlkey1002', 1, NULL, 0, NULL, '11:00:00'),
+(3, 1, 2, 1, 2, '2026-01-01', '2026-01-31', 'INV-1003', 0.00, 0.00, 'Strict 30 days', 'urlkey1003', 2, NULL, 0, NULL, '12:00:00'),
+(4, 1, 2, 1, 1, '2026-06-10', '2026-07-10', 'INV-1004', 0.00, 0.00, 'Draft terms', 'urlkey1004', 0, NULL, 0, NULL, '13:00:00'),
+(5, 1, 3, 1, 2, '2026-05-01', '2026-06-01', 'INV-1005', 0.00, 0.00, 'Partial pay test', 'urlkey1005', 1, NULL, 0, NULL, '14:00:00');
+
+-- 8. Invoice Items (8 records total)
+CREATE TABLE IF NOT EXISTS `ip_invoice_items` (
+  `item_id` int(11) NOT NULL AUTO_INCREMENT,
+  `invoice_id` int(11) NOT NULL,
+  `item_tax_rate_id` int(11) DEFAULT NULL,
+  `item_date_added` date DEFAULT NULL,
+  `item_name` varchar(100) NOT NULL,
+  `item_description` text,
+  `item_quantity` decimal(20,2) NOT NULL,
+  `item_price` decimal(20,2) NOT NULL,
+  `item_discount_amount` decimal(20,2) DEFAULT 0.00,
+  `item_order` int(11) DEFAULT 1,
+  `item_product_id` int(11) DEFAULT NULL,
+  `item_product_unit_id` int(11) DEFAULT NULL,
+  `item_subtotal` decimal(20,2) DEFAULT 0.00,
+  `item_tax_total` decimal(20,2) DEFAULT 0.00,
+  `item_total` decimal(20,2) DEFAULT 0.00,
+  PRIMARY KEY (`item_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_invoice_items` (`item_id`, `invoice_id`, `item_tax_rate_id`, `item_date_added`, `item_name`, `item_description`, `item_quantity`, `item_price`, `item_discount_amount`, `item_order`, `item_product_id`, `item_product_unit_id`, `item_subtotal`, `item_tax_total`, `item_total`) VALUES
+(1, 1, 1, '2026-01-15', 'Wireless Mouse', 'Ergonomic mouse', 2.00, 25.00, 0.00, 1, 1, 1, 50.00, 10.00, 60.00),
+(2, 1, 1, '2026-01-15', 'Mechanical Keyboard', 'RGB keyboard', 1.00, 85.00, 0.00, 2, 2, 1, 85.00, 17.00, 102.00),
+(3, 2, 1, '2026-06-01', 'USB-C Hub', 'Multiport hub', 3.00, 40.00, 0.00, 1, 3, 1, 120.00, 24.00, 144.00),
+(4, 3, 1, '2026-01-01', 'Consulting Hour', 'Architecture consulting', 4.00, 150.00, 0.00, 1, 4, 2, 600.00, 120.00, 720.00),
+(5, 3, 2, '2026-01-01', 'Website Maintenance', 'Monthly maintenance', 1.00, 200.00, 0.00, 2, 5, 1, 200.00, 10.00, 210.00),
+(6, 4, 1, '2026-06-10', 'Wireless Mouse', 'Office mouse', 5.00, 25.00, 0.00, 1, 1, 1, 125.00, 25.00, 150.00),
+(7, 5, 1, '2026-05-01', 'Security Audit', 'Vulnerability assessment', 1.00, 500.00, 0.00, 1, 6, 1, 500.00, 100.00, 600.00),
+(8, 5, 1, '2026-05-01', 'Consulting Hour', 'Follow-up consulting', 2.00, 150.00, 0.00, 2, 4, 2, 300.00, 60.00, 360.00);
+
+-- 9. Invoice Amounts (Financial Invariant Source)
+CREATE TABLE IF NOT EXISTS `ip_invoice_amounts` (
+  `invoice_amount_id` int(11) NOT NULL AUTO_INCREMENT,
+  `invoice_id` int(11) NOT NULL,
+  `invoice_item_subtotal` decimal(20,2) NOT NULL,
+  `invoice_item_tax_total` decimal(20,2) NOT NULL,
+  `invoice_tax_total` decimal(20,2) NOT NULL,
+  `invoice_total` decimal(20,2) NOT NULL,
+  `invoice_paid` decimal(20,2) NOT NULL,
+  `invoice_balance` decimal(20,2) NOT NULL,
+  `invoice_sign` enum('1','-1') DEFAULT '1',
+  PRIMARY KEY (`invoice_amount_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_invoice_amounts` (`invoice_amount_id`, `invoice_id`, `invoice_item_subtotal`, `invoice_item_tax_total`, `invoice_tax_total`, `invoice_total`, `invoice_paid`, `invoice_balance`, `invoice_sign`) VALUES
+(1, 1, 135.00, 27.00, 27.00, 162.00, 162.00, 0.00, '1'),
+(2, 2, 120.00, 24.00, 24.00, 144.00, 0.00, 144.00, '1'),
+(3, 3, 800.00, 130.00, 130.00, 930.00, 0.00, 930.00, '1'),
+(4, 4, 125.00, 25.00, 25.00, 150.00, 0.00, 150.00, '1'),
+(5, 5, 800.00, 160.00, 160.00, 960.00, 400.00, 560.00, '1');
+
+-- 10. Payments (4 records)
+CREATE TABLE IF NOT EXISTS `ip_payments` (
+  `payment_id` int(11) NOT NULL AUTO_INCREMENT,
+  `invoice_id` int(11) NOT NULL,
+  `payment_method_id` int(11) NOT NULL,
+  `payment_date` date NOT NULL,
+  `payment_amount` decimal(20,2) NOT NULL,
+  `payment_note` text,
+  PRIMARY KEY (`payment_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_payments` (`payment_id`, `invoice_id`, `payment_method_id`, `payment_date`, `payment_amount`, `payment_note`) VALUES
+(1, 1, 1, '2026-02-01', 100.00, 'First installment via Bank Wire'),
+(2, 1, 1, '2026-02-10', 62.00, 'Final settlement'),
+(3, 5, 2, '2026-05-15', 200.00, 'Deposit payment Credit Card'),
+(4, 5, 3, '2026-05-20', 200.00, 'Cash installment');
+
+-- 11. Quotes (2 records)
+CREATE TABLE IF NOT EXISTS `ip_quotes` (
+  `quote_id` int(11) NOT NULL AUTO_INCREMENT,
+  `invoice_id` int(11) DEFAULT 0,
+  `user_id` int(11) NOT NULL,
+  `client_id` int(11) NOT NULL,
+  `invoice_group_id` int(11) DEFAULT 1,
+  `quote_status_id` int(1) NOT NULL,
+  `quote_date_created` date NOT NULL,
+  `quote_date_expires` date NOT NULL,
+  `quote_number` varchar(50) NOT NULL,
+  `quote_discount_amount` decimal(20,2) DEFAULT 0.00,
+  `quote_discount_percent` decimal(20,2) DEFAULT 0.00,
+  `quote_url_key` varchar(32) DEFAULT NULL,
+  `quote_password` varchar(100) DEFAULT NULL,
+  `notes` text,
+  PRIMARY KEY (`quote_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_quotes` (`quote_id`, `invoice_id`, `user_id`, `client_id`, `invoice_group_id`, `quote_status_id`, `quote_date_created`, `quote_date_expires`, `quote_number`, `quote_discount_amount`, `quote_discount_percent`, `quote_url_key`, `quote_password`, `notes`) VALUES
+(1, 0, 1, 1, 1, 2, '2026-02-01', '2026-03-01', 'QUO-2001', 0.00, 0.00, 'quotekey2001', NULL, 'Quote for hardware upgrade'),
+(2, 0, 1, 3, 1, 4, '2026-02-10', '2026-03-10', 'QUO-2002', 0.00, 0.00, 'quotekey2002', NULL, 'Approved security audit quote');
+
+-- 12. Quote Items
+CREATE TABLE IF NOT EXISTS `ip_quote_items` (
+  `item_id` int(11) NOT NULL AUTO_INCREMENT,
+  `quote_id` int(11) NOT NULL,
+  `item_tax_rate_id` int(11) DEFAULT NULL,
+  `item_date_added` date DEFAULT NULL,
+  `item_name` varchar(100) NOT NULL,
+  `item_description` text,
+  `item_quantity` decimal(20,2) NOT NULL,
+  `item_price` decimal(20,2) NOT NULL,
+  `item_discount_amount` decimal(20,2) DEFAULT 0.00,
+  `item_order` int(11) DEFAULT 1,
+  `item_product_id` int(11) DEFAULT NULL,
+  `item_product_unit_id` int(11) DEFAULT NULL,
+  `item_subtotal` decimal(20,2) DEFAULT 0.00,
+  `item_tax_total` decimal(20,2) DEFAULT 0.00,
+  `item_total` decimal(20,2) DEFAULT 0.00,
+  PRIMARY KEY (`item_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_quote_items` (`item_id`, `quote_id`, `item_tax_rate_id`, `item_date_added`, `item_name`, `item_description`, `item_quantity`, `item_price`, `item_discount_amount`, `item_order`, `item_product_id`, `item_product_unit_id`, `item_subtotal`, `item_tax_total`, `item_total`) VALUES
+(1, 1, 1, '2026-02-01', 'Wireless Mouse', 'Quote item 1', 10.00, 25.00, 0.00, 1, 1, 1, 250.00, 50.00, 300.00),
+(2, 2, 1, '2026-02-10', 'Security Audit', 'Quote audit', 1.00, 500.00, 0.00, 1, 6, 1, 500.00, 100.00, 600.00);
+
+-- 13. Quote Amounts
+CREATE TABLE IF NOT EXISTS `ip_quote_amounts` (
+  `quote_amount_id` int(11) NOT NULL AUTO_INCREMENT,
+  `quote_id` int(11) NOT NULL,
+  `quote_item_subtotal` decimal(20,2) NOT NULL,
+  `quote_item_tax_total` decimal(20,2) NOT NULL,
+  `quote_tax_total` decimal(20,2) NOT NULL,
+  `quote_total` decimal(20,2) NOT NULL,
+  PRIMARY KEY (`quote_amount_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_quote_amounts` (`quote_amount_id`, `quote_id`, `quote_item_subtotal`, `quote_item_tax_total`, `quote_tax_total`, `quote_total`) VALUES
+(1, 1, 250.00, 50.00, 50.00, 300.00),
+(2, 2, 500.00, 100.00, 100.00, 600.00);
+
+-- 14. Projects (1 record) & Tasks (2 records)
+CREATE TABLE IF NOT EXISTS `ip_projects` (
+  `project_id` int(11) NOT NULL AUTO_INCREMENT,
+  `client_id` int(11) NOT NULL,
+  `project_name` varchar(100) NOT NULL,
+  PRIMARY KEY (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_projects` (`project_id`, `client_id`, `project_name`) VALUES
+(1, 1, 'Infrastructure Overhaul');
+
+CREATE TABLE IF NOT EXISTS `ip_tasks` (
+  `task_id` int(11) NOT NULL AUTO_INCREMENT,
+  `project_id` int(11) DEFAULT NULL,
+  `task_name` varchar(100) NOT NULL,
+  `task_description` text,
+  `task_price` decimal(20,2) DEFAULT 0.00,
+  `task_finish_date` date DEFAULT NULL,
+  `task_status` int(1) DEFAULT 1,
+  `tax_rate_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`task_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_tasks` (`task_id`, `project_id`, `task_name`, `task_description`, `task_price`, `task_finish_date`, `task_status`, `tax_rate_id`) VALUES
+(1, 1, 'Network Topology Setup', 'Install new switches and configure VLANs', 450.00, '2026-03-15', 3, 1),
+(2, 1, 'Firewall Policy Migration', 'Migrate rules to next-gen firewall', 350.00, '2026-03-20', 2, 1);
+
+-- 15. Custom Fields (1 record)
+CREATE TABLE IF NOT EXISTS `ip_custom_fields` (
+  `custom_field_id` int(11) NOT NULL AUTO_INCREMENT,
+  `custom_field_table` varchar(50) NOT NULL,
+  `custom_field_label` varchar(50) NOT NULL,
+  `custom_field_type` varchar(50) DEFAULT 'TEXT',
+  `custom_field_order` int(11) DEFAULT 1,
+  PRIMARY KEY (`custom_field_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ip_custom_fields` (`custom_field_id`, `custom_field_table`, `custom_field_label`, `custom_field_type`, `custom_field_order`) VALUES
+(1, 'ip_client_custom', 'Account Manager', 'TEXT', 1);

--- a/Modules/Core/Tests/Unit/DateFieldAutoPopulationTest.php
+++ b/Modules/Core/Tests/Unit/DateFieldAutoPopulationTest.php
@@ -156,7 +156,7 @@ class DateFieldAutoPopulationTest extends AbstractCompanyPanelTestCase
     {
         $this->markTestSkipped(
             'Flaky in the container: the 2-second tolerance assertion is timing-sensitive '
-            .'against mid-test config() mutations; see issue #44 in batch #685 for context.'
+            . 'against mid-test config() mutations; see issue #44 in batch #685 for context.'
         );
 
         /* Arrange */

--- a/Modules/Core/Tests/Unit/Services/UserServiceAssertBelongsToCompanyTest.php
+++ b/Modules/Core/Tests/Unit/Services/UserServiceAssertBelongsToCompanyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Modules\Core\Tests\Unit\Services;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Modules\Core\Enums\UserRole;
+use Modules\Core\Models\Company;
+use Modules\Core\Models\User;
+use Modules\Core\Services\UserService;
+use Modules\Core\Tests\AbstractCompanyPanelTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+
+class UserServiceAssertBelongsToCompanyTest extends AbstractCompanyPanelTestCase
+{
+    protected UserService $userService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->userService = app(UserService::class);
+    }
+
+    #[Test]
+    #[Group('unit')]
+    public function it_allows_user_attached_to_company(): void
+    {
+        /* Arrange: $this->user belongs to $this->company */
+        $this->expectNotToPerformAssertions();
+
+        /* Act */
+        $this->userService->assertBelongsToCompany($this->user, $this->company);
+    }
+
+    #[Test]
+    #[Group('unit')]
+    public function it_throws_authorization_exception_for_unattached_company(): void
+    {
+        /* Arrange */
+        $unrelatedCompany = Company::factory()->create();
+
+        /* Assert & Act */
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage(trans('ip.user_not_in_company') ?: 'You do not have access to this company.');
+
+        $this->userService->assertBelongsToCompany($this->user, $unrelatedCompany);
+    }
+
+    #[Test]
+    #[Group('unit')]
+    public function it_allows_elevated_role_to_access_unattached_company(): void
+    {
+        /* Arrange */
+        Role::query()->firstOrCreate(['name' => UserRole::SUPER_ADMIN->value, 'guard_name' => 'web']);
+        $this->user->assignRole(UserRole::SUPER_ADMIN->value);
+        $unrelatedCompany = Company::factory()->create();
+
+        $this->expectNotToPerformAssertions();
+
+        /* Act */
+        $this->userService->assertBelongsToCompany($this->user, $unrelatedCompany);
+    }
+
+    #[Test]
+    #[Group('unit')]
+    public function it_accepts_integer_company_id(): void
+    {
+        /* Arrange */
+        $this->expectNotToPerformAssertions();
+
+        /* Act */
+        $this->userService->assertBelongsToCompany($this->user, $this->company->id);
+    }
+}

--- a/Modules/Core/resources/views/filament/admin/pages/import-v1.blade.php
+++ b/Modules/Core/resources/views/filament/admin/pages/import-v1.blade.php
@@ -1,0 +1,242 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+
+        {{-- Step Navigation Bar --}}
+        <div class="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 pb-4">
+            <div class="flex items-center space-x-4">
+                <div class="flex items-center">
+                    <span class="flex items-center justify-center w-8 h-8 rounded-full text-xs font-semibold {{ $currentStep >= 1 ? 'bg-primary-600 text-white' : 'bg-gray-200 text-gray-700' }}">1</span>
+                    <span class="ml-2 font-medium text-sm {{ $currentStep === 1 ? 'text-primary-600 font-semibold' : 'text-gray-500' }}">1. Source & Target</span>
+                </div>
+                <div class="w-8 h-0.5 bg-gray-300"></div>
+                <div class="flex items-center">
+                    <span class="flex items-center justify-center w-8 h-8 rounded-full text-xs font-semibold {{ $currentStep >= 2 ? 'bg-primary-600 text-white' : 'bg-gray-200 text-gray-700' }}">2</span>
+                    <span class="ml-2 font-medium text-sm {{ $currentStep === 2 ? 'text-primary-600 font-semibold' : 'text-gray-500' }}">2. Dry-Run & Inspection</span>
+                </div>
+                <div class="w-8 h-0.5 bg-gray-300"></div>
+                <div class="flex items-center">
+                    <span class="flex items-center justify-center w-8 h-8 rounded-full text-xs font-semibold {{ $currentStep >= 3 ? 'bg-primary-600 text-white' : 'bg-gray-200 text-gray-700' }}">3</span>
+                    <span class="ml-2 font-medium text-sm {{ $currentStep === 3 ? 'text-primary-600 font-semibold' : 'text-gray-500' }}">3. Results & Invariants</span>
+                </div>
+            </div>
+
+            @if ($currentStep > 1)
+                <x-filament::button color="gray" wire:click="resetWizard" size="sm">
+                    Reset / Start Over
+                </x-filament::button>
+            @endif
+        </div>
+
+        {{-- STEP 1: SOURCE CONFIGURATION --}}
+        @if ($currentStep === 1)
+            <x-filament::section heading="Migration Settings">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Target Company</label>
+                        <select wire:model="selectedCompanyId" class="w-full rounded-lg border-gray-300 dark:border-gray-700 dark:bg-gray-900 text-sm">
+                            @foreach ($this->companies as $company)
+                                <option value="{{ $company->id }}">{{ $company->name }} ({{ $company->search_code }})</option>
+                            @endforeach
+                        </select>
+                        <p class="text-xs text-gray-500 mt-1">All migrated clients, invoices, quotes, products, and payments will be scoped to this company.</p>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Table Prefix</label>
+                        <input type="text" wire:model="tablePrefix" class="w-full rounded-lg border-gray-300 dark:border-gray-700 dark:bg-gray-900 text-sm" placeholder="ip_">
+                        <p class="text-xs text-gray-500 mt-1">Default table prefix used in v1 MySQL database (usually <code>ip_</code>).</p>
+                    </div>
+                </div>
+
+                <div class="mt-6 border-t border-gray-200 dark:border-gray-700 pt-6">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Source Type</label>
+                    <div class="flex space-x-4 mb-4">
+                        <label class="inline-flex items-center">
+                            <input type="radio" wire:model.live="sourceType" value="sql_file" class="text-primary-600">
+                            <span class="ml-2 text-sm font-medium">Upload SQL Dump (.sql)</span>
+                        </label>
+                        <label class="inline-flex items-center">
+                            <input type="radio" wire:model.live="sourceType" value="database" class="text-primary-600">
+                            <span class="ml-2 text-sm font-medium">Direct MySQL Database Connection</span>
+                        </label>
+                    </div>
+
+                    @if ($sourceType === 'sql_file')
+                        <div class="p-4 border-2 border-dashed border-gray-300 dark:border-gray-700 rounded-lg text-center">
+                            <input type="file" wire:model="sqlFile" accept=".sql,.txt" class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100">
+                            <div wire:loading wire:target="sqlFile" class="text-xs text-primary-600 mt-2">Uploading SQL file...</div>
+                        </div>
+                    @else
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 bg-gray-50 dark:bg-gray-900 p-4 rounded-lg">
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Host</label>
+                                <input type="text" wire:model="dbHost" class="w-full rounded-lg border-gray-300 dark:border-gray-700 text-sm">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Port</label>
+                                <input type="text" wire:model="dbPort" class="w-full rounded-lg border-gray-300 dark:border-gray-700 text-sm">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Database</label>
+                                <input type="text" wire:model="dbDatabase" class="w-full rounded-lg border-gray-300 dark:border-gray-700 text-sm">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Username</label>
+                                <input type="text" wire:model="dbUsername" class="w-full rounded-lg border-gray-300 dark:border-gray-700 text-sm">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Password</label>
+                                <input type="password" wire:model="dbPassword" class="w-full rounded-lg border-gray-300 dark:border-gray-700 text-sm">
+                            </div>
+                            <div class="flex items-end">
+                                <x-filament::button wire:click="testConnection" color="gray" size="sm" class="w-full">
+                                    Test Connection
+                                </x-filament::button>
+                            </div>
+                        </div>
+                    @endif
+                </div>
+
+                <div class="mt-6 flex justify-end">
+                    <x-filament::button wire:click="proceedToInspection" color="primary">
+                        Analyze Source & Dry-Run &rarr;
+                    </x-filament::button>
+                </div>
+            </x-filament::section>
+        @endif
+
+        {{-- STEP 2: DRY RUN & INSPECTION --}}
+        @if ($currentStep === 2 && $inspectionResult)
+            <x-filament::section heading="Source Data Inspection & Dry-Run Analysis">
+                <div class="overflow-x-auto">
+                    <table class="w-full text-sm text-left">
+                        <thead class="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 uppercase text-xs">
+                            <tr>
+                                <th class="p-3">Entity Type</th>
+                                <th class="p-3 text-right">Source Records</th>
+                                <th class="p-3 text-right">Will Migrate</th>
+                                <th class="p-3 text-right">Unmappable / Skips</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach ($inspectionResult['entities'] as $entity => $data)
+                                <tr>
+                                    <td class="p-3 font-medium">{{ $data['label'] }}</td>
+                                    <td class="p-3 text-right font-mono">{{ number_format($data['source_count']) }}</td>
+                                    <td class="p-3 text-right font-mono text-emerald-600 dark:text-emerald-400 font-semibold">{{ number_format($data['will_migrate']) }}</td>
+                                    <td class="p-3 text-right font-mono {{ $data['unmappable'] > 0 ? 'text-amber-600' : 'text-gray-400' }}">
+                                        {{ number_format($data['unmappable']) }}
+                                    </td>
+                                </tr>
+                            @endforeach
+                            <tr class="bg-gray-50 dark:bg-gray-800 font-bold border-t-2">
+                                <td class="p-3">Total</td>
+                                <td class="p-3 text-right font-mono">{{ number_format($inspectionResult['total_source_count']) }}</td>
+                                <td class="p-3 text-right font-mono text-emerald-600">{{ number_format($inspectionResult['total_will_migrate']) }}</td>
+                                <td class="p-3 text-right font-mono">{{ number_format($inspectionResult['total_unmappable']) }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                @if (!empty($inspectionResult['warnings']))
+                    <div class="mt-4 p-4 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-lg">
+                        <h4 class="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-1">Warnings / Notes:</h4>
+                        <ul class="list-disc pl-5 text-xs text-amber-700 dark:text-amber-300 space-y-1">
+                            @foreach ($inspectionResult['warnings'] as $warning)
+                                <li>{{ $warning }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                <div class="mt-6 flex justify-between">
+                    <x-filament::button color="gray" wire:click="$set('currentStep', 1)">
+                        &larr; Back
+                    </x-filament::button>
+                    <x-filament::button color="success" wire:click="runMigration" wire:loading.attr="disabled">
+                        <span wire:loading.remove wire:target="runMigration">Run Migration Now</span>
+                        <span wire:loading wire:target="runMigration">Migrating records...</span>
+                    </x-filament::button>
+                </div>
+            </x-filament::section>
+        @endif
+
+        {{-- STEP 3: RESULTS & INVARIANTS --}}
+        @if ($currentStep === 3 && $migrationResult)
+            <div class="space-y-6">
+                <x-filament::section heading="Migration Results Summary">
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+                        <div class="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg text-center">
+                            <span class="text-xs text-gray-500 uppercase">Batch ID</span>
+                            <div class="font-mono text-sm font-semibold mt-1">{{ $migrationResult['batch_id'] }}</div>
+                        </div>
+                        <div class="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg text-center">
+                            <span class="text-xs text-gray-500 uppercase">Status</span>
+                            <div class="text-sm font-semibold mt-1 {{ $migrationResult['success'] ? 'text-emerald-600' : 'text-red-600' }}">
+                                {{ $migrationResult['success'] ? '✓ Success' : '⚠ Completed with errors' }}
+                            </div>
+                        </div>
+                        <div class="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg text-center">
+                            <span class="text-xs text-gray-500 uppercase">Financial Invariants</span>
+                            <div class="text-sm font-semibold mt-1 {{ $migrationResult['financial_invariants']['passed'] ? 'text-emerald-600' : 'text-amber-600' }}">
+                                {{ $migrationResult['financial_invariants']['passed'] ? '✓ Verified (100% match)' : '⚠ ' . $migrationResult['financial_invariants']['failed_count'] . ' Mismatches' }}
+                            </div>
+                        </div>
+                    </div>
+
+                    <table class="w-full text-sm text-left mb-6">
+                        <thead class="bg-gray-100 dark:bg-gray-800 uppercase text-xs">
+                            <tr>
+                                <th class="p-3">Entity</th>
+                                <th class="p-3 text-right">Migrated</th>
+                                <th class="p-3 text-right">Skipped</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach ($migrationResult['results'] as $key => $res)
+                                <tr>
+                                    <td class="p-3 font-medium">{{ $res['label'] }}</td>
+                                    <td class="p-3 text-right font-mono text-emerald-600 font-semibold">{{ $res['migrated'] }}</td>
+                                    <td class="p-3 text-right font-mono text-gray-500">{{ $res['skipped'] }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+
+                    @if (!$migrationResult['financial_invariants']['passed'])
+                        <div class="p-4 bg-amber-50 border border-amber-200 rounded-lg mb-6 text-xs text-amber-800">
+                            <strong>Invariant Discrepancies:</strong>
+                            <ul class="list-disc pl-5 mt-1">
+                                @foreach ($migrationResult['financial_invariants']['mismatches'] as $m)
+                                    <li>{{ $m['type'] }} #{{ $m['number'] }} ({{ $m['field'] }}): Expected {{ $m['expected'] }}, got {{ $m['actual'] }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    @if ($rollbackResult)
+                        <div class="p-4 bg-blue-50 border border-blue-200 rounded-lg text-xs text-blue-800 mb-4">
+                            Batch {{ $rollbackResult['batch_id'] }} has been rolled back successfully.
+                        </div>
+                    @endif
+
+                    <div class="flex justify-between items-center pt-4 border-t border-gray-200 dark:border-gray-700">
+                        @if (!$rollbackResult)
+                            <x-filament::button color="danger" size="sm" wire:click="rollback" wire:confirm="Are you sure you want to rollback all records created in this migration batch?">
+                                Rollback This Batch
+                            </x-filament::button>
+                        @else
+                            <div></div>
+                        @endif
+
+                        <x-filament::button color="primary" wire:click="resetWizard">
+                            Done
+                        </x-filament::button>
+                    </div>
+                </x-filament::section>
+            </div>
+        @endif
+
+    </div>
+</x-filament-panels::page>

--- a/Modules/Invoices/Models/Invoice.php
+++ b/Modules/Invoices/Models/Invoice.php
@@ -129,10 +129,9 @@ class Invoice extends Model
         return $this->hasMany(InvoiceItem::class, 'invoice_id');
     }
 
-    public function mailQueue(): HasMany
+    public function mailQueue(): MorphMany
     {
-        return $this->hasMany(MailQueue::class, 'mailable_id')
-            ->where('mailable_type', self::class);
+        return $this->morphMany(MailQueue::class, 'mailable');
     }
 
     public function notes(): MorphMany

--- a/Modules/Invoices/Tests/Feature/EditInvoiceHeaderActionsTest.php
+++ b/Modules/Invoices/Tests/Feature/EditInvoiceHeaderActionsTest.php
@@ -143,7 +143,8 @@ class EditInvoiceHeaderActionsTest extends AbstractCompanyPanelTestCase
         $customer      = Relation::factory()->for($this->company)->customer()->create();
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
-        return Invoice::factory()->for($this->company)->create(array_merge([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->for($this->company)->create(array_merge([
             'invoice_number' => 'INV-987654',
             'customer_id'    => $customer->getKey(),
             'numbering_id'   => $documentGroup->getKey(),
@@ -153,5 +154,7 @@ class EditInvoiceHeaderActionsTest extends AbstractCompanyPanelTestCase
             'invoiced_at'    => '2025-05-10',
             'invoice_due_at' => '2025-06-09',
         ], $attributes));
+
+        return $invoice;
     }
 }

--- a/Modules/Invoices/Tests/Feature/EmailInvoiceActionTest.php
+++ b/Modules/Invoices/Tests/Feature/EmailInvoiceActionTest.php
@@ -128,7 +128,8 @@ class EmailInvoiceActionTest extends AbstractCompanyPanelTestCase
         ]);
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
-        return Invoice::factory()->for($this->company)->create(array_merge([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->for($this->company)->create(array_merge([
             'invoice_number' => 'INV-987654',
             'customer_id'    => $customer->getKey(),
             'numbering_id'   => $documentGroup->getKey(),
@@ -138,5 +139,7 @@ class EmailInvoiceActionTest extends AbstractCompanyPanelTestCase
             'invoiced_at'    => '2025-05-10',
             'invoice_due_at' => '2025-06-09',
         ], $attributes));
+
+        return $invoice;
     }
 }

--- a/Modules/Invoices/Tests/Feature/InvoiceListActionsTest.php
+++ b/Modules/Invoices/Tests/Feature/InvoiceListActionsTest.php
@@ -39,7 +39,7 @@ class InvoiceListActionsTest extends AbstractCompanyPanelTestCase
          * on invoices, create-payments and email-invoices.
          */
         $customer = Relation::factory()->for($this->company)->customer()->create();
-        /** @var Relation $customer */
+        /* @var Relation $customer */
         $this->customer = $customer;
 
         /** @var Numbering $numbering */

--- a/Modules/Invoices/Tests/Feature/InvoiceListActionsTest.php
+++ b/Modules/Invoices/Tests/Feature/InvoiceListActionsTest.php
@@ -38,12 +38,16 @@ class InvoiceListActionsTest extends AbstractCompanyPanelTestCase
          * assigns client_admin, which carries create/edit/delete/duplicate
          * on invoices, create-payments and email-invoices.
          */
-        $this->customer = Relation::factory()->for($this->company)->customer()->create();
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+        /** @var Relation $customer */
+        $this->customer = $customer;
 
-        $this->numbering = Numbering::factory()
+        /** @var Numbering $numbering */
+        $numbering = Numbering::factory()
             ->for($this->company)
             ->state(['type' => NumberingType::INVOICE->value])
             ->create();
+        $this->numbering = $numbering;
     }
 
     #[Test]
@@ -66,6 +70,7 @@ class InvoiceListActionsTest extends AbstractCompanyPanelTestCase
         /* Assert */
         $component->assertHasNoErrors();
 
+        /** @var Invoice|null $copy */
         $copy = Invoice::query()
             ->where('id', '!=', $invoice->id)
             ->orderByDesc('id')
@@ -278,12 +283,15 @@ class InvoiceListActionsTest extends AbstractCompanyPanelTestCase
 
     protected function makeInvoice(array $attributes = []): Invoice
     {
-        return Invoice::factory()->for($this->company)->create(array_merge([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->for($this->company)->create(array_merge([
             'customer_id'  => $this->customer->id,
             'numbering_id' => $this->numbering->id,
             'user_id'      => $this->user->id,
             'is_read_only' => false,
         ], $attributes));
+
+        return $invoice;
     }
 
     protected function listInvoices()

--- a/Modules/Invoices/Tests/Feature/InvoicePdfAndCreditNoteTest.php
+++ b/Modules/Invoices/Tests/Feature/InvoicePdfAndCreditNoteTest.php
@@ -226,7 +226,8 @@ class InvoicePdfAndCreditNoteTest extends AbstractCompanyPanelTestCase
         $customer      = Relation::factory()->for($this->company)->customer()->create();
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
-        return Invoice::factory()->for($this->company)->create(array_merge([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->for($this->company)->create(array_merge([
             'invoice_number' => 'INV-987654',
             'customer_id'    => $customer->getKey(),
             'numbering_id'   => $documentGroup->getKey(),
@@ -236,5 +237,7 @@ class InvoicePdfAndCreditNoteTest extends AbstractCompanyPanelTestCase
             'invoiced_at'    => '2025-05-10',
             'invoice_due_at' => '2025-06-09',
         ], $attributes));
+
+        return $invoice;
     }
 }

--- a/Modules/Invoices/Tests/Feature/SendReminderActionTest.php
+++ b/Modules/Invoices/Tests/Feature/SendReminderActionTest.php
@@ -300,7 +300,8 @@ class SendReminderActionTest extends AbstractCompanyPanelTestCase
 
     private function makeInvoice(Relation $customer, Numbering $numbering, array $attributes = []): Invoice
     {
-        return Invoice::factory()->for($this->company)->create(array_merge([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->for($this->company)->create(array_merge([
             'invoice_number' => 'INV-987654',
             'customer_id'    => $customer->getKey(),
             'numbering_id'   => $numbering->getKey(),
@@ -308,6 +309,8 @@ class SendReminderActionTest extends AbstractCompanyPanelTestCase
             'is_read_only'   => false,
             'invoiced_at'    => '2025-05-10',
         ], $attributes));
+
+        return $invoice;
     }
 
     private function listInvoices()

--- a/Modules/Projects/Tests/Feature/ProjectBillingTest.php
+++ b/Modules/Projects/Tests/Feature/ProjectBillingTest.php
@@ -129,18 +129,24 @@ class ProjectBillingTest extends AbstractCompanyPanelTestCase
     {
         $customer = Relation::factory()->for($this->company)->customer()->create();
 
-        return Project::factory()->for($this->company)->create([
+        /** @var Project $project */
+        $project = Project::factory()->for($this->company)->create([
             'customer_id' => $customer->id,
         ]);
+
+        return $project;
     }
 
     private function createTask(Project $project, array $attributes = []): Task
     {
-        return Task::factory()->for($this->company)->create(array_merge([
+        /** @var Task $task */
+        $task = Task::factory()->for($this->company)->create(array_merge([
             'customer_id' => $project->customer_id,
             'project_id'  => $project->id,
             'task_status' => TaskStatus::COMPLETED->value,
             'task_price'  => 100,
         ], $attributes));
+
+        return $task;
     }
 }

--- a/Modules/Quotes/Tests/Feature/EditQuoteHeaderActionsTest.php
+++ b/Modules/Quotes/Tests/Feature/EditQuoteHeaderActionsTest.php
@@ -116,7 +116,8 @@ class EditQuoteHeaderActionsTest extends AbstractCompanyPanelTestCase
         $prospect      = Relation::factory()->for($this->company)->prospect()->create();
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
-        return Quote::factory()->for($this->company)->create(array_merge([
+        /** @var Quote $quote */
+        $quote = Quote::factory()->for($this->company)->create(array_merge([
             'quote_number' => 'Q-987654',
             'prospect_id'  => $prospect->getKey(),
             'numbering_id' => $documentGroup->getKey(),
@@ -124,5 +125,7 @@ class EditQuoteHeaderActionsTest extends AbstractCompanyPanelTestCase
             'quote_status' => $status->value,
             'quoted_at'    => '2025-05-10',
         ], $attributes));
+
+        return $quote;
     }
 }

--- a/Modules/Quotes/Tests/Feature/QuoteConversionTest.php
+++ b/Modules/Quotes/Tests/Feature/QuoteConversionTest.php
@@ -109,7 +109,8 @@ class QuoteConversionTest extends AbstractCompanyPanelTestCase
         $prospect      = Relation::factory()->for($this->company)->prospect()->create();
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
-        return Quote::factory()->for($this->company)->create(array_merge([
+        /** @var Quote $quote */
+        $quote = Quote::factory()->for($this->company)->create(array_merge([
             'quote_number' => 'Q-' . fake()->unique()->numberBetween(1000, 99999),
             'prospect_id'  => $prospect->getKey(),
             'numbering_id' => $documentGroup->getKey(),
@@ -117,5 +118,7 @@ class QuoteConversionTest extends AbstractCompanyPanelTestCase
             'quote_status' => QuoteStatus::APPROVED->value,
             'quoted_at'    => '2025-05-10',
         ], $attributes));
+
+        return $quote;
     }
 }

--- a/Modules/Subscriptions/Database/Factories/SubscriptionFactory.php
+++ b/Modules/Subscriptions/Database/Factories/SubscriptionFactory.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Modules\Subscriptions\Database\Factories;
+
+use Modules\Clients\Models\Relation;
+use Modules\Core\Database\Factories\AbstractFactory;
+use Modules\Subscriptions\Enums\BillingInterval;
+use Modules\Subscriptions\Enums\IntervalUnit;
+use Modules\Subscriptions\Enums\SubscriptionStatus;
+use Modules\Subscriptions\Models\Subscription;
+use Modules\Subscriptions\Models\SubscriptionItem;
+
+class SubscriptionFactory extends AbstractFactory
+{
+    protected $model = Subscription::class;
+
+    public function definition(): array
+    {
+        $companyId = $this->resolveCompanyId();
+        $startsAt  = $this->faker->dateTimeBetween('-6 months', 'now');
+
+        return [
+            'company_id'               => $companyId,
+            'customer_id'              => $this->resolveForeignKey(Relation::class, $companyId),
+            'number'                   => 'SUB-' . $this->faker->unique()->numerify('#####'),
+            'name'                     => $this->faker->words(3, true) . ' Subscription',
+            'status'                   => SubscriptionStatus::ACTIVE,
+            'billing_interval'         => BillingInterval::MONTHLY,
+            'interval_unit'            => IntervalUnit::MONTH,
+            'interval_count'           => 1,
+            'price'                    => $this->faker->randomFloat(4, 49, 499),
+            'currency_code'            => 'USD',
+            'starts_at'                => $startsAt,
+            'ends_at'                  => null,
+            'trial_starts_at'          => null,
+            'trial_ends_at'            => null,
+            'grace_period_days'        => 0,
+            'grace_period_ends_at'     => null,
+            'current_period_starts_at' => $startsAt,
+            'current_period_ends_at'   => (clone $startsAt)->modify('+1 month'),
+            'paused_at'                => null,
+            'resume_at'                => null,
+            'cancel_at_period_end'     => false,
+            'canceled_at'              => null,
+            'notes'                    => $this->faker->sentence(),
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Subscription $subscription) {
+            SubscriptionItem::create([
+                'subscription_id' => $subscription->id,
+                'name'            => $subscription->name . ' Core Plan',
+                'quantity'        => 1,
+                'unit_price'      => $subscription->price,
+                'subtotal'        => $subscription->price,
+                'tax'             => 0,
+                'total'           => $subscription->price,
+            ]);
+        });
+    }
+
+    public function trialing(): static
+    {
+        return $this->state(function () {
+            $now = now();
+
+            return [
+                'status'          => SubscriptionStatus::TRIALING,
+                'trial_starts_at' => $now,
+                'trial_ends_at'   => (clone $now)->addDays(14),
+            ];
+        });
+    }
+
+    public function inGracePeriod(): static
+    {
+        return $this->state(function () {
+            $now = now();
+
+            return [
+                'status'               => SubscriptionStatus::IN_GRACE_PERIOD,
+                'grace_period_days'    => 7,
+                'grace_period_ends_at' => (clone $now)->addDays(7),
+            ];
+        });
+    }
+
+    public function paused(): static
+    {
+        return $this->state(function () {
+            return [
+                'status'    => SubscriptionStatus::PAUSED,
+                'paused_at' => now(),
+            ];
+        });
+    }
+
+    public function canceled(): static
+    {
+        return $this->state(function () {
+            $now = now();
+
+            return [
+                'status'      => SubscriptionStatus::CANCELED,
+                'canceled_at' => $now,
+                'ends_at'     => $now,
+            ];
+        });
+    }
+}

--- a/Modules/Subscriptions/Database/Migrations/2026_08_13_000001_create_subscriptions_table.php
+++ b/Modules/Subscriptions/Database/Migrations/2026_08_13_000001_create_subscriptions_table.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('company_id')->constrained('companies')->cascadeOnDelete();
+            $table->foreignId('customer_id')->constrained('relations')->cascadeOnDelete();
+            $table->string('number', 50)->nullable();
+            $table->string('name')->nullable();
+            $table->string('status', 30)->default('active');
+            $table->string('billing_interval', 30)->default('monthly');
+            $table->string('interval_unit', 20)->default('month');
+            $table->integer('interval_count')->default(1);
+
+            $table->decimal('price', 15, 4)->default(0.0000);
+            $table->string('currency_code', 3)->nullable();
+
+            $table->timestamp('starts_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+
+            $table->timestamp('trial_starts_at')->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+
+            $table->integer('grace_period_days')->default(0);
+            $table->timestamp('grace_period_ends_at')->nullable();
+
+            $table->timestamp('current_period_starts_at')->nullable();
+            $table->timestamp('current_period_ends_at')->nullable();
+
+            $table->timestamp('paused_at')->nullable();
+            $table->timestamp('resume_at')->nullable();
+
+            $table->boolean('cancel_at_period_end')->default(false);
+            $table->timestamp('canceled_at')->nullable();
+
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['company_id', 'status']);
+            $table->index(['customer_id']);
+        });
+
+        Schema::create('subscription_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('subscription_id')->constrained('subscriptions')->cascadeOnDelete();
+            $table->foreignId('product_id')->nullable()->constrained('products')->nullOnDelete();
+            $table->string('name');
+            $table->decimal('quantity', 15, 4)->default(1.0000);
+            $table->decimal('unit_price', 15, 4)->default(0.0000);
+            $table->decimal('subtotal', 15, 4)->default(0.0000);
+            $table->decimal('tax', 15, 4)->default(0.0000);
+            $table->decimal('total', 15, 4)->default(0.0000);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subscription_items');
+        Schema::dropIfExists('subscriptions');
+    }
+};

--- a/Modules/Subscriptions/Database/Seeders/SubscriptionSeeder.php
+++ b/Modules/Subscriptions/Database/Seeders/SubscriptionSeeder.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Modules\Subscriptions\Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Modules\Clients\Models\Relation;
+use Modules\Core\Models\Company;
+use Modules\Products\Models\Product;
+use Modules\Subscriptions\Enums\BillingInterval;
+use Modules\Subscriptions\Enums\IntervalUnit;
+use Modules\Subscriptions\Enums\SubscriptionStatus;
+use Modules\Subscriptions\Models\Subscription;
+use Modules\Subscriptions\Models\SubscriptionItem;
+
+class SubscriptionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $company = Company::query()->whereRaw('LOWER(search_code) = ?', ['ivplv2'])->first()
+            ?? Company::query()->first();
+
+        if ( ! $company) {
+            return;
+        }
+
+        $customer = Relation::query()->where('company_id', $company->id)->first();
+        if ( ! $customer) {
+            $customer = Relation::factory()->create(['company_id' => $company->id]);
+        }
+
+        $product = Product::query()->where('company_id', $company->id)->first();
+
+        $now = Carbon::now();
+
+        // 1. Active Monthly Subscription
+        $sub1 = Subscription::create([
+            'company_id'               => $company->id,
+            'customer_id'              => $customer->id,
+            'number'                   => 'SUB-2026-0001',
+            'name'                     => 'SaaS Premium Monthly Plan',
+            'status'                   => SubscriptionStatus::ACTIVE,
+            'billing_interval'         => BillingInterval::MONTHLY,
+            'interval_unit'            => IntervalUnit::MONTH,
+            'interval_count'           => 1,
+            'price'                    => 199.0000,
+            'currency_code'            => 'USD',
+            'starts_at'                => $now->copy()->subMonths(3),
+            'current_period_starts_at' => $now->copy()->subDays(10),
+            'current_period_ends_at'   => $now->copy()->addDays(20),
+            'notes'                    => 'Active monthly subscription with automated invoicing.',
+        ]);
+        SubscriptionItem::create([
+            'subscription_id' => $sub1->id,
+            'product_id'      => $product?->id,
+            'name'            => 'SaaS Premium Seat License',
+            'quantity'        => 2,
+            'unit_price'      => 99.5000,
+            'subtotal'        => 199.0000,
+            'tax'             => 0,
+            'total'           => 199.0000,
+        ]);
+
+        // 2. Active Yearly Subscription
+        $sub2 = Subscription::create([
+            'company_id'               => $company->id,
+            'customer_id'              => $customer->id,
+            'number'                   => 'SUB-2026-0002',
+            'name'                     => 'Enterprise Cloud Yearly Suite',
+            'status'                   => SubscriptionStatus::ACTIVE,
+            'billing_interval'         => BillingInterval::YEARLY,
+            'interval_unit'            => IntervalUnit::YEAR,
+            'interval_count'           => 1,
+            'price'                    => 2400.0000,
+            'currency_code'            => 'USD',
+            'starts_at'                => $now->copy()->subMonths(6),
+            'current_period_starts_at' => $now->copy()->subMonths(6),
+            'current_period_ends_at'   => $now->copy()->addMonths(6),
+            'notes'                    => 'Yearly enterprise contract with priority support.',
+        ]);
+        SubscriptionItem::create([
+            'subscription_id' => $sub2->id,
+            'product_id'      => $product?->id,
+            'name'            => 'Enterprise Annual Core Bundle',
+            'quantity'        => 1,
+            'unit_price'      => 2400.0000,
+            'subtotal'        => 2400.0000,
+            'tax'             => 0,
+            'total'           => 2400.0000,
+        ]);
+
+        // 3. Custom Billing Cycle (14 Days)
+        $sub3 = Subscription::create([
+            'company_id'               => $company->id,
+            'customer_id'              => $customer->id,
+            'number'                   => 'SUB-2026-0003',
+            'name'                     => 'Bi-Weekly Maintenance Service',
+            'status'                   => SubscriptionStatus::ACTIVE,
+            'billing_interval'         => BillingInterval::CUSTOM,
+            'interval_unit'            => IntervalUnit::DAY,
+            'interval_count'           => 14,
+            'price'                    => 150.0000,
+            'currency_code'            => 'USD',
+            'starts_at'                => $now->copy()->subDays(28),
+            'current_period_starts_at' => $now->copy()->subDays(2),
+            'current_period_ends_at'   => $now->copy()->addDays(12),
+            'notes'                    => 'Bi-weekly custom maintenance billing cycle.',
+        ]);
+        SubscriptionItem::create([
+            'subscription_id' => $sub3->id,
+            'product_id'      => $product?->id,
+            'name'            => '14-Day Maintenance Inspection',
+            'quantity'        => 1,
+            'unit_price'      => 150.0000,
+            'subtotal'        => 150.0000,
+            'tax'             => 0,
+            'total'           => 150.0000,
+        ]);
+
+        // 4. Trial Period Subscription
+        $sub4 = Subscription::create([
+            'company_id'               => $company->id,
+            'customer_id'              => $customer->id,
+            'number'                   => 'SUB-2026-0004',
+            'name'                     => 'Pro Tier 14-Day Free Trial',
+            'status'                   => SubscriptionStatus::TRIALING,
+            'billing_interval'         => BillingInterval::MONTHLY,
+            'interval_unit'            => IntervalUnit::MONTH,
+            'interval_count'           => 1,
+            'price'                    => 299.0000,
+            'currency_code'            => 'USD',
+            'starts_at'                => $now->copy()->subDays(5),
+            'trial_starts_at'          => $now->copy()->subDays(5),
+            'trial_ends_at'            => $now->copy()->addDays(9),
+            'current_period_starts_at' => $now->copy()->subDays(5),
+            'current_period_ends_at'   => $now->copy()->addDays(9),
+            'notes'                    => 'Trial active for another 9 days.',
+        ]);
+        SubscriptionItem::create([
+            'subscription_id' => $sub4->id,
+            'product_id'      => $product?->id,
+            'name'            => 'Pro Tier Trial Features',
+            'quantity'        => 1,
+            'unit_price'      => 299.0000,
+            'subtotal'        => 299.0000,
+            'tax'             => 0,
+            'total'           => 299.0000,
+        ]);
+
+        // 5. In Grace Period Subscription
+        $sub5 = Subscription::create([
+            'company_id'               => $company->id,
+            'customer_id'              => $customer->id,
+            'number'                   => 'SUB-2026-0005',
+            'name'                     => 'Standard Tier (In Grace Period)',
+            'status'                   => SubscriptionStatus::IN_GRACE_PERIOD,
+            'billing_interval'         => BillingInterval::MONTHLY,
+            'interval_unit'            => IntervalUnit::MONTH,
+            'interval_count'           => 1,
+            'price'                    => 89.0000,
+            'currency_code'            => 'USD',
+            'starts_at'                => $now->copy()->subMonths(2),
+            'grace_period_days'        => 7,
+            'grace_period_ends_at'     => $now->copy()->addDays(4),
+            'current_period_starts_at' => $now->copy()->subDays(31),
+            'current_period_ends_at'   => $now->copy()->subDays(1),
+            'notes'                    => 'Payment failed, subscriber given 7 days grace period.',
+        ]);
+        SubscriptionItem::create([
+            'subscription_id' => $sub5->id,
+            'product_id'      => $product?->id,
+            'name'            => 'Standard Monthly Package',
+            'quantity'        => 1,
+            'unit_price'      => 89.0000,
+            'subtotal'        => 89.0000,
+            'tax'             => 0,
+            'total'           => 89.0000,
+        ]);
+
+        // 6. Paused Subscription
+        $sub6 = Subscription::create([
+            'company_id'               => $company->id,
+            'customer_id'              => $customer->id,
+            'number'                   => 'SUB-2026-0006',
+            'name'                     => 'Seasonal Growth Subscription',
+            'status'                   => SubscriptionStatus::PAUSED,
+            'billing_interval'         => BillingInterval::MONTHLY,
+            'interval_unit'            => IntervalUnit::MONTH,
+            'interval_count'           => 1,
+            'price'                    => 149.0000,
+            'currency_code'            => 'USD',
+            'starts_at'                => $now->copy()->subMonths(4),
+            'paused_at'                => $now->copy()->subDays(12),
+            'current_period_starts_at' => $now->copy()->subDays(30),
+            'current_period_ends_at'   => $now->copy()->addDays(5),
+            'notes'                    => 'Subscription paused by customer request during off-season.',
+        ]);
+        SubscriptionItem::create([
+            'subscription_id' => $sub6->id,
+            'product_id'      => $product?->id,
+            'name'            => 'Growth Add-on Services',
+            'quantity'        => 1,
+            'unit_price'      => 149.0000,
+            'subtotal'        => 149.0000,
+            'tax'             => 0,
+            'total'           => 149.0000,
+        ]);
+
+        // 7. Cancel At Period End Subscription
+        $sub7 = Subscription::create([
+            'company_id'               => $company->id,
+            'customer_id'              => $customer->id,
+            'number'                   => 'SUB-2026-0007',
+            'name'                     => 'Developer API Subscription',
+            'status'                   => SubscriptionStatus::ACTIVE,
+            'billing_interval'         => BillingInterval::MONTHLY,
+            'interval_unit'            => IntervalUnit::MONTH,
+            'interval_count'           => 1,
+            'price'                    => 350.0000,
+            'currency_code'            => 'USD',
+            'starts_at'                => $now->copy()->subMonths(1),
+            'cancel_at_period_end'     => true,
+            'canceled_at'              => $now->copy()->subDays(3),
+            'current_period_starts_at' => $now->copy()->subDays(15),
+            'current_period_ends_at'   => $now->copy()->addDays(15),
+            'notes'                    => 'Customer requested cancellation at period end.',
+        ]);
+        SubscriptionItem::create([
+            'subscription_id' => $sub7->id,
+            'product_id'      => $product?->id,
+            'name'            => 'API Call Pool (High Volume)',
+            'quantity'        => 1,
+            'unit_price'      => 350.0000,
+            'subtotal'        => 350.0000,
+            'tax'             => 0,
+            'total'           => 350.0000,
+        ]);
+    }
+}

--- a/Modules/Subscriptions/Enums/BillingInterval.php
+++ b/Modules/Subscriptions/Enums/BillingInterval.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Modules\Subscriptions\Enums;
+
+use Modules\Core\Contracts\LabeledEnum;
+
+enum BillingInterval: string implements LabeledEnum
+{
+    case WEEKLY  = 'weekly';
+    case MONTHLY = 'monthly';
+    case YEARLY  = 'yearly';
+    case CUSTOM  = 'custom';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::WEEKLY  => 'Weekly',
+            self::MONTHLY => 'Monthly',
+            self::YEARLY  => 'Yearly',
+            self::CUSTOM  => 'Custom Cycle',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::WEEKLY  => 'info',
+            self::MONTHLY => 'primary',
+            self::YEARLY  => 'success',
+            self::CUSTOM  => 'warning',
+        };
+    }
+}

--- a/Modules/Subscriptions/Enums/CancellationType.php
+++ b/Modules/Subscriptions/Enums/CancellationType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Modules\Subscriptions\Enums;
+
+use Modules\Core\Contracts\LabeledEnum;
+
+enum CancellationType: string implements LabeledEnum
+{
+    case IMMEDIATE     = 'immediate';
+    case AT_PERIOD_END = 'at_period_end';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::IMMEDIATE     => 'Cancel Immediately',
+            self::AT_PERIOD_END => 'Cancel at End of Billing Period',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::IMMEDIATE     => 'danger',
+            self::AT_PERIOD_END => 'warning',
+        };
+    }
+}

--- a/Modules/Subscriptions/Enums/IntervalUnit.php
+++ b/Modules/Subscriptions/Enums/IntervalUnit.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Modules\Subscriptions\Enums;
+
+use Modules\Core\Contracts\LabeledEnum;
+
+enum IntervalUnit: string implements LabeledEnum
+{
+    case DAY   = 'day';
+    case WEEK  = 'week';
+    case MONTH = 'month';
+    case YEAR  = 'year';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::DAY   => 'Day(s)',
+            self::WEEK  => 'Week(s)',
+            self::MONTH => 'Month(s)',
+            self::YEAR  => 'Year(s)',
+        };
+    }
+
+    public function color(): string
+    {
+        return 'gray';
+    }
+}

--- a/Modules/Subscriptions/Enums/SubscriptionStatus.php
+++ b/Modules/Subscriptions/Enums/SubscriptionStatus.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Modules\Subscriptions\Enums;
+
+use Modules\Core\Contracts\LabeledEnum;
+
+enum SubscriptionStatus: string implements LabeledEnum
+{
+    case ACTIVE          = 'active';
+    case TRIALING        = 'trialing';
+    case IN_GRACE_PERIOD = 'in_grace_period';
+    case PAUSED          = 'paused';
+    case CANCELED        = 'canceled';
+    case EXPIRED         = 'expired';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ACTIVE          => 'Active',
+            self::TRIALING        => 'Trialing',
+            self::IN_GRACE_PERIOD => 'In Grace Period',
+            self::PAUSED          => 'Paused',
+            self::CANCELED        => 'Canceled',
+            self::EXPIRED         => 'Expired',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::ACTIVE          => 'success',
+            self::TRIALING        => 'info',
+            self::IN_GRACE_PERIOD => 'warning',
+            self::PAUSED          => 'gray',
+            self::CANCELED        => 'danger',
+            self::EXPIRED         => 'danger',
+        };
+    }
+
+    public function badgeIcon(): string
+    {
+        return match ($this) {
+            self::ACTIVE          => 'heroicon-o-check-circle',
+            self::TRIALING        => 'heroicon-o-clock',
+            self::IN_GRACE_PERIOD => 'heroicon-o-exclamation-triangle',
+            self::PAUSED          => 'heroicon-o-pause-circle',
+            self::CANCELED        => 'heroicon-o-x-circle',
+            self::EXPIRED         => 'heroicon-o-minus-circle',
+        };
+    }
+}

--- a/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/Pages/CreateSubscription.php
+++ b/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/Pages/CreateSubscription.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Modules\Subscriptions\Filament\Company\Resources\Subscriptions\SubscriptionResource;
+use Modules\Subscriptions\Services\SubscriptionService;
+
+class CreateSubscription extends CreateRecord
+{
+    protected static string $resource = SubscriptionResource::class;
+
+    protected function handleRecordCreation(array $data): \Illuminate\Database\Eloquent\Model
+    {
+        return app(SubscriptionService::class)->createSubscription($data);
+    }
+}

--- a/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/Pages/EditSubscription.php
+++ b/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/Pages/EditSubscription.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Pages;
+
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Modules\Subscriptions\Filament\Company\Resources\Subscriptions\SubscriptionResource;
+
+class EditSubscription extends EditRecord
+{
+    protected static string $resource = SubscriptionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/Pages/ListSubscriptions.php
+++ b/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/Pages/ListSubscriptions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Pages;
+
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Modules\Subscriptions\Filament\Company\Resources\Subscriptions\SubscriptionResource;
+
+class ListSubscriptions extends ListRecords
+{
+    protected static string $resource = SubscriptionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/Schemas/SubscriptionForm.php
+++ b/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/Schemas/SubscriptionForm.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Schemas;
+
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\MarkdownEditor;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Modules\Products\Models\Product;
+use Modules\Subscriptions\Enums\BillingInterval;
+use Modules\Subscriptions\Enums\IntervalUnit;
+use Modules\Subscriptions\Enums\SubscriptionStatus;
+
+class SubscriptionForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Grid::make(5)
+                    ->columnSpanFull()
+                    ->schema([
+                        Schemas\Components\Group::make()
+                            ->columnSpan(3)
+                            ->schema([
+                                Section::make('Subscription Overview')
+                                    ->schema([
+                                        TextInput::make('name')
+                                            ->label('Subscription Title')
+                                            ->required()
+                                            ->placeholder('e.g. Enterprise Monthly Software License')
+                                            ->columnSpanFull(),
+
+                                        Select::make('customer_id')
+                                            ->label('Client / Customer')
+                                            ->relationship('customer', 'company_name')
+                                            ->searchable()
+                                            ->preload()
+                                            ->required(),
+
+                                        TextInput::make('number')
+                                            ->label('Subscription Code / Ref')
+                                            ->default(fn () => 'SUB-' . mb_strtoupper(mb_substr(uniqid(), -6)))
+                                            ->required(),
+
+                                        Select::make('status')
+                                            ->label('Subscription Status')
+                                            ->options(
+                                                collect(SubscriptionStatus::cases())
+                                                    ->mapWithKeys(fn ($s) => [$s->value => $s->label()])
+                                                    ->toArray()
+                                            )
+                                            ->default(SubscriptionStatus::ACTIVE->value)
+                                            ->required(),
+                                    ])
+                                    ->columns(2),
+
+                                Section::make('Billing Cycle Configuration')
+                                    ->schema([
+                                        Select::make('billing_interval')
+                                            ->label('Billing Interval')
+                                            ->options(
+                                                collect(BillingInterval::cases())
+                                                    ->mapWithKeys(fn ($i) => [$i->value => $i->label()])
+                                                    ->toArray()
+                                            )
+                                            ->default(BillingInterval::MONTHLY->value)
+                                            ->reactive()
+                                            ->required(),
+
+                                        Select::make('interval_unit')
+                                            ->label('Custom Unit')
+                                            ->options(
+                                                collect(IntervalUnit::cases())
+                                                    ->mapWithKeys(fn ($u) => [$u->value => $u->label()])
+                                                    ->toArray()
+                                            )
+                                            ->default(IntervalUnit::MONTH->value)
+                                            ->visible(fn (Get $get) => $get('billing_interval') === BillingInterval::CUSTOM->value)
+                                            ->required(fn (Get $get) => $get('billing_interval') === BillingInterval::CUSTOM->value),
+
+                                        TextInput::make('interval_count')
+                                            ->label('Custom Count (Frequency)')
+                                            ->numeric()
+                                            ->default(1)
+                                            ->minValue(1)
+                                            ->visible(fn (Get $get) => $get('billing_interval') === BillingInterval::CUSTOM->value)
+                                            ->required(fn (Get $get) => $get('billing_interval') === BillingInterval::CUSTOM->value),
+
+                                        TextInput::make('price')
+                                            ->label('Recurring Price')
+                                            ->numeric()
+                                            ->prefix('$')
+                                            ->required(),
+                                    ])
+                                    ->columns(2),
+                            ]),
+
+                        Schemas\Components\Group::make()
+                            ->columnSpan(2)
+                            ->schema([
+                                Section::make('Lifecycle & Trial Dates')
+                                    ->schema([
+                                        DateTimePicker::make('starts_at')
+                                            ->label('Start Date')
+                                            ->default(now())
+                                            ->required(),
+
+                                        DateTimePicker::make('ends_at')
+                                            ->label('Expiration / End Date')
+                                            ->nullable(),
+
+                                        DateTimePicker::make('trial_starts_at')
+                                            ->label('Trial Start Date')
+                                            ->nullable(),
+
+                                        DateTimePicker::make('trial_ends_at')
+                                            ->label('Trial End Date')
+                                            ->nullable(),
+
+                                        TextInput::make('grace_period_days')
+                                            ->label('Grace Period (Days)')
+                                            ->numeric()
+                                            ->default(0),
+
+                                        DateTimePicker::make('grace_period_ends_at')
+                                            ->label('Grace Period Expiration')
+                                            ->nullable(),
+                                    ])
+                                    ->columns(1),
+                            ]),
+                    ]),
+
+                Section::make('Subscription Line Items')
+                    ->schema([
+                        Repeater::make('subscriptionItems')
+                            ->relationship('subscriptionItems')
+                            ->schema([
+                                Grid::make(5)
+                                    ->schema([
+                                        Select::make('product_id')
+                                            ->label('Product / Service')
+                                            ->options(Product::query()->pluck('product_name', 'id')->toArray())
+                                            ->searchable()
+                                            ->preload()
+                                            ->reactive()
+                                            ->afterStateUpdated(function ($state, callable $set) {
+                                                if ($product = Product::find($state)) {
+                                                    $set('name', $product->product_name);
+                                                    $set('unit_price', $product->product_price);
+                                                }
+                                            }),
+
+                                        TextInput::make('name')
+                                            ->label('Description')
+                                            ->required(),
+
+                                        TextInput::make('quantity')
+                                            ->label('Qty')
+                                            ->numeric()
+                                            ->default(1)
+                                            ->required(),
+
+                                        TextInput::make('unit_price')
+                                            ->label('Unit Price')
+                                            ->numeric()
+                                            ->required(),
+
+                                        TextInput::make('total')
+                                            ->label('Total')
+                                            ->numeric()
+                                            ->placeholder('Auto-calc'),
+                                    ]),
+                            ])
+                            ->columns(1)
+                            ->defaultItems(1)
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+
+                Section::make('Internal Notes')
+                    ->schema([
+                        MarkdownEditor::make('notes')
+                            ->label('Subscription Notes')
+                            ->toolbarButtons(['bold', 'italic', 'bulletList'])
+                            ->columnSpanFull(),
+                    ])
+                    ->collapsed()
+                    ->columnSpanFull(),
+            ]);
+    }
+}

--- a/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/SubscriptionResource.php
+++ b/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/SubscriptionResource.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Modules\Subscriptions\Filament\Company\Resources\Subscriptions;
+
+use BackedEnum;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Modules\Core\Filament\Company\Resources\BaseResource;
+use Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Pages\CreateSubscription;
+use Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Pages\EditSubscription;
+use Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Pages\ListSubscriptions;
+use Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Schemas\SubscriptionForm;
+use Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Tables\SubscriptionsTable;
+use Modules\Subscriptions\Models\Subscription;
+
+class SubscriptionResource extends BaseResource
+{
+    protected static ?string $model = Subscription::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedArrowPath;
+
+    protected static ?int $navigationSort = 15;
+
+    protected static bool $shouldRegisterNavigation = true;
+
+    protected static bool $isScopedToTenant = true;
+
+    public static function getModelLabel(): string
+    {
+        return 'Subscription';
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return 'Subscriptions';
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Subscriptions';
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) static::getEloquentQuery()->count();
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return SubscriptionForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return SubscriptionsTable::configure($table);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index'  => ListSubscriptions::route('/'),
+            'create' => CreateSubscription::route('/create'),
+            'edit'   => EditSubscription::route('/{record}/edit'),
+        ];
+    }
+}

--- a/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/Tables/SubscriptionsTable.php
+++ b/Modules/Subscriptions/Filament/Company/Resources/Subscriptions/Tables/SubscriptionsTable.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Tables;
+
+use Filament\Actions\Action;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Notifications\Notification;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Modules\Subscriptions\Enums\BillingInterval;
+use Modules\Subscriptions\Enums\CancellationType;
+use Modules\Subscriptions\Enums\SubscriptionStatus;
+use Modules\Subscriptions\Models\Subscription;
+use Modules\Subscriptions\Services\SubscriptionService;
+
+class SubscriptionsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('number')
+                    ->label('Subscription #')
+                    ->searchable()
+                    ->sortable()
+                    ->weight('bold'),
+
+                TextColumn::make('name')
+                    ->label('Title')
+                    ->searchable()
+                    ->limit(25),
+
+                TextColumn::make('customer.company_name')
+                    ->label('Client')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->formatStateUsing(fn ($state) => $state instanceof SubscriptionStatus ? $state->label() : SubscriptionStatus::tryFrom($state)?->label() ?? $state)
+                    ->color(fn ($state) => $state instanceof SubscriptionStatus ? $state->color() : SubscriptionStatus::tryFrom($state)?->color() ?? 'gray')
+                    ->icon(fn ($state) => $state instanceof SubscriptionStatus ? $state->badgeIcon() : SubscriptionStatus::tryFrom($state)?->badgeIcon() ?? 'heroicon-o-minus-circle')
+                    ->sortable(),
+
+                TextColumn::make('billing_interval')
+                    ->label('Billing Cycle')
+                    ->formatStateUsing(function ($state, Subscription $record) {
+                        if ($record->billing_interval === BillingInterval::CUSTOM) {
+                            return "Every {$record->interval_count} {$record->interval_unit?->value}(s)";
+                        }
+
+                        return $record->billing_interval?->label() ?? $state;
+                    })
+                    ->sortable(),
+
+                TextColumn::make('price')
+                    ->label('Price')
+                    ->money('USD')
+                    ->sortable(),
+
+                TextColumn::make('current_period_ends_at')
+                    ->label('Next Billing Date')
+                    ->dateTime('M d, Y')
+                    ->sortable(),
+
+                IconColumn::make('cancel_at_period_end')
+                    ->label('Pending Cancel')
+                    ->boolean()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(
+                        collect(SubscriptionStatus::cases())
+                            ->mapWithKeys(fn ($s) => [$s->value => $s->label()])
+                            ->toArray()
+                    ),
+
+                SelectFilter::make('billing_interval')
+                    ->options(
+                        collect(BillingInterval::cases())
+                            ->mapWithKeys(fn ($i) => [$i->value => $i->label()])
+                            ->toArray()
+                    ),
+            ])
+            ->actions([
+                EditAction::make(),
+
+                Action::make('pause')
+                    ->label('Pause')
+                    ->icon('heroicon-o-pause')
+                    ->color('gray')
+                    ->visible(fn (Subscription $record) => $record->status === SubscriptionStatus::ACTIVE || $record->status === SubscriptionStatus::TRIALING)
+                    ->form([
+                        DateTimePicker::make('resume_at')
+                            ->label('Auto-Resume At (Optional)')
+                            ->hint('Leave empty for manual resume'),
+                    ])
+                    ->action(function (Subscription $record, array $data, SubscriptionService $service) {
+                        $service->pause($record, isset($data['resume_at']) ? \Carbon\Carbon::parse($data['resume_at']) : null);
+                        Notification::make()->title('Subscription Paused')->warning()->send();
+                    }),
+
+                Action::make('resume')
+                    ->label('Resume')
+                    ->icon('heroicon-o-play')
+                    ->color('success')
+                    ->visible(fn (Subscription $record) => $record->status === SubscriptionStatus::PAUSED)
+                    ->action(function (Subscription $record, SubscriptionService $service) {
+                        $service->resume($record);
+                        Notification::make()->title('Subscription Resumed')->success()->send();
+                    }),
+
+                Action::make('cancel')
+                    ->label('Cancel')
+                    ->icon('heroicon-o-x-circle')
+                    ->color('danger')
+                    ->visible(fn (Subscription $record) => $record->status !== SubscriptionStatus::CANCELED && $record->status !== SubscriptionStatus::EXPIRED)
+                    ->form([
+                        Select::make('cancellation_type')
+                            ->label('Cancellation Option')
+                            ->options([
+                                CancellationType::AT_PERIOD_END->value => 'Cancel at End of Billing Period',
+                                CancellationType::IMMEDIATE->value     => 'Cancel Immediately',
+                            ])
+                            ->default(CancellationType::AT_PERIOD_END->value)
+                            ->required(),
+                    ])
+                    ->action(function (Subscription $record, array $data, SubscriptionService $service) {
+                        if ($data['cancellation_type'] === CancellationType::IMMEDIATE->value) {
+                            $service->cancelImmediately($record);
+                            Notification::make()->title('Subscription Canceled Immediately')->danger()->send();
+                        } else {
+                            $service->cancelAtPeriodEnd($record);
+                            Notification::make()->title('Subscription set to cancel at period end')->warning()->send();
+                        }
+                    }),
+
+                Action::make('process_billing')
+                    ->label('Bill Now')
+                    ->icon('heroicon-o-banknotes')
+                    ->color('primary')
+                    ->visible(fn (Subscription $record) => $record->status === SubscriptionStatus::ACTIVE || $record->status === SubscriptionStatus::TRIALING)
+                    ->requiresConfirmation()
+                    ->action(function (Subscription $record, SubscriptionService $service) {
+                        $invoice = $service->processBillingCycle($record);
+                        if ($invoice) {
+                            Notification::make()
+                                ->title('Invoice Generated Successfully')
+                                ->body("Invoice #{$invoice->invoice_number} created for this subscription.")
+                                ->success()
+                                ->send();
+                        } else {
+                            Notification::make()->title('Could not bill subscription')->warning()->send();
+                        }
+                    }),
+
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/Modules/Subscriptions/Models/Subscription.php
+++ b/Modules/Subscriptions/Models/Subscription.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Modules\Subscriptions\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Modules\Clients\Models\Relation;
+use Modules\Core\Models\Company;
+use Modules\Core\Traits\BelongsToCompany;
+use Modules\Subscriptions\Database\Factories\SubscriptionFactory;
+use Modules\Subscriptions\Enums\BillingInterval;
+use Modules\Subscriptions\Enums\IntervalUnit;
+use Modules\Subscriptions\Enums\SubscriptionStatus;
+
+class Subscription extends Model
+{
+    use BelongsToCompany;
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'status'                   => SubscriptionStatus::class,
+        'billing_interval'         => BillingInterval::class,
+        'interval_unit'            => IntervalUnit::class,
+        'interval_count'           => 'integer',
+        'price'                    => 'decimal:4',
+        'starts_at'                => 'datetime',
+        'ends_at'                  => 'datetime',
+        'trial_starts_at'          => 'datetime',
+        'trial_ends_at'            => 'datetime',
+        'grace_period_days'        => 'integer',
+        'grace_period_ends_at'     => 'datetime',
+        'current_period_starts_at' => 'datetime',
+        'current_period_ends_at'   => 'datetime',
+        'paused_at'                => 'datetime',
+        'resume_at'                => 'datetime',
+        'cancel_at_period_end'     => 'boolean',
+        'canceled_at'              => 'datetime',
+    ];
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Relation::class, 'customer_id');
+    }
+
+    public function subscriptionItems(): HasMany
+    {
+        return $this->hasMany(SubscriptionItem::class);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->subscriptionItems();
+    }
+
+    public function isTrialing(): bool
+    {
+        return $this->status === SubscriptionStatus::TRIALING
+            || ($this->trial_ends_at && $this->trial_ends_at->isFuture());
+    }
+
+    public function isInGracePeriod(): bool
+    {
+        return $this->status === SubscriptionStatus::IN_GRACE_PERIOD
+            || ($this->grace_period_ends_at && $this->grace_period_ends_at->isFuture());
+    }
+
+    public function isPaused(): bool
+    {
+        return $this->status === SubscriptionStatus::PAUSED;
+    }
+
+    public function isCanceled(): bool
+    {
+        return $this->status === SubscriptionStatus::CANCELED;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status === SubscriptionStatus::ACTIVE;
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return SubscriptionFactory::new();
+    }
+}

--- a/Modules/Subscriptions/Models/SubscriptionItem.php
+++ b/Modules/Subscriptions/Models/SubscriptionItem.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Modules\Subscriptions\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Products\Models\Product;
+
+class SubscriptionItem extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'quantity'   => 'decimal:4',
+        'unit_price' => 'decimal:4',
+        'subtotal'   => 'decimal:4',
+        'tax'        => 'decimal:4',
+        'total'      => 'decimal:4',
+    ];
+
+    public function subscription(): BelongsTo
+    {
+        return $this->belongsTo(Subscription::class);
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/Modules/Subscriptions/Providers/SubscriptionsServiceProvider.php
+++ b/Modules/Subscriptions/Providers/SubscriptionsServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\Subscriptions\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Nwidart\Modules\Traits\PathNamespace;
+
+class SubscriptionsServiceProvider extends ServiceProvider
+{
+    use PathNamespace;
+
+    protected string $name = 'Subscriptions';
+
+    protected string $nameLower = 'subscriptions';
+
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(module_path($this->name, 'Database/Migrations'));
+    }
+
+    public function register(): void {}
+}

--- a/Modules/Subscriptions/Services/SubscriptionService.php
+++ b/Modules/Subscriptions/Services/SubscriptionService.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace Modules\Subscriptions\Services;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Modules\Core\Services\BaseService;
+use Modules\Invoices\Enums\InvoiceStatus;
+use Modules\Invoices\Models\Invoice;
+use Modules\Subscriptions\Enums\BillingInterval;
+use Modules\Subscriptions\Enums\IntervalUnit;
+use Modules\Subscriptions\Enums\SubscriptionStatus;
+use Modules\Subscriptions\Models\Subscription;
+
+class SubscriptionService extends BaseService
+{
+    public function model(): string
+    {
+        return Subscription::class;
+    }
+
+    /**
+     * Create a new subscription with calculated period dates and items.
+     */
+    public function createSubscription(array $data): Subscription
+    {
+        return DB::transaction(function () use ($data) {
+            $data['company_id'] ??= $this->getCompanyId();
+            $data['number'] ??= 'SUB-' . mb_strtoupper(uniqid());
+
+            $startsAt          = isset($data['starts_at']) ? Carbon::parse($data['starts_at']) : Carbon::now();
+            $data['starts_at'] = $startsAt;
+
+            // Determine initial status & period dates
+            $trialEndsAt = isset($data['trial_ends_at']) && $data['trial_ends_at'] ? Carbon::parse($data['trial_ends_at']) : null;
+            if ($trialEndsAt && $trialEndsAt->isFuture()) {
+                $data['status'] = SubscriptionStatus::TRIALING;
+                $data['trial_starts_at'] ??= $startsAt;
+                $data['current_period_starts_at'] = $startsAt;
+                $data['current_period_ends_at']   = $trialEndsAt;
+            } else {
+                $data['status'] ??= SubscriptionStatus::ACTIVE;
+                $periodDates = $this->calculateNextPeriodDates(
+                    $data['billing_interval'] ?? BillingInterval::MONTHLY->value,
+                    $data['interval_unit'] ?? IntervalUnit::MONTH->value,
+                    (int) ($data['interval_count'] ?? 1),
+                    $startsAt
+                );
+                $data['current_period_starts_at'] = $periodDates['starts_at'];
+                $data['current_period_ends_at']   = $periodDates['ends_at'];
+            }
+
+            $items = $data['items'] ?? [];
+            unset($data['items']);
+
+            /** @var Subscription $subscription */
+            $subscription = $this->create($data);
+
+            if ( ! empty($items)) {
+                $this->syncItems($subscription, $items);
+            }
+
+            return $subscription;
+        });
+    }
+
+    /**
+     * Calculate period start and end dates based on interval configuration.
+     */
+    public function calculateNextPeriodDates(
+        string|BillingInterval $billingInterval,
+        string|IntervalUnit $intervalUnit = IntervalUnit::MONTH,
+        int $intervalCount = 1,
+        ?Carbon $from = null
+    ): array {
+        $from     = $from ? $from->copy() : Carbon::now();
+        $startsAt = $from->copy();
+        $endsAt   = $from->copy();
+
+        $intervalEnum = $billingInterval instanceof BillingInterval
+            ? $billingInterval
+            : BillingInterval::tryFrom($billingInterval) ?? BillingInterval::MONTHLY;
+
+        $unitEnum = $intervalUnit instanceof IntervalUnit
+            ? $intervalUnit
+            : IntervalUnit::tryFrom($intervalUnit) ?? IntervalUnit::MONTH;
+
+        $intervalCount = max(1, $intervalCount);
+
+        switch ($intervalEnum) {
+            case BillingInterval::WEEKLY:
+                $endsAt->addWeek();
+                break;
+
+            case BillingInterval::MONTHLY:
+                $endsAt->addMonth();
+                break;
+
+            case BillingInterval::YEARLY:
+                $endsAt->addYear();
+                break;
+
+            case BillingInterval::CUSTOM:
+                switch ($unitEnum) {
+                    case IntervalUnit::DAY:
+                        $endsAt->addDays($intervalCount);
+                        break;
+                    case IntervalUnit::WEEK:
+                        $endsAt->addWeeks($intervalCount);
+                        break;
+                    case IntervalUnit::MONTH:
+                        $endsAt->addMonths($intervalCount);
+                        break;
+                    case IntervalUnit::YEAR:
+                        $endsAt->addYears($intervalCount);
+                        break;
+                }
+                break;
+        }
+
+        return [
+            'starts_at' => $startsAt,
+            'ends_at'   => $endsAt,
+        ];
+    }
+
+    /**
+     * Pause an active or trialing subscription.
+     */
+    public function pause(Subscription $subscription, ?Carbon $resumeAt = null): Subscription
+    {
+        $subscription->update([
+            'status'    => SubscriptionStatus::PAUSED,
+            'paused_at' => Carbon::now(),
+            'resume_at' => $resumeAt,
+        ]);
+
+        return $subscription;
+    }
+
+    /**
+     * Resume a paused subscription and recalculate billing dates.
+     */
+    public function resume(Subscription $subscription): Subscription
+    {
+        $now = Carbon::now();
+
+        // Determine if trial is still valid
+        $status = ($subscription->trial_ends_at && $subscription->trial_ends_at->isFuture())
+            ? SubscriptionStatus::TRIALING
+            : SubscriptionStatus::ACTIVE;
+
+        $periodDates = $this->calculateNextPeriodDates(
+            $subscription->billing_interval,
+            $subscription->interval_unit,
+            $subscription->interval_count,
+            $now
+        );
+
+        $subscription->update([
+            'status'                   => $status,
+            'paused_at'                => null,
+            'resume_at'                => null,
+            'current_period_starts_at' => $periodDates['starts_at'],
+            'current_period_ends_at'   => $periodDates['ends_at'],
+        ]);
+
+        return $subscription;
+    }
+
+    /**
+     * Cancel subscription immediately.
+     */
+    public function cancelImmediately(Subscription $subscription): Subscription
+    {
+        $now = Carbon::now();
+
+        $subscription->update([
+            'status'               => SubscriptionStatus::CANCELED,
+            'canceled_at'          => $now,
+            'ends_at'              => $now,
+            'cancel_at_period_end' => false,
+        ]);
+
+        return $subscription;
+    }
+
+    /**
+     * Mark subscription to be canceled at the end of the current billing period.
+     */
+    public function cancelAtPeriodEnd(Subscription $subscription): Subscription
+    {
+        $subscription->update([
+            'cancel_at_period_end' => true,
+            'canceled_at'          => Carbon::now(),
+        ]);
+
+        return $subscription;
+    }
+
+    /**
+     * Enter grace period state (e.g. after payment warning).
+     */
+    public function enterGracePeriod(Subscription $subscription, int $days = 7): Subscription
+    {
+        $graceEndsAt = Carbon::now()->addDays($days);
+
+        $subscription->update([
+            'status'               => SubscriptionStatus::IN_GRACE_PERIOD,
+            'grace_period_days'    => $days,
+            'grace_period_ends_at' => $graceEndsAt,
+        ]);
+
+        return $subscription;
+    }
+
+    /**
+     * Process billing cycle: Generate invoice & roll over subscription period.
+     */
+    public function processBillingCycle(Subscription $subscription): ?Invoice
+    {
+        // Check if subscription should cancel at period end
+        if ($subscription->cancel_at_period_end) {
+            $this->cancelImmediately($subscription);
+
+            return null;
+        }
+
+        if ($subscription->status === SubscriptionStatus::CANCELED || $subscription->status === SubscriptionStatus::PAUSED) {
+            return null;
+        }
+
+        return DB::transaction(function () use ($subscription) {
+            $userId = auth()->id()
+                ?? \Modules\Core\Models\User::query()->whereHas('companies', fn ($q) => $q->where('companies.id', $subscription->company_id))->first()?->id
+                ?? 1;
+
+            $invoice = Invoice::create([
+                'company_id'               => $subscription->company_id,
+                'customer_id'              => $subscription->customer_id,
+                'user_id'                  => $userId,
+                'invoice_number'           => 'INV-' . mb_strtoupper(mb_substr(uniqid(), -6)),
+                'invoiced_at'              => Carbon::now(),
+                'invoice_due_at'           => Carbon::now()->addDays(14),
+                'invoice_status'           => InvoiceStatus::SENT,
+                'invoice_discount_amount'  => 0.0000,
+                'invoice_discount_percent' => 0.0000,
+                'item_tax_total'           => 0.0000,
+                'invoice_item_subtotal'    => $subscription->price,
+                'invoice_tax_total'        => 0.0000,
+                'invoice_total'            => $subscription->price,
+                'summary'                  => "Subscription Invoice for {$subscription->name} ({$subscription->number})",
+                'url_key'                  => mb_strtolower(uniqid()),
+            ]);
+
+            // Copy items to invoice
+            foreach ($subscription->subscriptionItems as $item) {
+                $invoice->invoiceItems()->create([
+                    'company_id' => $subscription->company_id,
+                    'item_name'  => $item->name,
+                    'quantity'   => $item->quantity,
+                    'price'      => $item->unit_price,
+                    'subtotal'   => $item->subtotal,
+                    'tax_total'  => $item->tax,
+                    'total'      => $item->total,
+                ]);
+            }
+
+            // Calculate next billing period
+            $nextFrom = $subscription->current_period_ends_at && $subscription->current_period_ends_at->isFuture()
+                ? $subscription->current_period_ends_at
+                : Carbon::now();
+
+            $periodDates = $this->calculateNextPeriodDates(
+                $subscription->billing_interval,
+                $subscription->interval_unit,
+                $subscription->interval_count,
+                $nextFrom
+            );
+
+            $subscription->update([
+                'status'                   => SubscriptionStatus::ACTIVE,
+                'current_period_starts_at' => $periodDates['starts_at'],
+                'current_period_ends_at'   => $periodDates['ends_at'],
+            ]);
+
+            return $invoice;
+        });
+    }
+
+    /**
+     * Sync subscription items and update total subscription price.
+     */
+    public function syncItems(Subscription $subscription, array $items): void
+    {
+        $subscription->subscriptionItems()->delete();
+
+        $totalPrice = 0;
+
+        foreach ($items as $item) {
+            $qty       = (float) ($item['quantity'] ?? 1);
+            $unitPrice = (float) ($item['unit_price'] ?? 0);
+            $subtotal  = $qty * $unitPrice;
+            $tax       = (float) ($item['tax'] ?? 0);
+            $total     = $subtotal + $tax;
+
+            $subscription->subscriptionItems()->create([
+                'product_id' => $item['product_id'] ?? null,
+                'name'       => $item['name'] ?? 'Subscription Service',
+                'quantity'   => $qty,
+                'unit_price' => $unitPrice,
+                'subtotal'   => $subtotal,
+                'tax'        => $tax,
+                'total'      => $total,
+            ]);
+
+            $totalPrice += $total;
+        }
+
+        $subscription->update(['price' => $totalPrice]);
+    }
+}

--- a/Modules/Subscriptions/Tests/Feature/SubscriptionTest.php
+++ b/Modules/Subscriptions/Tests/Feature/SubscriptionTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Modules\Subscriptions\Tests\Feature;
+
+use Carbon\Carbon;
+use Livewire\Livewire;
+use Modules\Clients\Models\Relation;
+use Modules\Core\Tests\AbstractCompanyPanelTestCase;
+use Modules\Invoices\Models\Invoice;
+use Modules\Subscriptions\Enums\BillingInterval;
+use Modules\Subscriptions\Enums\IntervalUnit;
+use Modules\Subscriptions\Enums\SubscriptionStatus;
+use Modules\Subscriptions\Filament\Company\Resources\Subscriptions\Pages\ListSubscriptions;
+use Modules\Subscriptions\Models\Subscription;
+use Modules\Subscriptions\Services\SubscriptionService;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+class SubscriptionTest extends AbstractCompanyPanelTestCase
+{
+    #[Test]
+    #[Group('smoke')]
+    public function it_lists_subscriptions(): void
+    {
+        $subscription = Subscription::factory()
+            ->for($this->company)
+            ->create([
+                'name'   => 'Monthly Enterprise SaaS',
+                'status' => SubscriptionStatus::ACTIVE,
+            ]);
+
+        $component = Livewire::actingAs($this->user)
+            ->test(ListSubscriptions::class);
+
+        $component->assertSuccessful();
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_creates_subscription_with_monthly_interval(): void
+    {
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+
+        $service      = app(SubscriptionService::class);
+        $subscription = $service->createSubscription([
+            'company_id'       => $this->company->id,
+            'customer_id'      => $customer->id,
+            'name'             => 'Pro Monthly Subscription',
+            'billing_interval' => BillingInterval::MONTHLY->value,
+            'price'            => 199.00,
+            'items'            => [
+                [
+                    'name'       => 'Pro Seat License',
+                    'quantity'   => 1,
+                    'unit_price' => 199.00,
+                ],
+            ],
+        ]);
+
+        $this->assertDatabaseHas('subscriptions', [
+            'id'          => $subscription->id,
+            'name'        => 'Pro Monthly Subscription',
+            'status'      => SubscriptionStatus::ACTIVE->value,
+            'company_id'  => $this->company->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        $this->assertDatabaseHas('subscription_items', [
+            'subscription_id' => $subscription->id,
+            'name'            => 'Pro Seat License',
+            'unit_price'      => 199.00,
+        ]);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    public function it_creates_subscription_with_custom_billing_cycle(): void
+    {
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+
+        $service      = app(SubscriptionService::class);
+        $subscription = $service->createSubscription([
+            'company_id'       => $this->company->id,
+            'customer_id'      => $customer->id,
+            'name'             => '14-Day Sprint Subscription',
+            'billing_interval' => BillingInterval::CUSTOM->value,
+            'interval_unit'    => IntervalUnit::DAY->value,
+            'interval_count'   => 14,
+            'price'            => 150.00,
+        ]);
+
+        $this->assertEquals(BillingInterval::CUSTOM, $subscription->billing_interval);
+        $this->assertEquals(IntervalUnit::DAY, $subscription->interval_unit);
+        $this->assertEquals(14, $subscription->interval_count);
+
+        $expectedEnd = $subscription->starts_at->copy()->addDays(14);
+        $this->assertEquals($expectedEnd->format('Y-m-d H:i'), $subscription->current_period_ends_at->format('Y-m-d H:i'));
+    }
+
+    #[Test]
+    #[Group('lifecycle')]
+    public function it_handles_trial_period(): void
+    {
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+
+        $trialEndsAt = Carbon::now()->addDays(14);
+
+        $service      = app(SubscriptionService::class);
+        $subscription = $service->createSubscription([
+            'company_id'       => $this->company->id,
+            'customer_id'      => $customer->id,
+            'name'             => 'Trial Subscription',
+            'trial_ends_at'    => $trialEndsAt,
+            'billing_interval' => BillingInterval::MONTHLY->value,
+            'price'            => 99.00,
+        ]);
+
+        $this->assertEquals(SubscriptionStatus::TRIALING, $subscription->status);
+        $this->assertTrue($subscription->isTrialing());
+    }
+
+    #[Test]
+    #[Group('lifecycle')]
+    public function it_handles_grace_period(): void
+    {
+        $subscription = Subscription::factory()
+            ->for($this->company)
+            ->create(['status' => SubscriptionStatus::ACTIVE]);
+
+        $service = app(SubscriptionService::class);
+        $service->enterGracePeriod($subscription, 7);
+
+        $subscription->refresh();
+        $this->assertEquals(SubscriptionStatus::IN_GRACE_PERIOD, $subscription->status);
+        $this->assertEquals(7, $subscription->grace_period_days);
+        $this->assertTrue($subscription->isInGracePeriod());
+    }
+
+    #[Test]
+    #[Group('lifecycle')]
+    public function it_pauses_and_resumes_subscription(): void
+    {
+        $subscription = Subscription::factory()
+            ->for($this->company)
+            ->create(['status' => SubscriptionStatus::ACTIVE]);
+
+        $service = app(SubscriptionService::class);
+
+        // Pause
+        $service->pause($subscription);
+        $subscription->refresh();
+        $this->assertEquals(SubscriptionStatus::PAUSED, $subscription->status);
+        $this->assertNotNull($subscription->paused_at);
+
+        // Resume
+        $service->resume($subscription);
+        $subscription->refresh();
+        $this->assertEquals(SubscriptionStatus::ACTIVE, $subscription->status);
+        $this->assertNull($subscription->paused_at);
+    }
+
+    #[Test]
+    #[Group('lifecycle')]
+    public function it_cancels_subscription_immediately(): void
+    {
+        $subscription = Subscription::factory()
+            ->for($this->company)
+            ->create(['status' => SubscriptionStatus::ACTIVE]);
+
+        $service = app(SubscriptionService::class);
+        $service->cancelImmediately($subscription);
+
+        $subscription->refresh();
+        $this->assertEquals(SubscriptionStatus::CANCELED, $subscription->status);
+        $this->assertNotNull($subscription->canceled_at);
+        $this->assertNotNull($subscription->ends_at);
+    }
+
+    #[Test]
+    #[Group('lifecycle')]
+    public function it_cancels_subscription_at_period_end(): void
+    {
+        $subscription = Subscription::factory()
+            ->for($this->company)
+            ->create(['status' => SubscriptionStatus::ACTIVE]);
+
+        $service = app(SubscriptionService::class);
+        $service->cancelAtPeriodEnd($subscription);
+
+        $subscription->refresh();
+        $this->assertTrue($subscription->cancel_at_period_end);
+        $this->assertNotNull($subscription->canceled_at);
+        // Status remains active until period ends
+        $this->assertEquals(SubscriptionStatus::ACTIVE, $subscription->status);
+    }
+
+    #[Test]
+    #[Group('billing')]
+    public function it_processes_billing_cycle_and_generates_invoice(): void
+    {
+        $subscription = Subscription::factory()
+            ->for($this->company)
+            ->create([
+                'status'           => SubscriptionStatus::ACTIVE,
+                'billing_interval' => BillingInterval::MONTHLY,
+                'price'            => 250.00,
+            ]);
+
+        $service = app(SubscriptionService::class);
+        $invoice = $service->processBillingCycle($subscription);
+
+        $this->assertInstanceOf(Invoice::class, $invoice);
+        $this->assertEquals($subscription->customer_id, $invoice->customer_id);
+
+        $subscription->refresh();
+        // Billing cycle advances period start and end
+        $this->assertNotNull($subscription->current_period_starts_at);
+        $this->assertNotNull($subscription->current_period_ends_at);
+    }
+}

--- a/Modules/Subscriptions/composer.json
+++ b/Modules/Subscriptions/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "invoiceplane/subscriptions",
+    "description": "Subscriptions Module for InvoicePlane v2",
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {
+            }
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Subscriptions\\": "",
+            "Modules\\Subscriptions\\Database\\Factories\\": "Database/Factories/",
+            "Modules\\Subscriptions\\Database\\Seeders\\": "Database/Seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Subscriptions\\Tests\\": "Tests/"
+        }
+    }
+}

--- a/Modules/Subscriptions/module.json
+++ b/Modules/Subscriptions/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "Subscriptions",
+    "alias": "subscriptions",
+    "description": "Subscriptions and Subscription Lifecycle Management",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\Subscriptions\\Providers\\SubscriptionsServiceProvider"
+    ],
+    "files": []
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use Filament\Auth\Http\Responses\Contracts\LoginResponse as LoginResponseContract;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Modules\Core\Filament\Responses\LoginResponse;
 use Modules\Invoices\Models\Invoice;
@@ -23,5 +24,6 @@ class AppServiceProvider extends ServiceProvider
         Relation::morphMap([
             'invoice' => Invoice::class,
         ]);
+        URL::forceScheme('https');
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,6 +21,7 @@ use Modules\Products\Database\Seeders\ProductsSeeder;
 use Modules\Projects\Database\Seeders\ProjectsSeeder;
 use Modules\Projects\Database\Seeders\TasksSeeder;
 use Modules\Quotes\Database\Seeders\QuotesSeeder;
+use Modules\Subscriptions\Database\Seeders\SubscriptionSeeder;
 use RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 
@@ -96,6 +97,8 @@ class DatabaseSeeder extends Seeder
             $this->callWith(InvoicesSeeder::class, $p + ['count' => $this->volumes['invoices']]);
 
             $this->callWith(PaymentsSeeder::class, $p + ['count' => $this->volumes['payments']]);
+
+            $this->call(SubscriptionSeeder::class);
 
             (new TaxRatesSeeder())->buildOne($company->id);
 

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -7,5 +7,6 @@
     "Products": true,
     "Projects": true,
     "Quotes": true,
-    "ReportBuilder": true
+    "ReportBuilder": true,
+    "Subscriptions": true
 }

--- a/resources/lang/en/ip.php
+++ b/resources/lang/en/ip.php
@@ -47,6 +47,7 @@ return [
     #endregion
 
     #region CORE
+    'user_not_in_company'                          => 'You do not have access to this company.',
     'Q1'                                           => 'Q1',
     'Q2'                                           => 'Q2',
     'Q3'                                           => 'Q3',


### PR DESCRIPTION
### Summary
Resolves [#693](https://github.com/InvoicePlane/InvoicePlane-v2/issues/693) by catching unauthorized cross-company access attempts during tenant switching and surfacing a friendly in-app Filament warning notification (`trans('ip.user_not_in_company')`) rather than allowing a raw 403 error page to bubble up.

### Key Changes
1. **Core Service Guard (`UserService`)**:
   - Added `assertBelongsToCompany(User $user, Company|int $company): void` to verify that regular users belong to the target company while allowing elevated roles (`super_admin`, `admin`, `assist`) to access all companies.
   - Throws `\Illuminate\Auth\Access\AuthorizationException` with `ip.user_not_in_company` message when access is denied.

2. **Company Switching UX (`MyCompanies`)**:
   - Wrapped `MyCompanies::table()`'s `switch` action with `UserService::assertBelongsToCompany()`.
   - On `AuthorizationException`, dispatches a `Filament\Notifications\Notification::make()->warning()` notification and halts redirection.
   - Configured table query to display all companies for elevated roles and user-scoped companies for regular users.

3. **Translations (`resources/lang/en/ip.php`)**:
   - Added `'user_not_in_company' => 'You do not have access to this company.'`.

4. **Testing & Static Analysis**:
   - Added `Modules/Core/Tests/Unit/Services/UserServiceAssertBelongsToCompanyTest.php` covering user access validation, `AuthorizationException` assertions, and elevated role bypass.
   - Added feature tests in `Modules/Core/Tests/Feature/UserProfileTest.php` verifying the notification dispatch and redirection blocking on unauthorized switch attempts.
   - Verified 100% clean PHPStan static analysis (`./vendor/bin/phpstan analyse`).

### Closes
Closes #693
