### PR TITLE
[IP-164]: Send quotes via email for client approval.

### DIFF
--- a/Modules/Core/Enums/MailType.php
+++ b/Modules/Core/Enums/MailType.php
@@ -7,6 +7,7 @@ use Modules\Core\Contracts\LabeledEnum;
 enum MailType: string implements LabeledEnum
 {
     case REMINDER = 'reminder';
+    case SENT = 'sent';
 
     public static function values(): array
     {
@@ -17,6 +18,7 @@ enum MailType: string implements LabeledEnum
     {
         return match ($this) {
             self::REMINDER => 'Reminder',
+            self::SENT => 'Sent',
         };
     }
 
@@ -24,6 +26,7 @@ enum MailType: string implements LabeledEnum
     {
         return match ($this) {
             self::REMINDER => 'warning',
+            self::SENT => 'success',
         };
     }
 }

--- a/Modules/Core/Services/CompanyDefaultsBootstrapService.php
+++ b/Modules/Core/Services/CompanyDefaultsBootstrapService.php
@@ -77,6 +77,22 @@ class CompanyDefaultsBootstrapService
             ]
         );
 
+        // Create default quote email template
+        EmailTemplate::query()->firstOrCreate(
+            [
+                'company_id' => $company->id,
+                'title'      => 'quote_sent',
+            ],
+            [
+                'subject'    => 'Quote #{{ quote.number }}',
+                'body'       => 'Please find your quote #{{ quote.number }} attached.',
+                'from_name'  => $company->name,
+                'from_email' => $fromEmail,
+                'cc'         => null,
+                'bcc'        => null,
+            ]
+        );
+
         // Create default tax rate
         TaxRate::query()->firstOrCreate(
             [

--- a/Modules/Core/Services/CompanyDefaultsBootstrapService.php
+++ b/Modules/Core/Services/CompanyDefaultsBootstrapService.php
@@ -84,8 +84,8 @@ class CompanyDefaultsBootstrapService
                 'title'      => 'quote_sent',
             ],
             [
-                'subject'    => 'Quote #{{ quote.number }}',
-                'body'       => 'Please find your quote #{{ quote.number }} attached.',
+                'subject'    => trans('ip.quote_sent_template_default_subject'),
+                'body'       => trans('ip.quote_sent_template_default_body'),
                 'from_name'  => $company->name,
                 'from_email' => $fromEmail,
                 'cc'         => null,

--- a/Modules/Quotes/Filament/Company/Actions/EmailQuoteAction.php
+++ b/Modules/Quotes/Filament/Company/Actions/EmailQuoteAction.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Modules\Quotes\Filament\Company\Actions;
+
+use Filament\Actions\Action;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+use Modules\Quotes\Models\Quote;
+use Modules\Quotes\Services\QuoteService;
+
+class EmailQuoteAction
+{
+    public static function make(): Action
+    {
+        return Action::make('email_quote')
+            ->label(trans('ip.email_quote'))
+            ->icon(Heroicon::OutlinedEnvelope)
+            ->schema(function (Quote $record) {
+                $defaults = app(QuoteService::class)->resolveEmailDefaults($record);
+
+                return [
+                    TextInput::make('recipient')
+                        ->label(trans('ip.recipient'))
+                        ->email()
+                        ->required()
+                        ->default($defaults['recipient']),
+                    TextInput::make('subject')
+                        ->label(trans('ip.subject'))
+                        ->required()
+                        ->default($defaults['subject']),
+                    Textarea::make('body')
+                        ->label(trans('ip.body'))
+                        ->required()
+                        ->rows(10)
+                        ->default($defaults['body']),
+                ];
+            })
+            ->modalHeading(trans('ip.email_quote'))
+            ->modalSubmitActionLabel(trans('ip.send_email'))
+            ->action(function (Quote $record, array $data): void {
+                app(QuoteService::class)->sendQuoteEmail(
+                    $record,
+                    $data['recipient'],
+                    $data['subject'],
+                    $data['body'],
+                );
+
+                Notification::make()
+                    ->title(trans('ip.email_sent'))
+                    ->body(trans('ip.quote_email_sent_successfully'))
+                    ->success()
+                    ->send();
+            });
+    }
+}

--- a/Modules/Quotes/Filament/Company/Resources/Quotes/Pages/EditQuote.php
+++ b/Modules/Quotes/Filament/Company/Resources/Quotes/Pages/EditQuote.php
@@ -8,7 +8,9 @@ use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
+use Modules\Core\Enums\Permission;
 use Modules\Quotes\Enums\QuoteStatus;
+use Modules\Quotes\Filament\Company\Actions\EmailQuoteAction;
 use Modules\Quotes\Filament\Company\Resources\Quotes\QuoteResource;
 use Modules\Quotes\Services\QuoteService;
 
@@ -51,18 +53,18 @@ class EditQuote extends EditRecord
             Action::make('download_pdf')
                 ->label(trans('ip.download_pdf'))
                 ->icon(Heroicon::OutlinedArrowDownTray)
-                ->action(fn () => Notification::make()
-                    ->title(trans('ip.not_yet_implemented'))
-                    ->warning()
-                    ->send()),
+                ->action(fn () => app(QuoteService::class)->generatePdf($this->getRecord())),
 
-            Action::make('send_email')
-                ->label(trans('ip.send_email'))
-                ->icon(Heroicon::OutlinedEnvelope)
-                ->action(fn () => Notification::make()
-                    ->title(trans('ip.not_yet_implemented'))
-                    ->warning()
-                    ->send()),
+            EmailQuoteAction::make()
+                ->visible(fn () => auth()->user()?->can(Permission::EMAIL_QUOTES->value))
+                ->disabled(function (): bool {
+                    return blank(app(QuoteService::class)->resolveEmailDefaults($this->getRecord())['recipient']);
+                })
+                ->tooltip(function (): ?string {
+                    return blank(app(QuoteService::class)->resolveEmailDefaults($this->getRecord())['recipient'])
+                        ? trans('ip.customer_has_no_email')
+                        : null;
+                }),
 
             Action::make('convert_to_invoice')
                 ->label(trans('ip.convert_to_invoice'))

--- a/Modules/Quotes/Filament/Company/Resources/Quotes/Tables/QuotesTable.php
+++ b/Modules/Quotes/Filament/Company/Resources/Quotes/Tables/QuotesTable.php
@@ -15,6 +15,7 @@ use Modules\Core\Enums\Permission;
 use Modules\Core\Helpers\EnumHelper;
 use Modules\Core\Support\DateHelpers;
 use Modules\Quotes\Enums\QuoteStatus;
+use Modules\Quotes\Filament\Company\Actions\EmailQuoteAction;
 use Modules\Quotes\Models\Quote;
 use Modules\Quotes\Services\QuoteService;
 
@@ -89,13 +90,16 @@ class QuotesTable
                             so need for modal anymore'
                         )
                         ->action(function (Quote $record): void {}),
-                    Action::make('send email')
-                        ->label(trans('ip.send_email'))
+                    EmailQuoteAction::make()
                         ->visible(fn () => auth()->user()?->can(Permission::EMAIL_QUOTES->value))
-
-                        ->modalDescription('todo: make sure we can email the Quote through an action,
-                            so need for modal anymore')
-                        ->action(function (Quote $record): void {}),
+                        ->disabled(function (Quote $record): bool {
+                            return blank(app(QuoteService::class)->resolveEmailDefaults($record)['recipient']);
+                        })
+                        ->tooltip(function (Quote $record): ?string {
+                            return blank(app(QuoteService::class)->resolveEmailDefaults($record)['recipient'])
+                                ? trans('ip.customer_has_no_email')
+                                : null;
+                        }),
                     Action::make('print')
                         ->label(trans('ip.print'))
                         ->icon('heroicon-o-printer')

--- a/Modules/Quotes/Mail/QuoteMailable.php
+++ b/Modules/Quotes/Mail/QuoteMailable.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Modules\Quotes\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Modules\Core\Support\PDF\PDFFactory;
+use Modules\Quotes\Models\Quote;
+use Modules\Quotes\Services\QuoteService;
+
+class QuoteMailable extends Mailable implements ShouldQueue
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public Quote $quote,
+        public string $emailSubject,
+        public string $bodyText,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: $this->emailSubject,
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            htmlString: nl2br(e($this->bodyText)),
+        );
+    }
+
+    /**
+     * Renders the PDF here, at send time, rather than in the caller ahead of
+     * queuing — a pre-rendered binary on a ShouldQueue mailable would get
+     * serialized into the queue payload (DB row / Redis value / SQS message)
+     * instead of being generated when the job actually runs.
+     */
+    public function attachments(): array
+    {
+        $filename  = ($this->quote->quote_number ?: 'quote-' . $this->quote->id) . '.pdf';
+        $html      = app(QuoteService::class)->renderHtml($this->quote);
+        $pdfBinary = PDFFactory::create()->getOutput($html);
+
+        return [
+            Attachment::fromData(fn () => $pdfBinary, $filename)
+                ->withMime('application/pdf'),
+        ];
+    }
+}

