### PR TITLE
[IP-97]: Add signature capture backend for quotes. 

### DIFF
--- a/Modules/Quotes/Database/Factories/QuoteSignatureFactory.php
+++ b/Modules/Quotes/Database/Factories/QuoteSignatureFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\Quotes\Database\Factories;
+
+use Modules\Core\Database\Factories\AbstractFactory;
+use Modules\Core\Models\User;
+use Modules\Quotes\Models\Quote;
+use Modules\Quotes\Models\QuoteSignature;
+
+class QuoteSignatureFactory extends AbstractFactory
+{
+    protected $model = QuoteSignature::class;
+
+    public function definition(): array
+    {
+        $companyId = $this->resolveCompanyId();
+
+        return [
+            'quote_id'       => $this->resolveForeignKey(Quote::class, $companyId),
+            'user_id'        => null,
+            'signer_name'    => fake()->name(),
+            'signature_disk' => 'local',
+            'signature_path' => 'quote-signatures/' . fake()->uuid() . '.png',
+            'signed_at'      => now(),
+            'ip_address'     => fake()->ipv4(),
+            'user_agent'     => fake()->userAgent(),
+        ];
+    }
+
+    public function forUser(User $user): static
+    {
+        return $this->state(fn () => [
+            'user_id'     => $user->id,
+            'signer_name' => $user->name,
+        ]);
+    }
+}

--- a/Modules/Quotes/Database/Migrations/2026_08_24_000001_create_quote_signatures_table.php
+++ b/Modules/Quotes/Database/Migrations/2026_08_24_000001_create_quote_signatures_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('quote_signatures', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('company_id');
+            $table->unsignedBigInteger('quote_id');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->string('signer_name');
+            $table->string('signature_disk');
+            $table->string('signature_path');
+            $table->timestamp('signed_at');
+            $table->string('ip_address', 45)->nullable();
+            $table->string('user_agent')->nullable();
+
+            $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
+            $table->foreign('quote_id', 'fk_quote_signatures_quote_id')->references('id')->on('quotes')->onDelete('cascade');
+            $table->foreign('user_id', 'fk_quote_signatures_user_id')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('quote_signatures');
+    }
+};

--- a/Modules/Quotes/Models/Quote.php
+++ b/Modules/Quotes/Models/Quote.php
@@ -48,6 +48,7 @@ use Modules\Quotes\Enums\QuoteStatus;
  * @property Relation               $relation
  * @property User                   $user
  * @property Collection|QuoteItem[] $quote_items
+ * @property Collection|QuoteSignature[] $signatures
  */
 class Quote extends Model
 {
@@ -116,6 +117,11 @@ class Quote extends Model
         return $this->hasMany(QuoteItem::class, 'quote_id');
     }
 
+    public function signatures(): HasMany
+    {
+        return $this->hasMany(QuoteSignature::class, 'quote_id');
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
@@ -154,6 +160,11 @@ class Quote extends Model
         }
 
         return 'secondary';
