### PR TITLE
[IP-382]: Snapshot company contact data at invoice creation

### DIFF
--- a/Modules/Invoices/Database/Migrations/2026_08_22_000001_add_company_snapshot_fields_to_invoices_table.php
+++ b/Modules/Invoices/Database/Migrations/2026_08_22_000001_add_company_snapshot_fields_to_invoices_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table): void {
+            $table->string('company_name')->nullable()->after('work_order');
+            $table->string('company_vat_number')->nullable()->after('company_name');
+            $table->string('company_id_number')->nullable()->after('company_vat_number');
+            $table->string('company_coc_number')->nullable()->after('company_id_number');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table): void {
+            $table->dropColumn(['company_name', 'company_vat_number', 'company_id_number', 'company_coc_number']);
+        });
+    }
+};

--- a/Modules/Invoices/Models/Invoice.php
+++ b/Modules/Invoices/Models/Invoice.php
@@ -55,6 +55,10 @@ use Modules\Quotes\Models\Quote;
  * @property string|null              $summary
  * @property string|null              $terms
  * @property string|null              $footer
+ * @property string|null              $company_name
+ * @property string|null              $company_vat_number
+ * @property string|null              $company_id_number
+ * @property string|null              $company_coc_number
  * @property Company                  $company
  * @property Customer                 $customer
  * @property Numbering                $group

--- a/Modules/Invoices/Services/InvoiceCopyService.php
+++ b/Modules/Invoices/Services/InvoiceCopyService.php
@@ -4,6 +4,7 @@ namespace Modules\Invoices\Services;
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Modules\Core\Models\Company;
 use Modules\Invoices\Enums\InvoiceStatus;
 use Modules\Invoices\Models\Invoice;
 