--- a/Modules/Quotes/Services/QuoteService.php
+++ b/Modules/Quotes/Services/QuoteService.php
@@ -5,17 +5,33 @@ namespace Modules\Quotes\Services;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Modules\Clients\Enums\CommunicationType;
+use Modules\Core\Enums\MailType;
+use Modules\Core\Models\EmailTemplate;
+use Modules\Core\Models\Setting;
 use Modules\Core\Services\BaseService;
+use Modules\Core\Support\DateHelpers;
+use Modules\Core\Support\EmailTemplatePreview;
+use Modules\Core\Support\PDF\PDFFactory;
 use Modules\Invoices\Enums\InvoiceStatus;
 use Modules\Invoices\Models\Invoice;
 use Modules\Quotes\Enums\QuoteStatus;
+use Modules\Quotes\Mail\QuoteMailable;
 use Modules\Quotes\Models\Quote;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Throwable;
 
 class QuoteService extends BaseService
 {
+    /**
+     * Title of the EmailTemplate used as the company's quote email template.
+     */
+    public const QUOTE_EMAIL_TEMPLATE_TITLE = 'quote_sent';
+
     public function model(): string
     {
         return Quote::class;
@@ -259,6 +275,198 @@ class QuoteService extends BaseService
 
             return $invoice;
         });