+    }
+
+    public function isSigned(): bool
+    {
+        return $this->signatures()->exists();
     }
 
     /*

--- a/Modules/Quotes/Models/QuoteSignature.php
+++ b/Modules/Quotes/Models/QuoteSignature.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Modules\Quotes\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Modules\Core\Models\User;
+use Modules\Core\Traits\BelongsToCompany;
+use Modules\Quotes\Database\Factories\QuoteSignatureFactory;
+
+/**
+ * @property int          $id
+ * @property int          $company_id
+ * @property int          $quote_id
+ * @property int|null     $user_id
+ * @property string       $signer_name
+ * @property string       $signature_disk
+ * @property string       $signature_path
+ * @property Carbon       $signed_at
+ * @property string|null  $ip_address
+ * @property string|null  $user_agent
+ * @property Quote        $quote
+ * @property User|null    $user
+ */
+class QuoteSignature extends Model
+{
+    use BelongsToCompany;
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $casts = [
+        'signed_at' => 'datetime',
+    ];
+
+    protected $guarded = [];
+
+    public function quote(): BelongsTo
+    {
+        return $this->belongsTo(Quote::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return QuoteSignatureFactory::new();
+    }
+}

--- a/Modules/Quotes/Services/QuoteService.php
+++ b/Modules/Quotes/Services/QuoteService.php
@@ -22,6 +22,7 @@ use Modules\Invoices\Models\Invoice;
 use Modules\Quotes\Enums\QuoteStatus;
 use Modules\Quotes\Mail\QuoteMailable;
 use Modules\Quotes\Models\Quote;
+use Modules\Quotes\Models\QuoteSignature;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Throwable;
 
@@ -326,6 +327,40 @@ class QuoteService extends BaseService
     }
 
     /**
+     * Capture a client (or user-linked) signature against a quote, storing
+     * the decoded image on the configured Filament filesystem disk and
+     * recording a QuoteSignature row. Does not change the quote's status.
+     *
+     * @throws InvalidArgumentException when $signatureData isn't a valid base64 data URL
+     */
+    public function captureSignature(
+        Quote $quote,
+        string $signatureData,
+        string $signerName,
+        ?int $userId = null,
+        ?string $ipAddress = null,
+        ?string $userAgent = null,
+    ): QuoteSignature {
+        [$extension, $binary] = $this->decodeSignatureData($signatureData);
+
+        $disk = config('filament.default_filesystem_disk');
+        $path = 'quote-signatures/' . $quote->id . '/' . Str::random(40) . '.' . $extension;
+
+        Storage::disk($disk)->put($path, $binary);
+
+        return $quote->signatures()->create([
+            'company_id'      => $quote->company_id,
+            'user_id'         => $userId,
+            'signer_name'     => $signerName,
+            'signature_disk'  => $disk,
+            'signature_path'  => $path,
+            'signed_at'       => now(),
+            'ip_address'      => $ipAddress,
+            'user_agent'      => $userAgent,
+        ]);
+    }
+
+    /**
      * Render the quote document markup used by both the PDF driver and the
      * on-screen preview.
      */
@@ -378,6 +413,32 @@ class QuoteService extends BaseService
             'font_size'     => Setting::getForCompany($companyId, Setting::KEY_FONT_SIZE) ?: '12',
             'logo_path'     => $logoPath && $logoDisk->exists($logoPath) ? $logoDisk->path($logoPath) : null,
         ];
