### PR TITLE
[IP-687/693]: Cross-company access guard with friendly notification (closes #687, #693)

### DIFF
--- a/Modules/Clients/Models/Relation.php
+++ b/Modules/Clients/Models/Relation.php
@@ -116,9 +116,16 @@ class Relation extends Model
         return $this->morphMany(Communication::class, 'communicationable');
     }
 
+    /**
+     * @return MorphMany<Communication, $this>
+     */
     public function ccEmailCommunications(): MorphMany
     {
-        return $this->communications()->where('communication_type', CommunicationType::INVOICE_CC->value);
+        /** @var MorphMany<Communication, $this> $relation */
+        $relation = $this->morphMany(Communication::class, 'communicationable')
+            ->where('communication_type', CommunicationType::INVOICE_CC->value);
+
+        return $relation;
     }
 
     public function contacts(): HasMany

--- a/Modules/Clients/Models/Relation.php
+++ b/Modules/Clients/Models/Relation.php
@@ -116,16 +116,10 @@ class Relation extends Model
         return $this->morphMany(Communication::class, 'communicationable');
     }
 
-    /**
-     * @return MorphMany<Communication, $this>
-     */
     public function ccEmailCommunications(): MorphMany
     {
-        /** @var MorphMany<Communication, $this> $relation */
-        $relation = $this->morphMany(Communication::class, 'communicationable')
-            ->where('communication_type', CommunicationType::INVOICE_CC->value);
-
-        return $relation;
+        /** @var MorphMany */
+        return $this->communications()->where('communication_type', CommunicationType::INVOICE_CC->value);
     }
 
     public function contacts(): HasMany

--- a/Modules/Core/Filament/Company/Pages/MyCompanies.php
+++ b/Modules/Core/Filament/Company/Pages/MyCompanies.php
@@ -4,15 +4,18 @@ namespace Modules\Core\Filament\Company\Pages;
 
 use Filament\Actions\Action;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Str;
 use Modules\Core\Enums\UserRole;
 use Modules\Core\Models\Company;
 use Modules\Core\Models\User;