@@ -16,11 +17,17 @@ class InvoiceCopyService
     public function copy(Invoice $invoice): Invoice
     {
         return DB::transaction(function () use ($invoice) {
+            $company = Company::find($invoice->company_id);
+
             $copy = Invoice::query()->create([
                 'customer_id'              => $invoice->customer_id,
                 'numbering_id'             => $invoice->numbering_id,
                 'user_id'                  => auth()->id(),
                 'invoice_number'           => null,
+                'company_name'             => $company?->name,
+                'company_vat_number'       => $company?->vat_number,
+                'company_id_number'        => $company?->id_number,
+                'company_coc_number'       => $company?->coc_number,
                 'invoice_status'           => InvoiceStatus::DRAFT,
                 'invoice_sign'             => $invoice->invoice_sign ?? '1',
                 'invoiced_at'              => now(),

--- a/Modules/Invoices/Services/InvoiceService.php
+++ b/Modules/Invoices/Services/InvoiceService.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Modules\Clients\Enums\CommunicationType;
 use Modules\Core\Enums\MailType;
+use Modules\Core\Models\Company;
 use Modules\Core\Models\EmailTemplate;
 use Modules\Core\Models\Setting;
 use Modules\Core\Services\BaseService;
@@ -60,9 +61,14 @@ class InvoiceService extends BaseService
             $itemTaxTotal    = $this->calculateItemTaxTotal($data);
             $invoiceTaxTotal = $this->calculateInvoiceTaxTotal($data);
             $invoiceTotal    = $this->calculateInvoiceTotal($data, $itemTaxTotal, $invoiceTaxTotal);
+            $company         = Company::find($this->getCompanyId());
 
             $invoice = Invoice::query()->create([
                 'customer_id'              => $data['customer_id'],
+                'company_name'             => $company?->name,
+                'company_vat_number'       => $company?->vat_number,
+                'company_id_number'        => $company?->id_number,
+                'company_coc_number'       => $company?->coc_number,
                 'numbering_id'             => $data['numbering_id'] ?? null,
                 'creditinvoice_parent_id'  => $data['creditinvoice_parent_id'] ?? null,
                 'user_id'                  => auth()->id(),
@@ -374,6 +380,10 @@ class InvoiceService extends BaseService
                 'creditinvoice_parent_id'  => $invoice->id,
                 'user_id'                  => auth()->id() ?? $invoice->user_id,
                 'invoice_number'           => null,
+                'company_name'             => $invoice->company_name,
+                'company_vat_number'       => $invoice->company_vat_number,
+                'company_id_number'        => $invoice->company_id_number,
+                'company_coc_number'       => $invoice->company_coc_number,
                 'invoice_status'           => InvoiceStatus::DRAFT->value,
                 'invoice_sign'             => '-1',
                 'invoiced_at'              => Carbon::today(),
@@ -460,7 +470,7 @@ class InvoiceService extends BaseService
             'invoice.total_formatted'    => number_format((float) $invoice->invoice_total, 2),
             'invoice.due_date_formatted' => DateHelpers::formatDate($invoice->invoice_due_at),
             'customer.name'              => $invoice->customer?->company_name,
-            'company.name'               => $invoice->company?->name,
+            'company.name'               => $invoice->company_name ?? $invoice->company?->name,
         ];
 
         $defaultSubject = trans($defaultSubjectTransKey, ['number' => $invoice->invoice_number]);

--- a/Modules/Invoices/Tests/Feature/CompanyRenameInvoicePreviewTest.php
+++ b/Modules/Invoices/Tests/Feature/CompanyRenameInvoicePreviewTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Modules\Invoices\Tests\Feature;
+
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Modules\Clients\Models\Relation;
+use Modules\Core\Enums\NumberingType;
+use Modules\Core\Enums\UserRole;
+use Modules\Core\Models\Company;
+use Modules\Core\Models\Numbering;
+use Modules\Core\Models\TaxRate;
+use Modules\Core\Models\User;
+use Modules\Core\Tests\AbstractCompanyPanelTestCase;
+use Modules\Invoices\Filament\Company\Resources\Invoices\Pages\EditInvoice;
+use Modules\Invoices\Filament\Company\Resources\Invoices\Pages\ListInvoices;
+use Modules\Invoices\Models\Invoice;
+use Modules\Products\Models\Product;
+use Modules\Products\Models\ProductCategory;
+use Modules\Products\Models\ProductUnit;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * End-to-end check for #382: an invoice created through the real Filament
+ * flow keeps its original company name after the company is renamed through
+ * the real Admin panel edit flow — not just via direct service/model calls.
+ */
+#[Group('crud')]
+class CompanyRenameInvoicePreviewTest extends AbstractCompanyPanelTestCase
+{
+    #[Test]
+    public function editing_the_company_through_the_admin_panel_does_not_change_an_already_issued_invoices_preview(): void
+    {
+        /* Arrange */
+        $this->company->update(['name' => 'Old Company Name BV']);
+
+        $customer        = Relation::factory()->for($this->company)->customer()->create();
+        $documentGroup   = Numbering::factory()->for($this->company)->state(['type' => NumberingType::INVOICE->value])->create();
+        $taxRate         = TaxRate::factory()->for($this->company)->create();
+        $productCategory = ProductCategory::factory()->for($this->company)->create();
+        $productUnit     = ProductUnit::factory()->for($this->company)->create();
+        $product         = Product::factory()->for($this->company)->create([
+            'category_id'   => $productCategory->id,
+            'unit_id'       => $productUnit->id,
+            'tax_rate_id'   => $taxRate->id,
+            'tax_rate_2_id' => null,
+        ]);
+
+        $payload = [
+            'invoice_number' => 'INV-CRP-001',
+            'customer_id'    => $customer->getKey(),
+            'numbering_id'   => $documentGroup->getKey(),
+            'user_id'        => $this->user->id,
+            'invoice_status' => 'sent',
+            'invoiced_at'    => '2025-05-10',
+            'invoice_due_at' => '2025-06-09',
+            'invoiceItems'   => [
+                [
+                    'product_id' => $product->getKey(),
+                    'quantity'   => 3,
+                    'price'      => 150,
+                    'discount'   => 0,
+                ],
+            ],
+        ];
+
+        /* Act — create the invoice through the real Filament "create" modal */
+        Livewire::actingAs($this->user)->test(ListInvoices::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->assertHasNoFormErrors()
+            ->callMountedAction()
+            ->assertHasNoFormErrors();
+
+        $invoice = Invoice::query()->where('invoice_number', 'INV-CRP-001')->firstOrFail();
+        $this->assertSame('Old Company Name BV', $invoice->company_name);
+
+        /* Act — rename the company through the real Admin panel edit action */
+        $this->editCompanyNameThroughAdminPanel($this->company, 'New Company Name NV');
+        $this->assertSame('New Company Name NV', $this->company->fresh()->name);
+
+        /* Assert — the already-issued invoice's preview still shows the old name */
+        Filament::setCurrentPanel(Filament::getPanel('company'));
+        Filament::setTenant($this->company, true);
+        session(['current_company_id' => $this->company->id]);
+
+        Livewire::actingAs($this->user)
+            ->test(EditInvoice::class, ['record' => $invoice->id])
+            ->mountAction('preview')
+            ->assertMountedActionModalSee('Old Company Name BV', escape: false)
+            ->assertMountedActionModalDontSee('New Company Name NV', escape: false);
+    }
+
+    /**
+     * Drives the real Admin > Companies > edit modal action (there is no
+     * dedicated edit page, it's a table row action — see CompaniesTable),
+     * switching into the admin panel as a super admin, then switching back.
+     */
+    private function editCompanyNameThroughAdminPanel(Company $company, string $newName): void
+    {
+        /** @var User $superAdmin */
+        $superAdmin = User::factory()->create();
+        $superAdmin->assignRole(UserRole::SUPER_ADMIN->value);
+
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+        $formData = $company->only(['search_code', 'name', 'slug', 'vat_number', 'id_number', 'coc_number']);
+        $formData['name'] = $newName;
+
+        Livewire::actingAs($superAdmin)
+            ->test(\Modules\Core\Filament\Admin\Resources\Companies\Pages\ListCompanies::class)
+            ->callTableAction('edit', $company, $formData)
+            ->assertHasNoTableActionErrors();
+    }
+}

--- a/Modules/Invoices/Tests/Feature/InvoiceCompanySnapshotTest.php
+++ b/Modules/Invoices/Tests/Feature/InvoiceCompanySnapshotTest.php
@@ -77,6 +77,25 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    public function it_renders_the_snapshotted_id_and_coc_numbers_on_the_pdf_not_the_companys_current_ones(): void
+    {
+        /* Arrange */
+        $this->company->update(['id_number' => 'ID-OLD', 'coc_number' => 'COC-OLD']);
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+        $invoice  = app(InvoiceService::class)->createInvoice($this->invoicePayload($customer));
+        $this->company->update(['id_number' => 'ID-NEW', 'coc_number' => 'COC-NEW']);
+
+        /* Act */
+        $html = app(InvoiceService::class)->renderHtml($invoice->fresh());
+
+        /* Assert */
+        $this->assertStringContainsString('ID-OLD', $html);
+        $this->assertStringContainsString('COC-OLD', $html);
+        $this->assertStringNotContainsString('ID-NEW', $html);
+        $this->assertStringNotContainsString('COC-NEW', $html);
+    }
+
+    #[Test]
     public function it_falls_back_to_the_live_company_name_for_invoices_created_before_the_snapshot_existed(): void
     {
         /* Arrange */

--- a/Modules/Invoices/Tests/Feature/InvoiceCompanySnapshotTest.php
+++ b/Modules/Invoices/Tests/Feature/InvoiceCompanySnapshotTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Modules\Invoices\Tests\Feature;
+
+use Modules\Clients\Models\Relation;
+use Modules\Core\Tests\AbstractCompanyPanelTestCase;
+use Modules\Invoices\Enums\InvoiceStatus;
+use Modules\Invoices\Models\Invoice;
+use Modules\Invoices\Services\InvoiceCopyService;
+use Modules\Invoices\Services\InvoiceService;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+#[Group('crud')]
+class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs($this->user);
+    }
+
+    #[Test]
+    public function it_snapshots_the_companys_details_onto_the_invoice_at_creation(): void
+    {
+        /* Arrange */
+        $this->company->update([
+            'name'        => 'ACME Corp',
+            'vat_number'  => 'BE0123456789',
+            'id_number'   => 'ID-1',
+            'coc_number'  => 'COC-1',
+        ]);
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+
+        /* Act */
+        $invoice = app(InvoiceService::class)->createInvoice($this->invoicePayload($customer));
+
+        /* Assert */
+        $this->assertSame('ACME Corp', $invoice->company_name);
+        $this->assertSame('BE0123456789', $invoice->company_vat_number);
+        $this->assertSame('ID-1', $invoice->company_id_number);
+        $this->assertSame('COC-1', $invoice->company_coc_number);
+    }
+
+    #[Test]
+    public function it_does_not_change_an_existing_invoices_snapshot_when_the_company_is_renamed(): void
+    {
+        /* Arrange */
+        $this->company->update(['name' => 'ACME Corp']);
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+        $invoice  = app(InvoiceService::class)->createInvoice($this->invoicePayload($customer));
+
+        /* Act */
+        $this->company->update(['name' => 'New Company Name']);
+
+        /* Assert */
+        $this->assertSame('ACME Corp', $invoice->fresh()->company_name);
+        $this->assertSame('New Company Name', $this->company->fresh()->name);
+    }
+
+    #[Test]
+    public function it_renders_the_snapshotted_company_name_on_the_pdf_not_the_companys_current_name(): void
+    {
+        /* Arrange */
+        $this->company->update(['name' => 'ACME Corp']);
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+        $invoice  = app(InvoiceService::class)->createInvoice($this->invoicePayload($customer));
+        $this->company->update(['name' => 'New Company Name']);
+
+        /* Act */
+        $html = app(InvoiceService::class)->renderHtml($invoice->fresh());
+
+        /* Assert */
+        $this->assertStringContainsString('ACME Corp', $html);
+        $this->assertStringNotContainsString('New Company Name', $html);
+    }
+
+    #[Test]
+    public function it_falls_back_to_the_live_company_name_for_invoices_created_before_the_snapshot_existed(): void
+    {
+        /* Arrange */
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+        $invoice  = Invoice::factory()->for($this->company)->create([
+            'customer_id'    => $customer->getKey(),
+            'invoice_status' => InvoiceStatus::SENT->value,
+            'company_name'   => null,
+        ]);
+
+        /* Act */
+        $html = app(InvoiceService::class)->renderHtml($invoice);
+
+        /* Assert */
+        $this->assertStringContainsString($this->company->name, $html);
+    }
+
+    #[Test]
+    public function a_credit_note_inherits_the_parent_invoices_snapshot_not_the_live_company(): void
+    {
+        /* Arrange */
+        $this->company->update(['name' => 'ACME Corp']);
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+        $invoice  = app(InvoiceService::class)->createInvoice(array_merge(
+            $this->invoicePayload($customer),
+            ['invoice_status' => InvoiceStatus::PAID->value],
+        ));
+        $this->company->update(['name' => 'New Company Name']);
+
+        /* Act */
+        $creditNote = app(InvoiceService::class)->createCreditNote($invoice->fresh());
+
+        /* Assert */
+        $this->assertSame('ACME Corp', $creditNote->company_name);
+    }
+
+    #[Test]
+    public function duplicating_an_invoice_snapshots_the_current_company_details(): void
+    {
+        /* Arrange */
+        $this->company->update(['name' => 'ACME Corp']);
+        $customer = Relation::factory()->for($this->company)->customer()->create();
+        $invoice  = app(InvoiceService::class)->createInvoice($this->invoicePayload($customer));
+        $this->company->update(['name' => 'New Company Name']);
+
+        /* Act */
+        $copy = app(InvoiceCopyService::class)->copy($invoice->fresh());
+
+        /* Assert */
+        $this->assertSame('New Company Name', $copy->company_name);
+    }
+
+    private function invoicePayload(Relation $customer): array
+    {
+        return [
+            'customer_id'              => $customer->getKey(),
+            'invoice_number'           => null,
+            'invoice_status'           => InvoiceStatus::DRAFT->value,
+            'invoiced_at'              => '2026-01-01',
+            'invoice_due_at'           => '2026-01-31',
+            'invoice_item_subtotal'    => 100,
+        ];
+    }
+}

--- a/Modules/Invoices/Tests/Unit/InvoiceCompanySnapshotTest.php
+++ b/Modules/Invoices/Tests/Unit/InvoiceCompanySnapshotTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Invoices\Tests\Feature;
+namespace Modules\Invoices\Tests\Unit;
 
 use Modules\Clients\Models\Relation;
 use Modules\Core\Tests\AbstractCompanyPanelTestCase;
@@ -11,7 +11,6 @@ use Modules\Invoices\Services\InvoiceService;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
-#[Group('crud')]
 class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
 {
     protected function setUp(): void
@@ -22,6 +21,7 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('unit')]
     public function it_snapshots_the_companys_details_onto_the_invoice_at_creation(): void
     {
         /* Arrange */
@@ -44,6 +44,7 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('unit')]
     public function it_does_not_change_an_existing_invoices_snapshot_when_the_company_is_renamed(): void
     {
         /* Arrange */
@@ -60,6 +61,7 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('unit')]
     public function it_renders_the_snapshotted_company_name_on_the_pdf_not_the_companys_current_name(): void
     {
         /* Arrange */
@@ -77,6 +79,7 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('unit')]
     public function it_renders_the_snapshotted_id_and_coc_numbers_on_the_pdf_not_the_companys_current_ones(): void
     {
         /* Arrange */
@@ -96,6 +99,7 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('unit')]
     public function it_falls_back_to_the_live_company_name_for_invoices_created_before_the_snapshot_existed(): void
     {
         /* Arrange */
@@ -114,6 +118,7 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('unit')]
     public function a_credit_note_inherits_the_parent_invoices_snapshot_not_the_live_company(): void
     {
         /* Arrange */
@@ -133,6 +138,7 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('unit')]
     public function duplicating_an_invoice_snapshots_the_current_company_details(): void
     {
         /* Arrange */
@@ -146,6 +152,58 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
 
         /* Assert */
         $this->assertSame('New Company Name', $copy->company_name);
+    }
+
+    #[Test]
+    #[Group('unit')]
+    public function it_leaves_the_snapshot_fields_null_when_the_company_has_none_of_them_set(): void
+    {
+        /* Arrange */
+        $this->company->update(['vat_number' => null, 'id_number' => null, 'coc_number' => null]);
+        // Pinned to null too — the "Vat id short" label is shared with the
+        // customer block, so a random factory-generated customer VAT would
+        // make this assertion a false negative for unrelated reasons.
+        $customer = Relation::factory()->for($this->company)->customer()->create(['vat_number' => null]);
+
+        /* Act */
+        $invoice = app(InvoiceService::class)->createInvoice($this->invoicePayload($customer));
+
+        /* Assert */
+        $this->assertNull($invoice->company_vat_number);
+        $this->assertNull($invoice->company_id_number);
+        $this->assertNull($invoice->company_coc_number);
+
+        $html = app(InvoiceService::class)->renderHtml($invoice->fresh());
+        $this->assertStringNotContainsString(trans('ip.vat_id_short'), $html);
+        $this->assertStringNotContainsString(trans('ip.id_number'), $html);
+        $this->assertStringNotContainsString(trans('ip.coc_number'), $html);
+    }
+
+    #[Test]
+    #[Group('unit')]
+    public function it_renders_without_error_when_the_invoices_company_cannot_be_resolved(): void
+    {
+        /* Arrange */
+        // An unsaved model with a company_id that matches no row — simulates an
+        // orphaned/legacy invoice whose company relation no longer resolves.
+        // (Not reachable through create(): companies.id is a real FK on
+        // invoices.company_id with onDelete('cascade'), so a persisted invoice
+        // can never actually outlive its company row.)
+        $invoice = Invoice::factory()->for($this->company)->make([
+            'company_id'          => 999999999,
+            'customer_id'         => 999999999,
+            'company_name'        => null,
+            'company_vat_number'  => null,
+            'company_id_number'   => null,
+            'company_coc_number'  => null,
+        ]);
+
+        /* Act */
+        $html = app(InvoiceService::class)->renderHtml($invoice);
+
+        /* Assert */
+        $this->assertIsString($html);
+        $this->assertNotSame('', trim($html));
     }
 
     private function invoicePayload(Relation $customer): array

--- a/Modules/Invoices/resources/views/pdf/invoice.blade.php
+++ b/Modules/Invoices/resources/views/pdf/invoice.blade.php
@@ -14,6 +14,12 @@
                 @if ($invoice->company_vat_number ?? $invoice->company?->vat_number)
                     <div>{{ trans('ip.vat_id_short') }}: {{ $invoice->company_vat_number ?? $invoice->company?->vat_number }}</div>
                 @endif
+                @if ($invoice->company_id_number ?? $invoice->company?->id_number)
+                    <div>{{ trans('ip.id_number') }}: {{ $invoice->company_id_number ?? $invoice->company?->id_number }}</div>
+                @endif
+                @if ($invoice->company_coc_number ?? $invoice->company?->coc_number)
+                    <div>{{ trans('ip.coc_number') }}: {{ $invoice->company_coc_number ?? $invoice->company?->coc_number }}</div>
+                @endif
             </td>
             <td style="vertical-align: top; text-align: right;">
                 <div style="font-size: 18px; font-weight: bold; text-transform: uppercase;">{{ trans('ip.invoice') }}</div>

--- a/Modules/Invoices/resources/views/pdf/invoice.blade.php
+++ b/Modules/Invoices/resources/views/pdf/invoice.blade.php
@@ -8,9 +8,12 @@
         <tr>
             <td style="vertical-align: top;">
                 @if ($branding['logo_path'])
-                    <img src="{{ $branding['logo_path'] }}" alt="{{ $invoice->company?->name }}" style="max-height: 60px; max-width: 240px; margin-bottom: 8px;">
+                    <img src="{{ $branding['logo_path'] }}" alt="{{ $invoice->company_name ?? $invoice->company?->name }}" style="max-height: 60px; max-width: 240px; margin-bottom: 8px;">
                 @endif
-                <div style="font-size: 20px; font-weight: bold;">{{ $invoice->company?->name }}</div>
+                <div style="font-size: 20px; font-weight: bold;">{{ $invoice->company_name ?? $invoice->company?->name }}</div>
+                @if ($invoice->company_vat_number ?? $invoice->company?->vat_number)
+                    <div>{{ trans('ip.vat_id_short') }}: {{ $invoice->company_vat_number ?? $invoice->company?->vat_number }}</div>
+                @endif
             </td>
             <td style="vertical-align: top; text-align: right;">
                 <div style="font-size: 18px; font-weight: bold; text-transform: uppercase;">{{ trans('ip.invoice') }}</div>


### PR DESCRIPTION
# Pull Request Checklist   

## Checklist  
- [x] My code follows the code formatting guidelines.  
- [x] I have tested my changes locally.  
- [x] I selected the appropriate branch for this PR.  
- [x] I have rebased my changes on top of the selected branch.  
- [ ] I included relevant documentation updates if necessary.  
- [x] I have an accompanying issue ID for this pull request.  

---

## Description  

Invoices now snapshot the issuing company's name, VAT number, ID number, and Chamber-of-Commerce number at the moment they're created, instead of always reading them live off the `companies` table. The invoice PDF/preview template, the credit note flow, invoice duplication, and the "Email Invoice" placeholder all now prefer this frozen snapshot and fall back to the live company record for invoices created before this change.

- Added a migration adding `company_name`, `company_vat_number`, `company_id_number`, `company_coc_number` (nullable) to `invoices`.
- `InvoiceService::createInvoice()` populates the snapshot from the current company at creation time.
- `InvoiceService::createCreditNote()` copies the snapshot from the parent invoice (not the live company), so a credit note stays consistent with the invoice it corrects.
- `InvoiceCopyService::copy()` (duplicate invoice) snapshots the *current* company, since a duplicate is effectively a new invoice.
- `pdf/invoice.blade.php` renders `company_name`/`company_vat_number` with `?? $invoice->company?->name` fallback for pre-existing invoices, and now also displays the company's VAT number (previously not shown at all).
- Fixed the same "renamed company retroactively changes old data" bug in the invoice email template's `company.name` placeholder.
- Added `Modules/Invoices/Tests/Feature/InvoiceCompanySnapshotTest.php` covering: snapshot captured at creation, a later company rename doesn't change an existing invoice, the PDF renders the frozen name not the live one, pre-migration invoices fall back correctly, credit notes inherit the parent's snapshot, and duplicated invoices pick up the current company.

**Scope note:** this covers the company fields that are actually editable in the app today (name, VAT/ID/COC numbers via the admin Company form and the company-panel Settings page). Company address and phone/email have no editing UI anywhere in the app yet — building that, and snapshotting it, is a separate follow-up.

---

## Related Issue(s)  

Fixes #382

---

## Motivation and Context  

A company that updates its details (e.g. after moving address, or a legal rename) had every past invoice's PDF silently change to show the new name, since the invoice header was always rendered live from the `Company` relationship rather than the data that was true when the invoice was issued. This is a real compliance problem — old invoices should stay legally accurate to what was true at the time they were sent. This PR applies the same denormalized-snapshot pattern the codebase already uses for invoice line items (`invoice_items` stores product name/price at time of sale) to the invoice header's company details.

---

## Issue Type (Check one or more)  
- [x] Bugfix  
- [ ] Improvement of an existing feature  
- [ ] New feature  

---

## Screenshots  
N/A

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoices now preserve the company name and registration details from the time they are issued.
  * Invoice previews and PDFs retain original company information even after company details change.
  * Credit notes and copied invoices inherit the relevant company details.
  * Email placeholders use the preserved invoice company name when available.

* **Bug Fixes**
  * Improved handling of missing company records or incomplete company details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->