+    }
+
+    /**
+     * Resolve the recipient/subject/body defaults for the "Email Quote" modal,
+     * rendering the company's quote email template against this quote.
+     */
+    public function resolveEmailDefaults(Quote $quote): array
+    {
+        $defaults = $this->resolveTemplateDefaults($quote);
+        unset($defaults['template']);
+
+        return $defaults;
+    }
+
+    /**
+     * Queue the quote mailable for delivery using the given (possibly
+     * user-edited) recipient/subject/body, as resolved/prefilled by
+     * resolveEmailDefaults() and submitted via the "Email Quote" modal.
+     * Logs a MailQueue entry so the quote's send history is auditable, and
+     * transitions a draft quote to Sent on first send.
+     */
+    public function sendQuoteEmail(Quote $quote, string $recipient, string $subject, string $body): void
+    {
+        Mail::to($recipient)
+            ->cc($this->resolveQuoteCcEmails($quote))
+            ->queue(new QuoteMailable($quote, $subject, $body));
+
+        $template = EmailTemplate::forCompany($quote->company_id)
+            ->where('title', self::QUOTE_EMAIL_TEMPLATE_TITLE)
+            ->first();
+
+        $quote->mailQueue()->create([
+            'mailable_type' => Quote::class,
+            'type'          => MailType::SENT,
+            'from'          => $template?->from_email ?? (string) config('mail.from.address'),
+            'to'            => $recipient,
+            'cc'            => '',
+            'bcc'           => '',
+            'subject'       => $subject,
+            'body'          => $body,
+            'attach_pdf'    => true,
+            'is_sent'       => true,
+            'sent_at'       => now(),
+        ]);
+
+        if ($quote->quote_status === QuoteStatus::DRAFT) {
+            $quote->update(['quote_status' => QuoteStatus::SENT]);
+        }
+    }
+
+    /**
+     * Render the quote document markup used by both the PDF driver and the
+     * on-screen preview.
+     */
+    public function renderHtml(Quote $quote): string
+    {
+        $quote->loadMissing(['company', 'prospect', 'quoteItems']);
+
+        return view('quotes::pdf.quote', [
+            'quote'    => $quote,
+            'branding' => $this->resolveBranding($quote),
+        ])->render();
+    }
+
+    /**
+     * Stream the quote as a PDF download named after the quote number.
+     */
+    public function generatePdf(Quote $quote): StreamedResponse
+    {
+        $driver   = PDFFactory::create();
+        $output   = $driver->getOutput($this->renderHtml($quote));
+        $filename = ($quote->quote_number ?: 'quote-draft-' . $quote->id) . '.pdf';
+
+        return response()->streamDownload(
+            function () use ($output): void {
+                echo $output;
+            },
+            $filename,
+            ['Content-Type' => 'application/pdf'],
+        );
+    }
+
+    /**
+     * Company branding for the quote PDF/preview: colors, font, and logo.
+     * Falls back to the current hardcoded look when a company hasn't set
+     * any branding.
+     *
+     * @return array{primary_color: string, accent_color: string, font_family: string, font_size: string, logo_path: ?string}
+     */
+    private function resolveBranding(Quote $quote): array
+    {
+        $companyId = $quote->company_id;
+
+        $logoPath = Setting::getForCompany($companyId, Setting::KEY_INVOICE_LOGO);
+        $logoDisk = Storage::disk(config('filament.default_filesystem_disk'));
+
+        return [
+            'primary_color' => Setting::getForCompany($companyId, Setting::KEY_PRIMARY_COLOR) ?: '#1f2937',
+            'accent_color'  => Setting::getForCompany($companyId, Setting::KEY_ACCENT_COLOR) ?: '#6b7280',
+            'font_family'   => Setting::getForCompany($companyId, Setting::KEY_FONT_FAMILY) ?: 'DejaVu Sans, Helvetica, Arial, sans-serif',
+            'font_size'     => Setting::getForCompany($companyId, Setting::KEY_FONT_SIZE) ?: '12',
+            'logo_path'     => $logoPath && $logoDisk->exists($logoPath) ? $logoDisk->path($logoPath) : null,
+        ];
+    }
+
+    /**
+     * Shared resolution logic for the "Email Quote" modal: loads the
+     * company's quote EmailTemplate, renders its subject/body against this
+     * quote, and resolves the recipient. Returns the EmailTemplate alongside
+     * the rendered defaults so callers that also need template fields (e.g.
+     * sendQuoteEmail()'s from_email) don't have to re-query it.
+     */
+    private function resolveTemplateDefaults(Quote $quote): array
+    {
+        $quote->loadMissing(['prospect', 'company']);
+
+        $template = EmailTemplate::forCompany($quote->company_id)
+            ->where('title', self::QUOTE_EMAIL_TEMPLATE_TITLE)
+            ->first();
+
+        $placeholders = [
+            'quote.number'                => $quote->quote_number,
+            'quote.total_formatted'       => number_format((float) $quote->quote_total, 2),
+            'quote.expires_at_formatted'  => DateHelpers::formatDate($quote->quote_expires_at),
+            'customer.name'               => $quote->prospect?->company_name,
+            'company.name'                => $quote->company?->name,
+        ];
+
+        $defaultSubject = trans('ip.email_quote_default_subject', ['number' => $quote->quote_number]);
+
+        return [
+            'template'  => $template,
+            'recipient' => $this->resolveQuoteRecipientEmail($quote),
+            'subject'   => $template?->subject
+                ? EmailTemplatePreview::render($template->subject, $placeholders)
+                : $defaultSubject,
+            'body' => $template?->body
+                ? EmailTemplatePreview::render($template->body, $placeholders)
+                : '',
+        ];
+    }
+
+    /**
+     * Walk the quote's prospect → contacts → communications chain and
+     * return the first email address found, preferring a primary one.
+     */
+    private function resolveQuoteRecipientEmail(Quote $quote): ?string
+    {
+        $quote->loadMissing('prospect.contacts.communications');
+
+        $prospect = $quote->prospect;
+
+        if ( ! $prospect) {
+            return null;
+        }
+
+        $emailCommunication = $prospect->contacts
+            ->flatMap(fn ($contact) => $contact->communications)
+            ->filter(fn ($communication) => $communication->communication_type === CommunicationType::EMAIL->value)
+            ->sortByDesc('is_primary')
+            ->first();
+
+        return $emailCommunication?->communication_value;
+    }
+
+    /**
+     * Merge the prospect's stored CC addresses with the quote email
+     * template's cc column (comma/semicolon separated), validating each
+     * address and de-duplicating the result.
+     */
+    private function resolveQuoteCcEmails(Quote $quote): array
+    {
+        $quote->loadMissing('prospect');
+
+        $prospectCcEmails = $quote->prospect?->ccEmailCommunications()
+            ->pluck('communication_value')
+            ->all() ?? [];
+
+        $template = EmailTemplate::forCompany($quote->company_id)
+            ->where('title', self::QUOTE_EMAIL_TEMPLATE_TITLE)
+            ->first();
+
+        $templateCcEmails = $template?->cc
+            ? preg_split('/[,;]+/', $template->cc)
+            : [];
+
+        return collect([...$prospectCcEmails, ...$templateCcEmails])
+            ->map(fn (string $email) => mb_trim($email))
+            ->filter(fn (string $email) => filter_var($email, FILTER_VALIDATE_EMAIL) !== false)
+            ->unique()
+            ->values()
+            ->all();
     }
 
     private function calculateItemTaxTotal(array $data): float