+use Modules\Core\Services\UserService;
 
 class MyCompanies extends Page implements HasTable
 {
@@ -25,8 +28,12 @@ class MyCompanies extends Page implements HasTable
         /** @var User $user */
         $user = auth()->user();
 
+        $query = ($user && $user->hasAnyRole(UserRole::elevated()))
+            ? Company::query()
+            : ($user ? $user->companies()->getQuery() : Company::query()->whereRaw('1 = 0'));
+
         return $table
-            ->query(fn () => $user->companies()->getQuery())
+            ->query(fn () => $query)
             ->columns([
                 TextColumn::make('name')
                     ->label(trans('ip.name'))
@@ -46,6 +53,20 @@ class MyCompanies extends Page implements HasTable
                     ->label(trans('ip.switch'))
                     ->icon('heroicon-o-arrow-right-start-on-rectangle')
                     ->action(function (Company $record): void {
+                        /** @var User $user */
+                        $user = auth()->user();
+
+                        try {
+                            app(UserService::class)->assertBelongsToCompany($user, $record);
+                        } catch (AuthorizationException $e) {
+                            Notification::make()
+                                ->warning()
+                                ->title(trans('ip.user_not_in_company') ?: 'You do not have access to this company.')
+                                ->send();
+
+                            return;
+                        }
+
                         session(['current_company_id' => $record->id]);
                         Filament::setTenant($record);
 

--- a/Modules/Core/Services/EmailTemplateVariableResolver.php
+++ b/Modules/Core/Services/EmailTemplateVariableResolver.php
@@ -61,9 +61,11 @@ class EmailTemplateVariableResolver
     {
         $contacts = $client->contacts()->with('communications')->get();
 
-        return $contacts->firstWhere('default_to', true)
+        $contact = $contacts->firstWhere('default_to', true)
             ?? ($client->primary_contact_id ? $contacts->firstWhere('id', $client->primary_contact_id) : null)
             ?? $contacts->first();
+
+        return $contact instanceof Contact ? $contact : null;
     }
 
     protected function invoicingContactEmail(?Relation $client, ?Contact $contact): string

--- a/Modules/Core/Services/UserService.php
+++ b/Modules/Core/Services/UserService.php
@@ -7,8 +7,10 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Modules\Core\Enums\UserRole;
 use Modules\Core\Events\UserWasCreated;
 use Modules\Core\Events\UserWasUpdated;
+use Modules\Core\Models\Company;
 use Modules\Core\Models\Upload;
 use Modules\Core\Models\User;
 use Throwable;
@@ -133,5 +135,26 @@ class UserService extends BaseService
         $existing->delete();
 
         return true;
+    }
+
+    /**
+     * Assert that the user has permission/membership to access the specified company.
+     * Elevated roles (super_admin, admin, assist) have access to all companies.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function assertBelongsToCompany(User $user, Company|int $company): void
+    {
+        if ($user->hasAnyRole(UserRole::elevated())) {
+            return;
+        }
+
+        $companyId = $company instanceof Company ? $company->id : $company;
+
+        if ( ! $user->companies()->where('companies.id', $companyId)->exists()) {
+            throw new \Illuminate\Auth\Access\AuthorizationException(
+                trans('ip.user_not_in_company') ?: 'You do not have access to this company.'
+            );
+        }
     }
 }

--- a/Modules/Core/Tests/Feature/EmailTemplateVariablesTest.php
+++ b/Modules/Core/Tests/Feature/EmailTemplateVariablesTest.php
@@ -145,11 +145,15 @@ class EmailTemplateVariablesTest extends AbstractCompanyPanelTestCase
         $client->update(['primary_contact_id' => null]);
         $client->contacts()->delete();
 
-        return $client->fresh();
+        /** @var Relation $fresh */
+        $fresh = $client->fresh();
+
+        return $fresh;
     }
 
     protected function makeContact(Relation $client, array $attributes, ?string $email = null): Contact
     {
+        /** @var Contact $contact */
         $contact = Contact::factory()->create(array_merge([
             'company_id'  => $this->company->id,
             'relation_id' => $client->id,
@@ -170,7 +174,8 @@ class EmailTemplateVariablesTest extends AbstractCompanyPanelTestCase
 
     protected function makeInvoice(Relation $client): Invoice
     {
-        return Invoice::factory()->create([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->create([
             'company_id'     => $this->company->id,
             'customer_id'    => $client->id,
             'user_id'        => $this->user->id,
@@ -178,5 +183,7 @@ class EmailTemplateVariablesTest extends AbstractCompanyPanelTestCase
             'invoiced_at'    => '2026-01-01',
             'invoice_total'  => 250,
         ]);
+
+        return $invoice;
     }
 }

--- a/Modules/Core/Tests/Feature/LoginRedirectTest.php
+++ b/Modules/Core/Tests/Feature/LoginRedirectTest.php
@@ -205,20 +205,26 @@ class LoginRedirectTest extends AbstractCompanyPanelTestCase
 
     private function activeUser(array $overrides = []): User
     {
-        return User::factory()->create(array_merge([
+        /** @var User $user */
+        $user = User::factory()->create(array_merge([
             'is_active'         => true,
             'email_verified_at' => Carbon::now(),
             'password'          => bcrypt('password'),
         ], $overrides));
+
+        return $user;
     }
 
     private function ivplv2Company(): Company
     {
-        return Company::factory()->create([
+        /** @var Company $company */
+        $company = Company::factory()->create([
             'search_code' => 'ivplv2',
             'name'        => 'InvoicePlane Corporation',
             'slug'        => 'invoiceplane-corporation',
         ]);
+
+        return $company;
     }
 
     private function elevatedRole(string $role): void

--- a/Modules/Core/Tests/Feature/LoginResponseTest.php
+++ b/Modules/Core/Tests/Feature/LoginResponseTest.php
@@ -140,10 +140,8 @@ class LoginResponseTest extends AbstractAdminPanelTestCase
 
     private function dispatchResponse(): RedirectResponse
     {
-        /** @var RedirectResponse $response */
-        $response = (new LoginResponse())->toResponse(request());
-
-        return $response;
+        /** @var RedirectResponse */
+        return (new LoginResponse())->toResponse(request());
     }
 
     // endregion

--- a/Modules/Core/Tests/Feature/LoginResponseTest.php
+++ b/Modules/Core/Tests/Feature/LoginResponseTest.php
@@ -129,6 +129,7 @@ class LoginResponseTest extends AbstractAdminPanelTestCase
 
     private function makeUser(Company ...$companies): User
     {
+        /** @var User $user */
         $user = User::factory()->create();
         foreach ($companies as $company) {
             $user->companies()->attach($company);
@@ -139,7 +140,10 @@ class LoginResponseTest extends AbstractAdminPanelTestCase
 
     private function dispatchResponse(): RedirectResponse
     {
-        return (new LoginResponse())->toResponse(request());
+        /** @var RedirectResponse $response */
+        $response = (new LoginResponse())->toResponse(request());
+
+        return $response;
     }
 
     // endregion

--- a/Modules/Core/Tests/Feature/UserProfileTest.php
+++ b/Modules/Core/Tests/Feature/UserProfileTest.php
@@ -5,6 +5,7 @@ namespace Modules\Core\Tests\Feature;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Modules\Core\Enums\UserRole;
 use Modules\Core\Filament\Company\Pages\Auth\EditProfile;
 use Modules\Core\Filament\Company\Pages\MyCompanies;
 use Modules\Core\Models\Company;
@@ -12,6 +13,7 @@ use Modules\Core\Services\UserService;
 use Modules\Core\Tests\AbstractCompanyPanelTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
 
 #[CoversClass(EditProfile::class)]
 #[CoversClass(MyCompanies::class)]
@@ -130,5 +132,53 @@ class UserProfileTest extends AbstractCompanyPanelTestCase
         ]));
 
         $this->assertSame($otherCompany->id, session('current_company_id'));
+    }
+
+    #[Test]
+    public function it_blocks_switching_and_sends_warning_notification_when_user_does_not_belong_to_target_company(): void
+    {
+        /* Arrange */
+        $otherCompany = Company::factory()->create(['search_code' => 'OTHERCO']);
+        $this->user->companies()->attach($otherCompany);
+
+        $initialCompanyId = $this->company->id;
+        session(['current_company_id' => $initialCompanyId]);
+
+        $this->mock(UserService::class, function ($mock) {
+            $mock->shouldReceive('assertBelongsToCompany')
+                ->once()
+                ->andThrow(new \Illuminate\Auth\Access\AuthorizationException(trans('ip.user_not_in_company')));
+        });
+
+        /* Act */
+        $component = $this->testLivewire(MyCompanies::class)
+            ->callTableAction('switch', $otherCompany);
+
+        /* Assert */
+        $component->assertNotified()
+            ->assertNoRedirect();
+
+        $this->assertSame($initialCompanyId, session('current_company_id'));
+    }
+
+    #[Test]
+    public function it_allows_elevated_user_to_switch_to_any_company_without_explicit_pivot_record(): void
+    {
+        /* Arrange */
+        $superAdminRole = Role::firstOrCreate(['name' => UserRole::SUPER_ADMIN->value, 'guard_name' => 'web']);
+        $this->user->assignRole($superAdminRole);
+
+        $anyCompany = Company::factory()->create(['search_code' => 'ANYCO']);
+
+        /* Act */
+        $component = $this->testLivewire(MyCompanies::class)
+            ->callTableAction('switch', $anyCompany);
+
+        /* Assert */
+        $component->assertRedirect(route('filament.company.pages.dashboard', [
+            'tenant' => Str::lower($anyCompany->search_code),
+        ]));
+
+        $this->assertSame($anyCompany->id, session('current_company_id'));
     }
 }

--- a/Modules/Core/Tests/Unit/Services/UserServiceAssertBelongsToCompanyTest.php
+++ b/Modules/Core/Tests/Unit/Services/UserServiceAssertBelongsToCompanyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Modules\Core\Tests\Unit\Services;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Modules\Core\Enums\UserRole;
+use Modules\Core\Models\Company;
+use Modules\Core\Models\User;
+use Modules\Core\Services\UserService;
+use Modules\Core\Tests\AbstractCompanyPanelTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Role;
+
+class UserServiceAssertBelongsToCompanyTest extends AbstractCompanyPanelTestCase
+{
+    protected UserService $userService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->userService = app(UserService::class);
+    }
+
+    #[Test]
+    #[Group('unit')]
+    public function it_allows_user_attached_to_company(): void
+    {
+        /* Arrange: $this->user belongs to $this->company */
+        $this->expectNotToPerformAssertions();
+
+        /* Act */
+        $this->userService->assertBelongsToCompany($this->user, $this->company);
+    }
+
+    #[Test]
+    #[Group('unit')]
+    public function it_throws_authorization_exception_for_unattached_company(): void
+    {
+        /* Arrange */
+        $unrelatedCompany = Company::factory()->create();
+
+        /* Assert & Act */
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage(trans('ip.user_not_in_company') ?: 'You do not have access to this company.');
+
+        $this->userService->assertBelongsToCompany($this->user, $unrelatedCompany);
+    }
+
+    #[Test]
+    #[Group('unit')]
+    public function it_allows_elevated_role_to_access_unattached_company(): void
+    {
+        /* Arrange */
+        Role::query()->firstOrCreate(['name' => UserRole::SUPER_ADMIN->value, 'guard_name' => 'web']);
+        $this->user->assignRole(UserRole::SUPER_ADMIN->value);
+        $unrelatedCompany = Company::factory()->create();
+
+        $this->expectNotToPerformAssertions();
+
+        /* Act */
+        $this->userService->assertBelongsToCompany($this->user, $unrelatedCompany);
+    }
+
+    #[Test]
+    #[Group('unit')]
+    public function it_accepts_integer_company_id(): void
+    {
+        /* Arrange */
+        $this->expectNotToPerformAssertions();
+
+        /* Act */
+        $this->userService->assertBelongsToCompany($this->user, $this->company->id);
+    }
+}

--- a/Modules/Invoices/Models/Invoice.php
+++ b/Modules/Invoices/Models/Invoice.php
@@ -129,10 +129,9 @@ class Invoice extends Model
         return $this->hasMany(InvoiceItem::class, 'invoice_id');
     }
 
-    public function mailQueue(): HasMany
+    public function mailQueue(): MorphMany
     {
-        return $this->hasMany(MailQueue::class, 'mailable_id')
-            ->where('mailable_type', self::class);
+        return $this->morphMany(MailQueue::class, 'mailable');
     }
 
     public function notes(): MorphMany

--- a/Modules/Invoices/Tests/Feature/EditInvoiceHeaderActionsTest.php
+++ b/Modules/Invoices/Tests/Feature/EditInvoiceHeaderActionsTest.php
@@ -143,7 +143,8 @@ class EditInvoiceHeaderActionsTest extends AbstractCompanyPanelTestCase
         $customer      = Relation::factory()->for($this->company)->customer()->create();
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
-        return Invoice::factory()->for($this->company)->create(array_merge([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->for($this->company)->create(array_merge([
             'invoice_number' => 'INV-987654',
             'customer_id'    => $customer->getKey(),
             'numbering_id'   => $documentGroup->getKey(),
@@ -153,5 +154,7 @@ class EditInvoiceHeaderActionsTest extends AbstractCompanyPanelTestCase
             'invoiced_at'    => '2025-05-10',
             'invoice_due_at' => '2025-06-09',
         ], $attributes));
+
+        return $invoice;
     }
 }

--- a/Modules/Invoices/Tests/Feature/EmailInvoiceActionTest.php
+++ b/Modules/Invoices/Tests/Feature/EmailInvoiceActionTest.php
@@ -128,7 +128,8 @@ class EmailInvoiceActionTest extends AbstractCompanyPanelTestCase
         ]);
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
-        return Invoice::factory()->for($this->company)->create(array_merge([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->for($this->company)->create(array_merge([
             'invoice_number' => 'INV-987654',
             'customer_id'    => $customer->getKey(),
             'numbering_id'   => $documentGroup->getKey(),
@@ -138,5 +139,7 @@ class EmailInvoiceActionTest extends AbstractCompanyPanelTestCase
             'invoiced_at'    => '2025-05-10',
             'invoice_due_at' => '2025-06-09',
         ], $attributes));
+
+        return $invoice;
     }
 }

--- a/Modules/Invoices/Tests/Feature/InvoiceListActionsTest.php
+++ b/Modules/Invoices/Tests/Feature/InvoiceListActionsTest.php
@@ -38,12 +38,16 @@ class InvoiceListActionsTest extends AbstractCompanyPanelTestCase
          * assigns client_admin, which carries create/edit/delete/duplicate
          * on invoices, create-payments and email-invoices.
          */
-        $this->customer = Relation::factory()->for($this->company)->customer()->create();
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+        /** @var Relation $customer */
+        $this->customer = $customer;
 
-        $this->numbering = Numbering::factory()
+        /** @var Numbering $numbering */
+        $numbering = Numbering::factory()
             ->for($this->company)
             ->state(['type' => NumberingType::INVOICE->value])
             ->create();
+        $this->numbering = $numbering;
     }
 
     #[Test]
@@ -66,6 +70,7 @@ class InvoiceListActionsTest extends AbstractCompanyPanelTestCase
         /* Assert */
         $component->assertHasNoErrors();
 
+        /** @var Invoice|null $copy */
         $copy = Invoice::query()
             ->where('id', '!=', $invoice->id)
             ->orderByDesc('id')
@@ -278,12 +283,15 @@ class InvoiceListActionsTest extends AbstractCompanyPanelTestCase
 
     protected function makeInvoice(array $attributes = []): Invoice
     {
-        return Invoice::factory()->for($this->company)->create(array_merge([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->for($this->company)->create(array_merge([
             'customer_id'  => $this->customer->id,
             'numbering_id' => $this->numbering->id,
             'user_id'      => $this->user->id,
             'is_read_only' => false,
         ], $attributes));
+
+        return $invoice;
     }
 
     protected function listInvoices()

--- a/Modules/Invoices/Tests/Feature/InvoicePdfAndCreditNoteTest.php
+++ b/Modules/Invoices/Tests/Feature/InvoicePdfAndCreditNoteTest.php
@@ -226,7 +226,8 @@ class InvoicePdfAndCreditNoteTest extends AbstractCompanyPanelTestCase
         $customer      = Relation::factory()->for($this->company)->customer()->create();
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
-        return Invoice::factory()->for($this->company)->create(array_merge([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->for($this->company)->create(array_merge([
             'invoice_number' => 'INV-987654',
             'customer_id'    => $customer->getKey(),
             'numbering_id'   => $documentGroup->getKey(),
@@ -236,5 +237,7 @@ class InvoicePdfAndCreditNoteTest extends AbstractCompanyPanelTestCase
             'invoiced_at'    => '2025-05-10',
             'invoice_due_at' => '2025-06-09',
         ], $attributes));
+
+        return $invoice;
     }
 }

--- a/Modules/Invoices/Tests/Feature/SendReminderActionTest.php
+++ b/Modules/Invoices/Tests/Feature/SendReminderActionTest.php
@@ -300,7 +300,8 @@ class SendReminderActionTest extends AbstractCompanyPanelTestCase
 
     private function makeInvoice(Relation $customer, Numbering $numbering, array $attributes = []): Invoice
     {
-        return Invoice::factory()->for($this->company)->create(array_merge([
+        /** @var Invoice $invoice */
+        $invoice = Invoice::factory()->for($this->company)->create(array_merge([
             'invoice_number' => 'INV-987654',
             'customer_id'    => $customer->getKey(),
             'numbering_id'   => $numbering->getKey(),
@@ -308,6 +309,8 @@ class SendReminderActionTest extends AbstractCompanyPanelTestCase
             'is_read_only'   => false,
             'invoiced_at'    => '2025-05-10',
         ], $attributes));
+
+        return $invoice;
     }
 
     private function listInvoices()

--- a/Modules/Projects/Tests/Feature/ProjectBillingTest.php
+++ b/Modules/Projects/Tests/Feature/ProjectBillingTest.php
@@ -129,18 +129,24 @@ class ProjectBillingTest extends AbstractCompanyPanelTestCase
     {
         $customer = Relation::factory()->for($this->company)->customer()->create();
 
-        return Project::factory()->for($this->company)->create([
+        /** @var Project $project */
+        $project = Project::factory()->for($this->company)->create([
             'customer_id' => $customer->id,
         ]);
+
+        return $project;
     }
 
     private function createTask(Project $project, array $attributes = []): Task
     {
-        return Task::factory()->for($this->company)->create(array_merge([
+        /** @var Task $task */
+        $task = Task::factory()->for($this->company)->create(array_merge([
             'customer_id' => $project->customer_id,
             'project_id'  => $project->id,
             'task_status' => TaskStatus::COMPLETED->value,
             'task_price'  => 100,
         ], $attributes));
+
+        return $task;
     }
 }

--- a/Modules/Quotes/Tests/Feature/EditQuoteHeaderActionsTest.php
+++ b/Modules/Quotes/Tests/Feature/EditQuoteHeaderActionsTest.php
@@ -116,7 +116,8 @@ class EditQuoteHeaderActionsTest extends AbstractCompanyPanelTestCase
         $prospect      = Relation::factory()->for($this->company)->prospect()->create();
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
-        return Quote::factory()->for($this->company)->create(array_merge([
+        /** @var Quote $quote */
+        $quote = Quote::factory()->for($this->company)->create(array_merge([
             'quote_number' => 'Q-987654',
             'prospect_id'  => $prospect->getKey(),
             'numbering_id' => $documentGroup->getKey(),
@@ -124,5 +125,7 @@ class EditQuoteHeaderActionsTest extends AbstractCompanyPanelTestCase
             'quote_status' => $status->value,
             'quoted_at'    => '2025-05-10',
         ], $attributes));
+
+        return $quote;
     }
 }

--- a/Modules/Quotes/Tests/Feature/QuoteConversionTest.php
+++ b/Modules/Quotes/Tests/Feature/QuoteConversionTest.php
@@ -109,7 +109,8 @@ class QuoteConversionTest extends AbstractCompanyPanelTestCase
         $prospect      = Relation::factory()->for($this->company)->prospect()->create();
         $documentGroup = Numbering::factory()->for($this->company)->create();
 
-        return Quote::factory()->for($this->company)->create(array_merge([
+        /** @var Quote $quote */
+        $quote = Quote::factory()->for($this->company)->create(array_merge([
             'quote_number' => 'Q-' . fake()->unique()->numberBetween(1000, 99999),
             'prospect_id'  => $prospect->getKey(),
             'numbering_id' => $documentGroup->getKey(),
@@ -117,5 +118,7 @@ class QuoteConversionTest extends AbstractCompanyPanelTestCase
             'quote_status' => QuoteStatus::APPROVED->value,
             'quoted_at'    => '2025-05-10',
         ], $attributes));
+
+        return $quote;
     }
 }

--- a/resources/lang/en/ip.php
+++ b/resources/lang/en/ip.php
@@ -47,6 +47,7 @@ return [
     #endregion
 
     #region CORE
+    'user_not_in_company'                          => 'You do not have access to this company.',
     'Q1'                                           => 'Q1',
     'Q2'                                           => 'Q2',
     'Q3'                                           => 'Q3',


### PR DESCRIPTION
_Original work by @Ahmedraza-fyntune_

---

### Summary
Resolves #687 and #693 by adding defense-in-depth authorization checks against unauthorized cross-company access during tenant switching, surfacing a friendly in-app Filament warning notification instead of allowing raw 403 errors to bubble up.

**Issue #687**: Filament's table-action record caching occasionally bound `$record` to an unrelated company, allowing users to silently switch into tenants they had no access to. Added `UserService::assertBelongsToCompany()` as a defensive authorization guard.

**Issue #693**: When cross-company access was attempted (either via bug or manipulation), users received a raw 403 error page. Now catches authorization failures and surfaces a friendly `ip.user_not_in_company` notification while blocking the switch.

### Key Changes
1. **Core Service Guard (`UserService`)**:
   - Added `assertBelongsToCompany(User $user, Company|int $company): void` to verify that regular users belong to the target company while allowing elevated roles (`super_admin`, `admin`, `assist`) to access all companies.
   - Throws `\Illuminate\Auth\Access\AuthorizationException` with `ip.user_not_in_company` message when access is denied.

2. **Company Switching UX (`MyCompanies`)**:
   - Wrapped `MyCompanies::table()`'s `switch` action with `UserService::assertBelongsToCompany()`.
   - On `AuthorizationException`, dispatches a `Filament\Notifications\Notification::make()->warning()` notification and halts redirection.
   - Configured table query to display all companies for elevated roles and user-scoped companies for regular users.

3. **Translations (`resources/lang/en/ip.php`)**:
   - Added `'user_not_in_company' => 'You do not have access to this company.'`.

4. **Testing & Static Analysis**:
   - Added `Modules/Core/Tests/Unit/Services/UserServiceAssertBelongsToCompanyTest.php` covering user access validation, `AuthorizationException` assertions, and elevated role bypass.
   - Added feature tests in `Modules/Core/Tests/Feature/UserProfileTest.php` verifying the notification dispatch and redirection blocking on unauthorized switch attempts.
   - Verified 100% clean PHPStan static analysis.

### Closes
Closes #687, #693