### PR TITLE
fix(ci): build frontend assets before running PHPUnit

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -42,6 +42,23 @@ jobs:
           php-extensions: 'mbstring, bcmath, pdo_mysql'
           composer-flags: '--no-progress --prefer-dist --optimize-autoloader'
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build frontend assets
+        # Feature tests render real Blade views with @vite(...) directives
+        # (e.g. GuestQuoteViewTest exercises resources/css/guest.css) — without
+        # a built manifest those fail with "Unable to locate file in Vite
+        # manifest", not a PHP bug. quickstart.yml already builds assets before
+        # its own artisan test run for the same reason; mirror that here.
+        run: yarn build
+
       - name: Prepare Laravel environment
         run: |
           cp .env.testing.example .env.testing


### PR DESCRIPTION
## Summary
- `phpunit.yml` had no Node/yarn/build step, unlike its sibling `quickstart.yml`
- Feature tests that render real Blade views with `@vite(...)` (e.g. `GuestQuoteViewTest`, which exercises `resources/css/guest.css` from the guest quote-signing feature) fail with "Unable to locate file in Vite manifest" on a fresh checkout with no built assets — not a PHP bug, just a missing build step
- Confirmed locally: rebuilding assets alone (no source change) turned the 5 previously-failing `GuestQuoteViewTest` cases green

## Test plan
- [x] Ran `GuestQuoteViewTest` locally after rebuilding Vite assets — 14/14 pass
- [x] Mirrors the existing Node/yarn/build step ordering already used in `quickstart.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated test workflow to use Node.js 22.
  * Added frontend dependency installation and asset building before running tests.
  * Improved test environment preparation for Laravel projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->