--- a/Modules/Quotes/Tests/Feature/EditQuoteHeaderActionsTest.php
+++ b/Modules/Quotes/Tests/Feature/EditQuoteHeaderActionsTest.php
@@ -49,7 +49,7 @@ class EditQuoteHeaderActionsTest extends AbstractCompanyPanelTestCase
         $component
             ->assertSuccessful()
             ->assertActionVisible('download_pdf')
-            ->assertActionVisible('send_email')
+            ->assertActionVisible('email_quote')
             ->assertActionVisible('convert_to_invoice')
             ->assertActionVisible('copy_quote')
             ->assertActionVisible('delete');

--- a/Modules/Quotes/Tests/Feature/EmailQuoteActionTest.php
+++ b/Modules/Quotes/Tests/Feature/EmailQuoteActionTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Modules\Quotes\Tests\Feature;
+
+use Illuminate\Support\Facades\Mail;
+use Livewire\Livewire;
+use Modules\Clients\Enums\CommunicationType;
+use Modules\Clients\Models\Relation;
+use Modules\Core\Database\Seeders\PermissionsSeeder;
+use Modules\Core\Database\Seeders\RolesSeeder;
+use Modules\Core\Enums\MailType;
+use Modules\Core\Enums\Permission;
+use Modules\Core\Enums\UserRole;
+use Modules\Core\Models\EmailTemplate;
+use Modules\Core\Tests\AbstractCompanyPanelTestCase;
+use Modules\Quotes\Enums\QuoteStatus;
+use Modules\Quotes\Filament\Company\Resources\Quotes\Pages\EditQuote;
+use Modules\Quotes\Mail\QuoteMailable;
+use Modules\Quotes\Models\Quote;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+class EmailQuoteActionTest extends AbstractCompanyPanelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /*
+         * Resource pages gate on Spatie permissions, so the test user
+         * needs the seeded client_admin permission set to mount the page.
+         */
+        (new PermissionsSeeder())->run();
+        (new RolesSeeder())->run();
+        $this->user->assignRole(UserRole::CUSTOMER_ADMIN->value);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    #[Group('slow')]
+    public function it_prefills_the_modal_from_the_companys_quote_email_template(): void
+    {
+        /*
+         * Every company is auto-bootstrapped with a "quote_sent" EmailTemplate
+         * (see CompanyDefaultsBootstrapService::bootstrap()), so update it
+         * rather than creating a second row with the same title.
+         */
+        EmailTemplate::forCompany($this->company->id)
+            ->where('title', 'quote_sent')
+            ->update([
+                'subject' => 'New Quote: {{ quote.number }}',
+                'body'    => 'Dear {{ customer.name }}, your quote #{{ quote.number }} totals {{ quote.total_formatted }}.',
+            ]);
+
+        $quote = $this->createQuote(['quote_total' => 150]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(EditQuote::class, ['record' => $quote->id])
+            ->assertSuccessful()
+            ->mountAction('email_quote');
+
+        /* Assert */
+        $component
+            ->assertActionDataSet([
+                'recipient' => 'prospect@example.com',
+                'subject'   => 'New Quote: QUO-987654',
+                'body'      => "Dear {$quote->prospect->company_name}, your quote #QUO-987654 totals 150.00.",
+            ]);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    #[Group('slow')]
+    public function it_falls_back_to_a_default_subject_and_blank_body_without_a_template(): void
+    {
+        /* Arrange */
+        EmailTemplate::forCompany($this->company->id)->where('title', 'quote_sent')->delete();
+
+        $quote = $this->createQuote();
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(EditQuote::class, ['record' => $quote->id])
+            ->assertSuccessful()
+            ->mountAction('email_quote');
+
+        /* Assert */
+        $component
+            ->assertActionDataSet([
+                'recipient' => 'prospect@example.com',
+                'subject'   => 'Quote #QUO-987654',
+                'body'      => '',
+            ]);
+    }
+
+    #[Test]
+    #[Group('slow')]
+    #[Group('crud')]
+    public function it_hides_the_action_without_the_email_quotes_permission(): void
+    {
+        /* Arrange */
+        $this->user->syncRoles([]);
+        $this->user->givePermissionTo([
+            Permission::VIEW_QUOTES->value,
+            Permission::EDIT_QUOTES->value,
+        ]);
+        $quote = $this->createQuote();
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(EditQuote::class, ['record' => $quote->id]);
+
+        /* Assert */
+        $component
+            ->assertSuccessful()
+            ->assertActionHidden('email_quote');
+    }
+
+    #[Test]
+    #[Group('crud')]
+    #[Group('slow')]
+    public function it_queues_the_quote_mailable_logs_a_mail_queue_row_and_marks_the_quote_sent(): void
+    {
+        /* Arrange */
+        Mail::fake();
+        $quote = $this->createQuote(['quote_status' => QuoteStatus::DRAFT]);
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(EditQuote::class, ['record' => $quote->id])
+            ->assertSuccessful()
+            ->mountAction('email_quote')
+            ->setActionData([
+                'recipient' => 'prospect@example.com',
+                'subject'   => 'Subject line',
+                'body'      => 'Body text',
+            ])
+            ->callMountedAction();
+
+        /* Assert */
+        Mail::assertQueued(QuoteMailable::class, fn ($mail) => $mail->hasTo('prospect@example.com'));
+
+        $this->assertDatabaseHas('mail_queue', [
+            'mailable_id'   => $quote->id,
+            'mailable_type' => Quote::class,
+            'type'          => MailType::SENT->value,
+            'to'            => 'prospect@example.com',
+        ]);
+
+        $this->assertDatabaseHas('quotes', [
+            'id'           => $quote->id,
+            'quote_status' => QuoteStatus::SENT->value,
+        ]);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    #[Group('slow')]
+    public function it_shows_an_error_when_no_contact_email_is_found_on_the_prospect(): void
+    {
+        /* Arrange */
+        $prospect = Relation::factory()->for($this->company)->prospect()->create();
+        $prospect->contacts()->create([
+            'company_id' => $this->company->id,
+            'first_name' => 'Jane',
+            'last_name'  => 'Doe',
+        ]);
+
+        $quote = Quote::factory()->for($this->company)->create([
+            'prospect_id'  => $prospect->id,
+            'quote_status' => QuoteStatus::DRAFT,
+        ]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(EditQuote::class, ['record' => $quote->id])
+            ->assertSuccessful();
+
+        /* Assert */
+        $component->assertActionDisabled('email_quote');
+
+        $this->assertDatabaseHas('quotes', [
+            'id'           => $quote->id,
+            'quote_status' => QuoteStatus::DRAFT->value,
+        ]);
+    }
+
+    private function createQuote(array $attributes = []): Quote
+    {
+        $prospect = Relation::factory()->for($this->company)->prospect()->create();
+        $contact  = $prospect->contacts()->create([
+            'company_id' => $this->company->id,
+            'first_name' => 'John',
+            'last_name'  => 'Prospect',
+        ]);
+        $contact->communications()->create([
+            'company_id'          => $this->company->id,
+            'is_primary'          => true,
+            'communication_type'  => CommunicationType::EMAIL->value,
+            'communication_value' => 'prospect@example.com',
+        ]);
+
+        /** @var Quote $quote */
+        $quote = Quote::factory()->for($this->company)->create(array_merge([
+            'quote_number' => 'QUO-987654',
+            'prospect_id'  => $prospect->id,
+            'user_id'      => $this->user->id,
+            'quote_status' => QuoteStatus::SENT,
+            'quoted_at'    => '2025-05-10',
+            'quote_expires_at' => '2025-06-09',
+        ], $attributes));
+
+        return $quote;
+    }
+}

--- a/Modules/Quotes/Tests/Feature/EmailQuoteActionTest.php
+++ b/Modules/Quotes/Tests/Feature/EmailQuoteActionTest.php
@@ -91,11 +91,11 @@ class EmailQuoteActionTest extends AbstractCompanyPanelTestCase
             ->assertSuccessful()
             ->mountAction('email_quote');
 
-        /* Assert */
         $placeholders = [
             'quote.number' => $quote->quote_number,
         ];
 
+        /* Assert */
         $component
             ->assertActionDataSet([
                 'recipient' => 'prospect@example.com',

--- a/Modules/Quotes/Tests/Feature/EmailQuoteActionTest.php
+++ b/Modules/Quotes/Tests/Feature/EmailQuoteActionTest.php
@@ -12,6 +12,7 @@ use Modules\Core\Enums\MailType;
 use Modules\Core\Enums\Permission;
 use Modules\Core\Enums\UserRole;
 use Modules\Core\Models\EmailTemplate;
+use Modules\Core\Support\EmailTemplatePreview;
 use Modules\Core\Tests\AbstractCompanyPanelTestCase;
 use Modules\Quotes\Enums\QuoteStatus;
 use Modules\Quotes\Filament\Company\Resources\Quotes\Pages\EditQuote;
@@ -68,6 +69,38 @@ class EmailQuoteActionTest extends AbstractCompanyPanelTestCase
                 'recipient' => 'prospect@example.com',
                 'subject'   => 'New Quote: QUO-987654',
                 'body'      => "Dear {$quote->prospect->company_name}, your quote #QUO-987654 totals 150.00.",
+            ]);
+    }
+
+    #[Test]
+    #[Group('crud')]
+    #[Group('slow')]
+    public function it_prefills_the_modal_from_the_bootstrapped_default_quote_template(): void
+    {
+        /*
+         * Arrange
+         *
+         * Uses the "quote_sent" EmailTemplate exactly as CompanyDefaultsBootstrapService
+         * seeds it (translated subject/body), without overwriting or deleting it.
+         */
+        $quote = $this->createQuote(['quote_total' => 150]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(EditQuote::class, ['record' => $quote->id])
+            ->assertSuccessful()
+            ->mountAction('email_quote');
+
+        /* Assert */
+        $placeholders = [
+            'quote.number' => $quote->quote_number,
+        ];
+
+        $component
+            ->assertActionDataSet([
+                'recipient' => 'prospect@example.com',
+                'subject'   => EmailTemplatePreview::render(trans('ip.quote_sent_template_default_subject'), $placeholders),
+                'body'      => EmailTemplatePreview::render(trans('ip.quote_sent_template_default_body'), $placeholders),
             ]);
     }
 

--- a/Modules/Quotes/Tests/Feature/EmailQuoteActionTest.php
+++ b/Modules/Quotes/Tests/Feature/EmailQuoteActionTest.php
@@ -41,6 +41,8 @@ class EmailQuoteActionTest extends AbstractCompanyPanelTestCase
     public function it_prefills_the_modal_from_the_companys_quote_email_template(): void
     {
         /*
+         * Arrange
+         *
          * Every company is auto-bootstrapped with a "quote_sent" EmailTemplate
          * (see CompanyDefaultsBootstrapService::bootstrap()), so update it
          * rather than creating a second row with the same title.

--- a/Modules/Quotes/resources/views/pdf/quote.blade.php
+++ b/Modules/Quotes/resources/views/pdf/quote.blade.php
@@ -1,0 +1,113 @@
+{{-- Quote document markup — used by the PDF driver and the on-screen preview. --}}
+@php
+    $primaryColor = $branding['primary_color'];
+    $accentColor  = $branding['accent_color'];
+@endphp
+<div class="ip-quote" style="font-family: {{ $branding['font_family'] }}; color: {{ $primaryColor }}; font-size: {{ $branding['font_size'] }}px; line-height: 1.5;">
+    <table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+        <tr>
+            <td style="vertical-align: top;">
+                @if ($branding['logo_path'])
+                    <img src="{{ $branding['logo_path'] }}" alt="{{ $quote->company?->name }}" style="max-height: 60px; max-width: 240px; margin-bottom: 8px;">
+                @endif
+                <div style="font-size: 20px; font-weight: bold;">{{ $quote->company?->name }}</div>
+                @if ($quote->company?->vat_number)
+                    <div>{{ trans('ip.vat_id_short') }}: {{ $quote->company->vat_number }}</div>
+                @endif
+                @if ($quote->company?->id_number)
+                    <div>{{ trans('ip.id_number') }}: {{ $quote->company->id_number }}</div>
+                @endif
+                @if ($quote->company?->coc_number)
+                    <div>{{ trans('ip.coc_number') }}: {{ $quote->company->coc_number }}</div>
+                @endif
+            </td>
+            <td style="vertical-align: top; text-align: right;">
+                <div style="font-size: 18px; font-weight: bold; text-transform: uppercase;">{{ trans('ip.quote') }}</div>
+                <div>{{ $quote->quote_number ?? trans('ip.draft') }}</div>
+            </td>
+        </tr>
+    </table>
+
+    <table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+        <tr>
+            <td style="vertical-align: top;">
+                <div style="font-weight: bold; margin-bottom: 4px;">{{ trans('ip.bill_to') }}</div>
+                <div>{{ $quote->prospect?->company_name }}</div>
+                @if ($quote->prospect?->vat_number)
+                    <div>{{ trans('ip.vat_id_short') }}: {{ $quote->prospect->vat_number }}</div>
+                @endif
+            </td>
+            <td style="vertical-align: top; text-align: right;">
+                <div>{{ trans('ip.quote_date') }}: {{ $quote->quoted_at?->format('Y-m-d') }}</div>
+                <div>{{ trans('ip.expires_at') }}: {{ $quote->quote_expires_at?->format('Y-m-d') }}</div>
+            </td>
+        </tr>
+    </table>
+
+    <table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+        <thead>
+            <tr>
+                <th style="text-align: left; border-bottom: 2px solid {{ $primaryColor }}; padding: 6px 4px;">{{ trans('ip.item') }}</th>
+                <th style="text-align: right; border-bottom: 2px solid {{ $primaryColor }}; padding: 6px 4px;">{{ trans('ip.quantity') }}</th>
+                <th style="text-align: right; border-bottom: 2px solid {{ $primaryColor }}; padding: 6px 4px;">{{ trans('ip.price') }}</th>
+                <th style="text-align: right; border-bottom: 2px solid {{ $primaryColor }}; padding: 6px 4px;">{{ trans('ip.discount') }}</th>
+                <th style="text-align: right; border-bottom: 2px solid {{ $primaryColor }}; padding: 6px 4px;">{{ trans('ip.subtotal') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($quote->quoteItems as $item)
+                <tr>
+                    <td style="border-bottom: 1px solid #e5e7eb; padding: 6px 4px;">
+                        {{ $item->item_name }}
+                        @if ($item->description)
+                            <div style="color: {{ $accentColor }};">{{ $item->description }}</div>
+                        @endif
+                    </td>
+                    <td style="text-align: right; border-bottom: 1px solid #e5e7eb; padding: 6px 4px;">{{ $item->quantity + 0 }}</td>
+                    <td style="text-align: right; border-bottom: 1px solid #e5e7eb; padding: 6px 4px;">{{ number_format((float) $item->price, 2) }}</td>
+                    <td style="text-align: right; border-bottom: 1px solid #e5e7eb; padding: 6px 4px;">{{ number_format((float) $item->discount, 2) }}</td>
+                    <td style="text-align: right; border-bottom: 1px solid #e5e7eb; padding: 6px 4px;">{{ number_format((float) $item->subtotal, 2) }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    <table style="width: 40%; margin-left: 60%; border-collapse: collapse; margin-bottom: 24px;">
+        <tr>
+            <td style="padding: 4px;">{{ trans('ip.subtotal') }}</td>
+            <td style="text-align: right; padding: 4px;">{{ number_format((float) $quote->quote_item_subtotal, 2) }}</td>
+        </tr>
+        <tr>
+            <td style="padding: 4px;">{{ trans('ip.tax') }}</td>
+            <td style="text-align: right; padding: 4px;">{{ number_format((float) $quote->quote_tax_total + (float) $quote->item_tax_total, 2) }}</td>
+        </tr>
+        @if ((float) $quote->quote_discount_amount > 0)
+            <tr>
+                <td style="padding: 4px;">{{ trans('ip.discount') }}</td>
+                <td style="text-align: right; padding: 4px;">-{{ number_format((float) $quote->quote_discount_amount, 2) }}</td>
+            </tr>
+        @endif
+        <tr>
+            <td style="padding: 4px; border-top: 2px solid {{ $primaryColor }}; font-weight: bold;">{{ trans('ip.total') }}</td>
+            <td style="text-align: right; padding: 4px; border-top: 2px solid {{ $primaryColor }}; font-weight: bold;">{{ number_format((float) $quote->quote_total, 2) }}</td>
+        </tr>
+    </table>
+
+    @if ($quote->summary)
+        <div style="margin-bottom: 12px;">
+            <div style="font-weight: bold;">{{ trans('ip.summary') }}</div>
+            <div>{{ $quote->summary }}</div>
+        </div>
+    @endif
+
+    @if ($quote->terms)
+        <div style="margin-bottom: 12px;">
+            <div style="font-weight: bold;">{{ trans('ip.terms') }}</div>
+            <div>{{ $quote->terms }}</div>
+        </div>
+    @endif
+
+    @if ($quote->footer)
+        <div style="color: {{ $accentColor }}; margin-top: 24px;">{{ $quote->footer }}</div>
+    @endif
+</div>

--- a/resources/lang/en/ip.php
+++ b/resources/lang/en/ip.php
@@ -592,6 +592,9 @@ return [
     'quote_templates'                 => 'Quote Templates',
     'quote_to_invoice'                => 'Quote to Invoice',
     'quote_duplicated'                => 'Quote duplicated successfully',
+    
+    'email_quote_default_subject'     => 'Quote #:number',
+    'quote_email_sent_successfully'   => 'The quote email has been queued for delivery.',
     'quote_viewed'                    => 'This quote has been viewed',
     'quoted_at'                       => 'Quote Date',
     'quotes'                          => 'Quotes',

--- a/resources/lang/en/ip.php
+++ b/resources/lang/en/ip.php
@@ -595,6 +595,8 @@ return [
     
     'email_quote_default_subject'     => 'Quote #:number',
     'quote_email_sent_successfully'   => 'The quote email has been queued for delivery.',
+    'quote_sent_template_default_subject' => 'Quote #{{ quote.number }}',
+    'quote_sent_template_default_body'    => 'Please find your quote #{{ quote.number }} attached.',
     'quote_viewed'                    => 'This quote has been viewed',
     'quoted_at'                       => 'Quote Date',
     'quotes'                          => 'Quotes',


### PR DESCRIPTION
# Pull Request Checklist

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [x] I included relevant documentation updates if necessary.
- [x] I have an accompanying issue ID for this pull request.

---

## Description

Implements sending a quote to the prospect by email for approval, replacing the no-op "send email" stub with a working action.

- Adds `QuoteService::sendQuoteEmail()`/`resolveEmailDefaults()`, mirroring the invoice email pipeline's recipient-resolution and template-rendering pattern (`EmailTemplatePreview`, prospect → contacts → communications lookup).
- Adds `QuoteService::renderHtml()`/`generatePdf()` and a new `quotes::pdf.quote` Blade view — quotes had no PDF generation at all before this.
- New `QuoteMailable` (queued, PDF attached at send-time) and `EmailQuoteAction` Filament action (modal with editable recipient/subject/body), wired into both `QuotesTable` (row action) and `EditQuote` (header action), replacing their stubs. Both are disabled with a tooltip when the prospect has no resolvable email.
- Sending logs a `mail_queue` audit row (new `MailType::SENT` case) and transitions a draft quote's status to `Sent` on first send.
- `CompanyDefaultsBootstrapService` now also bootstraps a `quote_sent` `EmailTemplate` per company, matching the existing `invoice_sent`/`invoice_reminder` pattern.
- New translation keys (`email_quote`, `email_quote_default_subject`, `quote_email_sent_successfully`).

## Related Issue(s)

Closes #164

## Motivation and Context

Quoting is currently a dead end in the app — a client_admin can build a quote but has no way to deliver it to the prospect for approval, and the "send email"/"download pdf" actions were TODO stubs. This closes that loop by porting the invoice module's proven email pipeline over to quotes, filling in the gaps (PDF attachment, send audit trail, status transition) that the invoice side didn't fully have either.

## Issue Type (Check one or more)
- [ ] Bugfix
- [ ] Improvement of an existing feature
- [x] New feature

## Screenshots (If Applicable)

N/A 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to email quotes with editable recipients, subjects, and message content.
  * Quote emails include a generated PDF attachment and update the quote status to Sent.
  * Added quote PDF generation and preview with company branding, pricing, terms, and footer details.
  * Added default quote email templates and email history tracking.
  * Added a Sent status indicator for mailed quotes.

* **Bug Fixes**
  * Email actions are hidden or disabled when permissions are missing or no recipient email is available.

* **Tests**
  * Added coverage for quote email defaults, permissions, delivery, status updates, and missing contact emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->