+    }
+
+    /**
+     * Decode a `data:image/<type>;base64,<payload>` string into a
+     * [file extension, raw binary] pair.
+     *
+     * @return array{0: string, 1: string}
+     *
+     * @throws InvalidArgumentException when the input isn't a valid base64 image data URL
+     */
+    private function decodeSignatureData(string $signatureData): array
+    {
+        $mimeToExtension = [
+            'image/png'  => 'png',
+            'image/jpeg' => 'jpg',
+            'image/webp' => 'webp',
+        ];
+
+        if (
+            ! preg_match('/^data:(image\/(?:png|jpeg|webp));base64,(?<payload>.+)$/', $signatureData, $matches)
+            || ($binary = base64_decode($matches['payload'], true)) === false
+        ) {
+            throw new InvalidArgumentException(trans('ip.quote_signature_invalid_format'));
+        }
+
+        return [$mimeToExtension[$matches[1]], $binary];
     }
 
     /**

--- a/Modules/Quotes/Services/QuoteService.php
+++ b/Modules/Quotes/Services/QuoteService.php
@@ -23,6 +23,7 @@ use Modules\Quotes\Enums\QuoteStatus;
 use Modules\Quotes\Mail\QuoteMailable;
 use Modules\Quotes\Models\Quote;
 use Modules\Quotes\Models\QuoteSignature;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Throwable;
 
@@ -346,18 +347,25 @@ class QuoteService extends BaseService
         $disk = config('filament.default_filesystem_disk');
         $path = 'quote-signatures/' . $quote->id . '/' . Str::random(40) . '.' . $extension;
 
-        Storage::disk($disk)->put($path, $binary);
+        if ( ! Storage::disk($disk)->put($path, $binary)) {
+            throw new RuntimeException(trans('ip.quote_signature_storage_failed'));
+        }
 
-        return $quote->signatures()->create([
-            'company_id'      => $quote->company_id,
-            'user_id'         => $userId,
-            'signer_name'     => $signerName,
-            'signature_disk'  => $disk,
-            'signature_path'  => $path,
-            'signed_at'       => now(),
-            'ip_address'      => $ipAddress,
-            'user_agent'      => $userAgent,
-        ]);
+        try {
+            return $quote->signatures()->create([
+                'company_id'      => $quote->company_id,
+                'user_id'         => $userId,
+                'signer_name'     => $signerName,
+                'signature_disk'  => $disk,
+                'signature_path'  => $path,
+                'signed_at'       => now(),
+                'ip_address'      => $ipAddress,
+                'user_agent'      => $userAgent,
+            ]);
+        } catch (Throwable $e) {
+            Storage::disk($disk)->delete($path);
+            throw $e;
+        }
     }
 
     /**
@@ -435,6 +443,12 @@ class QuoteService extends BaseService
             ! preg_match('/^data:(image\/(?:png|jpeg|webp));base64,(?<payload>.+)$/', $signatureData, $matches)
             || ($binary = base64_decode($matches['payload'], true)) === false
         ) {
+            throw new InvalidArgumentException(trans('ip.quote_signature_invalid_format'));
+        }
+
+        $detectedImage = @getimagesizefromstring($binary);
+
+        if ($detectedImage === false || $detectedImage['mime'] !== $matches[1]) {
             throw new InvalidArgumentException(trans('ip.quote_signature_invalid_format'));
         }
 

--- a/Modules/Quotes/Tests/Feature/QuoteSignatureCaptureTest.php
+++ b/Modules/Quotes/Tests/Feature/QuoteSignatureCaptureTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Modules\Quotes\Tests\Feature;
+
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Modules\Core\Tests\AbstractCompanyPanelTestCase;
+use Modules\Quotes\Enums\QuoteStatus;
+use Modules\Quotes\Models\Quote;
+use Modules\Quotes\Models\QuoteSignature;
+use Modules\Quotes\Services\QuoteService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(QuoteService::class)]
+#[CoversClass(QuoteSignature::class)]
+class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
+{
+    private const VALID_PNG_DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+    #[Test]
+    public function it_stores_a_captured_signature_on_a_quote(): void
+    {
+        /* Arrange */
+        Storage::fake(config('filament.default_filesystem_disk'));
+        $quote = Quote::factory()->for($this->company)->create();
+
+        /* Act */
+        $signature = app(QuoteService::class)->captureSignature($quote, self::VALID_PNG_DATA_URL, 'Jane Client');
+
+        /* Assert */
+        Storage::disk(config('filament.default_filesystem_disk'))->assertExists($signature->signature_path);
+        $this->assertDatabaseHas('quote_signatures', [
+            'id'          => $signature->id,
+            'quote_id'    => $quote->id,
+            'company_id'  => $quote->company_id,
+            'signer_name' => 'Jane Client',
+        ]);
+    }
+
+    #[Test]
+    public function it_links_a_signature_to_a_user_when_a_user_id_is_provided(): void
+    {
+        /* Arrange */
+        Storage::fake(config('filament.default_filesystem_disk'));
+        $quote = Quote::factory()->for($this->company)->create();
+
+        /* Act */
+        $signature = app(QuoteService::class)->captureSignature(
+            $quote,
+            self::VALID_PNG_DATA_URL,
+            $this->user->name,
+            $this->user->id,
+            '127.0.0.1',
+            'PHPUnit',
+        );
+
+        /* Assert */
+        $this->assertSame($this->user->id, $signature->fresh()->user_id);
+        $this->assertSame('127.0.0.1', $signature->fresh()->ip_address);
+        $this->assertSame('PHPUnit', $signature->fresh()->user_agent);
+    }
+
+    #[Test]
+    public function it_reports_a_quote_as_unsigned_when_no_signature_has_been_captured(): void
+    {
+        /* Arrange */
+        $quote = Quote::factory()->for($this->company)->create();
+
+        /* Act */
+        $isSigned = $quote->isSigned();
+
+        /* Assert */
+        $this->assertFalse($isSigned);
+    }
+
+    #[Test]
+    public function it_reports_a_quote_as_signed_after_a_signature_is_captured(): void
+    {
+        /* Arrange */
+        Storage::fake(config('filament.default_filesystem_disk'));
+        $quote = Quote::factory()->for($this->company)->create();
+        app(QuoteService::class)->captureSignature($quote, self::VALID_PNG_DATA_URL, 'Jane Client');
+
+        /* Act */
+        $isSigned = $quote->isSigned();
+
+        /* Assert */
+        $this->assertTrue($isSigned);
+    }
+
+    #[Test]
+    public function it_does_not_change_the_quote_status_when_a_signature_is_captured(): void
+    {
+        /* Arrange */
+        Storage::fake(config('filament.default_filesystem_disk'));
+        $quote = Quote::factory()->for($this->company)->sent()->create();
+
+        /* Act */
+        app(QuoteService::class)->captureSignature($quote, self::VALID_PNG_DATA_URL, 'Jane Client');
+
+        /* Assert */
+        $this->assertSame(QuoteStatus::SENT, $quote->fresh()->quote_status);
+    }
+
+    #[Test]
+    public function it_throws_when_the_signature_data_is_not_a_valid_base64_image(): void
+    {
+        /* Arrange */
+        Storage::fake(config('filament.default_filesystem_disk'));
+        $quote = Quote::factory()->for($this->company)->create();
+
+        /* Act & Assert */
+        $this->expectException(InvalidArgumentException::class);
+        app(QuoteService::class)->captureSignature($quote, 'not-a-data-url', 'Jane Client');
+    }
+
+    #[Test]
+    public function it_supports_capturing_more_than_one_signature_on_the_same_quote(): void
+    {
+        /* Arrange */
+        Storage::fake(config('filament.default_filesystem_disk'));
+        $quote   = Quote::factory()->for($this->company)->create();
+        $service = app(QuoteService::class);
+
+        /* Act */
+        $service->captureSignature($quote, self::VALID_PNG_DATA_URL, 'First Signer');
+        $service->captureSignature($quote, self::VALID_PNG_DATA_URL, 'Second Signer');
+
+        /* Assert */
+        $this->assertSame(2, $quote->signatures()->count());
+    }
+}

