### PR TITLE
fix: remove dangling Report Builder page references from CompanyPanelProvider

### DIFF
--- a/Modules/Clients/Models/Relation.php
+++ b/Modules/Clients/Models/Relation.php
@@ -117,7 +117,7 @@ class Relation extends Model
         return $this->morphMany(Communication::class, 'communicationable');
     }
 
-    public function ccEmailCommunications()
+    public function ccEmailCommunications(): MorphMany
     {
         return $this->communications()->whereIn('communication_type', CommunicationType::ccTypes());
     }

--- a/Modules/Core/Providers/CompanyPanelProvider.php
+++ b/Modules/Core/Providers/CompanyPanelProvider.php
@@ -28,8 +28,6 @@ use Modules\Core\Filament\Company\Pages\Auth\EditProfile;
 use Modules\Core\Filament\Company\Pages\CompanySettings;
 use Modules\Core\Filament\Company\Pages\Dashboard;
 use Modules\Core\Filament\Company\Pages\MyCompanies;
-use Modules\Core\Filament\Company\Pages\ReportBuilder;
-use Modules\Core\Filament\Company\Pages\ReportTemplates;
 use Modules\Core\Filament\Company\Resources\CompanyUsers\CompanyUserResource;
 use Modules\Core\Filament\Company\Resources\EmailTemplates\EmailTemplateResource;
 use Modules\Core\Filament\Company\Resources\NoteTemplates\NoteTemplateResource;
@@ -188,8 +186,6 @@ class CompanyPanelProvider extends PanelProvider
                 EditProfile::class,
                 MyCompanies::class,
                 CompanySettings::class,
-                ReportTemplates::class,
-                ReportBuilder::class,
             ])
             ->widgets([
                 RecentQuotesWidget::class,
@@ -239,11 +235,6 @@ class CompanyPanelProvider extends PanelProvider
                             //->icon('heroicon-o-currency-dollar')
                             ->items([
                                 ...self::withQuickCreate(PaymentResource::class),
-                            ]),
-
-                        NavigationGroup::make(trans('ip.report_templates'))
-                            ->items([
-                                ...ReportTemplates::getNavigationItems(),
                             ]),
 
                         NavigationGroup::make('Resources')


### PR DESCRIPTION
# Pull Request Checklist

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [x] I included relevant documentation updates if necessary.
- [x] I have an accompanying issue ID for this pull request.

---

## Description

`CompanyPanelProvider` still imported and registered the `ReportTemplates` and
`ReportBuilder` page classes (as pages, and in the navigation builder) after
the commit that reverted #130 ("Remove Report Builder, Blocks, Bricks and
related files from develop") deleted the underlying page files. This left
`develop` in a state where `composer install`'s `package:discover` step — and
any boot of the `company` panel — fails outright with a "Class ... not found"
error.

This PR removes the three dangling references (two `use` imports, the
`->pages([...])` registration, and the navigation group built from
`ReportTemplates::getNavigationItems()`). No behavior is added; this only
removes code pointing at files that no longer exist.

Also gives `Relation::ccEmailCommunications()` an explicit `MorphMany` return
type, matching its sibling relationship methods on the same model — a
one-line drive-by fix noticed while tracing through this same area of code.

## Related Issue(s)

Fixes #725
Related to #130 (the Report Builder feature whose revert left this dangling)

## Motivation and Context

Found while syncing a fork's `develop` with upstream: a fresh `composer
install` on `develop` currently fails package discovery entirely because of
this dangling reference, which blocks any local setup from upstream
`develop` as-is.

## Issue Type (Check one or more)
- [x] Bugfix
- [ ] Improvement of an existing feature
- [ ] New feature

## Screenshots (If Applicable)

N/A — non-visual fix. Before this change, `composer install` fails with:

```
Error
Class "Modules\Core\Filament\Company\Pages\ReportTemplates" not found
at vendor/filament/filament/routes/web.php:165
```

After this change, `composer install` and the full local test suite
(579 tests / 2448 assertions) complete successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Report Builder and Report Templates have been removed from the company panel.
  * The report templates navigation section is no longer displayed.
  * All other company panel pages, resources, widgets, and navigation remain available.
* **Refactor**
  * Improved internal relationship type declarations without changing email communication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->