--- a/Modules/Quotes/Tests/Feature/QuoteSignatureCaptureTest.php
+++ b/Modules/Quotes/Tests/Feature/QuoteSignatureCaptureTest.php
@@ -10,6 +10,7 @@ use Modules\Quotes\Models\Quote;
 use Modules\Quotes\Models\QuoteSignature;
 use Modules\Quotes\Services\QuoteService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
 #[CoversClass(QuoteService::class)]
@@ -19,6 +20,7 @@ class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
     private const VALID_PNG_DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
 
     #[Test]
+    #[Group('crud')]
     public function it_stores_a_captured_signature_on_a_quote(): void
     {
         /* Arrange */
@@ -39,6 +41,7 @@ class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('crud')]
     public function it_links_a_signature_to_a_user_when_a_user_id_is_provided(): void
     {
         /* Arrange */
@@ -62,6 +65,7 @@ class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('crud')]
     public function it_reports_a_quote_as_unsigned_when_no_signature_has_been_captured(): void
     {
         /* Arrange */
@@ -75,6 +79,7 @@ class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('crud')]
     public function it_reports_a_quote_as_signed_after_a_signature_is_captured(): void
     {
         /* Arrange */
@@ -90,6 +95,7 @@ class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('crud')]
     public function it_does_not_change_the_quote_status_when_a_signature_is_captured(): void
     {
         /* Arrange */
@@ -104,6 +110,7 @@ class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('crud')]
     public function it_throws_when_the_signature_data_is_not_a_valid_base64_image(): void
     {
         /* Arrange */
@@ -116,6 +123,21 @@ class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
     }
 
     #[Test]
+    #[Group('crud')]
+    public function it_throws_when_the_payload_is_valid_base64_but_not_actually_an_image(): void
+    {
+        /* Arrange */
+        Storage::fake(config('filament.default_filesystem_disk'));
+        $quote     = Quote::factory()->for($this->company)->create();
+        $notAnImage = 'data:image/png;base64,' . base64_encode('this is not image bytes');
+
+        /* Act & Assert */
+        $this->expectException(InvalidArgumentException::class);
+        app(QuoteService::class)->captureSignature($quote, $notAnImage, 'Jane Client');
+    }
+
+    #[Test]
+    #[Group('crud')]
     public function it_supports_capturing_more_than_one_signature_on_the_same_quote(): void
     {
         /* Arrange */

--- a/resources/lang/en/ip.php
+++ b/resources/lang/en/ip.php
@@ -576,6 +576,7 @@ return [
     'quote_pre_password'              => 'Quote standard PDF password (optional)',
     'quote_rejected'                  => 'This quote has been rejected',
     'quote_sent'                      => 'This quote has been sent',
+    'quote_signature_invalid_format'  => 'The signature data must be a base64-encoded image.',
     'quote_status'                    => 'Status',
     'quote_status_approved'           => 'Approved',
     'quote_status_draft'              => 'Draft',

--- a/resources/lang/en/ip.php
+++ b/resources/lang/en/ip.php
@@ -577,6 +577,7 @@ return [
     'quote_rejected'                  => 'This quote has been rejected',
     'quote_sent'                      => 'This quote has been sent',
     'quote_signature_invalid_format'  => 'The signature data must be a base64-encoded image.',
+    'quote_signature_storage_failed'  => 'The signature could not be saved. Please try again.',
     'quote_status'                    => 'Status',
     'quote_status_approved'           => 'Approved',
     'quote_status_draft'              => 'Draft',


### PR DESCRIPTION
# Pull Request Checklist  
## Checklist  
- [x] My code follows the code formatting guidelines.  
- [x] I have tested my changes locally.  
- [x] I selected the appropriate branch for this PR.  
- [x] I have rebased my changes on top of the selected branch.  
- [ ] I included relevant documentation updates if necessary.  
- [x] I have an accompanying issue ID for this pull request.  

---

## Description  
Adds the backend/storage layer for capturing a client signature on a quote: a `quote_signatures` table (one row per signature, so multi-signer support can be added later without a schema rewrite), a `QuoteSignature` model, `Quote::signatures()` / `Quote::isSigned()`, and `QuoteService::captureSignature()`, which decodes a base64 image data URL and stores it on the configured Filament filesystem disk rather than inline in the database. Capturing a signature does not change the quote's status. Covered by 7 new feature tests in `QuoteSignatureCaptureTest`.

This PR does **not** include a public/guest-facing quote view for clients to actually sign from — that route/controller/blade surface doesn't exist anywhere in the app yet and is being scoped as a separate issue. It also does not render the signature onto the quote PDF, and does not build the multi-approver (3+ linked users) workflow described in the original issue — that's intentionally descoped to a single client signature for this pass.

---

## Related Issue(s)  
Part of #97

---

## Motivation and Context  
The original issue asked for multi-user e-signature approval on quotes, which isn't grounded in anything that exists in the codebase today (no approvers concept, no public quote view, no e-signature package). This PR scopes down to a single client signature and lays the storage/service foundation for it.

---

## Issue Type (Check one or more)  
- [ ] Bugfix  
- [x] Improvement of an existing feature  
- [x] New feature  

---

## Screenshots 
N/A 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to capture and store signatures on quotes.
  * Quotes now indicate whether they have been signed.
  * Supports multiple signatures per quote with signer and audit details.
  * Added validation for supported base64-encoded image signatures.

* **Bug Fixes**
  * Preserves the quote’s existing status when a signature is captured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->