### PR TITLE
test(ci): permanent audit gate for CI jobs missing a frontend build step

### DIFF
--- a/Modules/Clients/Models/Relation.php
+++ b/Modules/Clients/Models/Relation.php
@@ -117,6 +117,7 @@ class Relation extends Model
         return $this->morphMany(Communication::class, 'communicationable');
     }
 
+    /** @return MorphMany<Communication, $this> */
     public function ccEmailCommunications(): MorphMany
     {
         return $this->communications()->whereIn('communication_type', CommunicationType::ccTypes());

--- a/Modules/Core/Enums/MailType.php
+++ b/Modules/Core/Enums/MailType.php
@@ -7,7 +7,7 @@ use Modules\Core\Contracts\LabeledEnum;
 enum MailType: string implements LabeledEnum
 {
     case REMINDER = 'reminder';
-    case SENT = 'sent';
+    case SENT     = 'sent';
 
     public static function values(): array
     {
@@ -18,7 +18,7 @@ enum MailType: string implements LabeledEnum
     {
         return match ($this) {
             self::REMINDER => 'Reminder',
-            self::SENT => 'Sent',
+            self::SENT     => 'Sent',
         };
     }
 
@@ -26,7 +26,7 @@ enum MailType: string implements LabeledEnum
     {
         return match ($this) {
             self::REMINDER => 'warning',
-            self::SENT => 'success',
+            self::SENT     => 'success',
         };
     }
 }

--- a/Modules/Core/Models/Company.php
+++ b/Modules/Core/Models/Company.php
@@ -5,7 +5,6 @@ namespace Modules\Core\Models;
 use Filament\Models\Contracts\HasCurrentTenantLabel;
 use Filament\Models\Contracts\HasName;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -301,7 +300,7 @@ class Company extends Model implements HasName, HasCurrentTenantLabel
     | Factory
     |--------------------------------------------------------------------------
     */
-    protected static function newFactory(): Factory
+    protected static function newFactory(): CompanyFactory
     {
         return CompanyFactory::new();
     }

--- a/Modules/Core/Tests/Unit/CiWorkflowAssetBuildAuditTest.php
+++ b/Modules/Core/Tests/Unit/CiWorkflowAssetBuildAuditTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Modules\Core\Tests\Unit;
+
+use Modules\Core\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * mind-the-gap: CI workflow "required precondition" audit.
+ *
+ * Real incident this guards against: `phpunit.yml` ran `php artisan test`
+ * with no Node/yarn/build step at all, while its sibling `quickstart.yml`
+ * built frontend assets first. Feature tests that do a real HTTP request
+ * into a Blade view calling `@vite(...)` (e.g. `GuestQuoteViewTest`, via
+ * `resources/css/guest.css`) fail with "Unable to locate file in Vite
+ * manifest" on a clean checkout as a result — not a real test failure, a
+ * missing precondition that only one of two near-identical workflows had.
+ *
+ * Asserts every workflow job that runs PHP tests also builds frontend
+ * assets first, unless explicitly listed in KNOWN_EXEMPT_JOBS with a reason
+ * — same "record it or it's a bug" discipline as
+ * FormDbConstraintAuditTest / FormDbGapKnownExceptions.
+ */
+class CiWorkflowAssetBuildAuditTest extends AbstractTestCase
+{
+    /** "<workflow-file>:<job-key>" => reason a stranger could evaluate. */
+    private const array KNOWN_EXEMPT_JOBS = [
+        'smoke.yml:smoke'                                  => "Only runs #[Group('smoke')] tests — Filament resource CRUD driven through Livewire::test(), which mounts the component directly and never renders the outer @vite-using layout via a real HTTP request.",
+        'composer-update.yml:update-composer-dependencies' => 'Its smoke-test step runs phpunit.smoke.xml, which filters to the same smoke group as smoke.yml above, for the same reason.',
+    ];
+
+    #[Test]
+    public function every_php_test_job_builds_frontend_assets_first_or_is_a_known_exception(): void
+    {
+        $violations = [];
+
+        foreach (glob(base_path('.github/workflows/*.yml')) as $file) {
+            $workflow = Yaml::parseFile($file);
+            $filename = basename($file);
+
+            foreach ($workflow['jobs'] ?? [] as $jobKey => $job) {
+                $runsPhpTests    = false;
+                $buildsAssets    = false;
+                $testStepReached = false;
+
+                foreach ($job['steps'] ?? [] as $step) {
+                    $run = $step['run'] ?? '';
+
+                    if ( ! $testStepReached && (str_contains($run, 'artisan test') || str_contains($run, 'vendor/bin/phpunit'))) {
+                        $runsPhpTests    = true;
+                        $testStepReached = true;
+                    }
+
+                    if ( ! $testStepReached && (str_contains($run, 'yarn build') || str_contains($run, 'npm run build'))) {
+                        $buildsAssets = true;
+                    }
+                }
+
+                if ( ! $runsPhpTests || $buildsAssets) {
+                    continue;
+                }
+
+                $key = "{$filename}:{$jobKey}";
+
+                if ( ! array_key_exists($key, self::KNOWN_EXEMPT_JOBS)) {
+                    $violations[] = $key;
+                }
+            }
+        }
+
+        self::assertSame(
+            [],
+            $violations,
+            'These CI jobs run PHP tests without building frontend assets first — add a '
+                . "'yarn build' step before the test step, or add a reasoned entry to "
+                . 'KNOWN_EXEMPT_JOBS: ' . implode(', ', $violations),
+        );
+    }
+
+    #[Test]
+    public function every_known_exempt_job_still_exists(): void
+    {
+        $stale = [];
+
+        foreach (array_keys(self::KNOWN_EXEMPT_JOBS) as $key) {
+            [$filename, $jobKey] = explode(':', $key, 2);
+            $path                = base_path(".github/workflows/{$filename}");
+
+            if ( ! is_file($path)) {
+                $stale[] = $key;
+
+                continue;
+            }
+
+            $workflow = Yaml::parseFile($path);
+
+            if ( ! array_key_exists($jobKey, $workflow['jobs'] ?? [])) {
+                $stale[] = $key;
+            }
+        }
+
+        self::assertSame(
+            [],
+            $stale,
+            'KNOWN_EXEMPT_JOBS references a workflow file or job that no longer exists — remove the stale entry: '
+                . implode(', ', $stale),
+        );
+    }
+}

--- a/Modules/Invoices/Tests/Feature/CompanyRenameInvoicePreviewTest.php
+++ b/Modules/Invoices/Tests/Feature/CompanyRenameInvoicePreviewTest.php
@@ -105,7 +105,7 @@ class CompanyRenameInvoicePreviewTest extends AbstractCompanyPanelTestCase
 
         Filament::setCurrentPanel(Filament::getPanel('admin'));
 
-        $formData = $company->only(['search_code', 'name', 'slug', 'vat_number', 'id_number', 'coc_number']);
+        $formData         = $company->only(['search_code', 'name', 'slug', 'vat_number', 'id_number', 'coc_number']);
         $formData['name'] = $newName;
 
         Livewire::actingAs($superAdmin)

--- a/Modules/Invoices/Tests/Unit/InvoiceCompanySnapshotTest.php
+++ b/Modules/Invoices/Tests/Unit/InvoiceCompanySnapshotTest.php
@@ -26,10 +26,10 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         $this->company->update([
-            'name'        => 'ACME Corp',
-            'vat_number'  => 'BE0123456789',
-            'id_number'   => 'ID-1',
-            'coc_number'  => 'COC-1',
+            'name'       => 'ACME Corp',
+            'vat_number' => 'BE0123456789',
+            'id_number'  => 'ID-1',
+            'coc_number' => 'COC-1',
         ]);
         $customer = Relation::factory()->for($this->company)->customer()->create();
 
@@ -190,12 +190,12 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
         // invoices.company_id with onDelete('cascade'), so a persisted invoice
         // can never actually outlive its company row.)
         $invoice = Invoice::factory()->for($this->company)->make([
-            'company_id'          => 999999999,
-            'customer_id'         => 999999999,
-            'company_name'        => null,
-            'company_vat_number'  => null,
-            'company_id_number'   => null,
-            'company_coc_number'  => null,
+            'company_id'         => 999999999,
+            'customer_id'        => 999999999,
+            'company_name'       => null,
+            'company_vat_number' => null,
+            'company_id_number'  => null,
+            'company_coc_number' => null,
         ]);
 
         /* Act */
@@ -203,18 +203,18 @@ class InvoiceCompanySnapshotTest extends AbstractCompanyPanelTestCase
 
         /* Assert */
         $this->assertIsString($html);
-        $this->assertNotSame('', trim($html));
+        $this->assertNotSame('', mb_trim($html));
     }
 
     private function invoicePayload(Relation $customer): array
     {
         return [
-            'customer_id'              => $customer->getKey(),
-            'invoice_number'           => null,
-            'invoice_status'           => InvoiceStatus::DRAFT->value,
-            'invoiced_at'              => '2026-01-01',
-            'invoice_due_at'           => '2026-01-31',
-            'invoice_item_subtotal'    => 100,
+            'customer_id'           => $customer->getKey(),
+            'invoice_number'        => null,
+            'invoice_status'        => InvoiceStatus::DRAFT->value,
+            'invoiced_at'           => '2026-01-01',
+            'invoice_due_at'        => '2026-01-31',
+            'invoice_item_subtotal' => 100,
         ];
     }
 }

--- a/Modules/Quotes/Models/Quote.php
+++ b/Modules/Quotes/Models/Quote.php
@@ -22,32 +22,32 @@ use Modules\Quotes\Database\Factories\QuoteFactory;
 use Modules\Quotes\Enums\QuoteStatus;
 
 /**
- * @property int                    $id
- * @property int                    $company_id
- * @property int                    $prospect_id
- * @property int|null               $numbering_id
- * @property int                    $user_id
- * @property string                 $quote_number
- * @property QuoteStatus            $quote_status
- * @property Carbon|null            $quoted_at
- * @property Carbon|null            $quote_expires_at
- * @property float                  $quote_discount_amount
- * @property float                  $quote_discount_percent
- * @property float|null             $item_tax_total
- * @property float                  $quote_item_subtotal
- * @property float                  $quote_tax_total
- * @property float                  $quote_total
- * @property string|null            $quote_password
- * @property string|null            $url_key
- * @property string|null            $template
- * @property string|null            $summary
- * @property string|null            $terms
- * @property string|null            $footer
- * @property Company                $company
- * @property Numbering|null         $numbering
- * @property Relation               $relation
- * @property User                   $user
- * @property Collection|QuoteItem[] $quote_items
+ * @property int                         $id
+ * @property int                         $company_id
+ * @property int                         $prospect_id
+ * @property int|null                    $numbering_id
+ * @property int                         $user_id
+ * @property string                      $quote_number
+ * @property QuoteStatus                 $quote_status
+ * @property Carbon|null                 $quoted_at
+ * @property Carbon|null                 $quote_expires_at
+ * @property float                       $quote_discount_amount
+ * @property float                       $quote_discount_percent
+ * @property float|null                  $item_tax_total
+ * @property float                       $quote_item_subtotal
+ * @property float                       $quote_tax_total
+ * @property float                       $quote_total
+ * @property string|null                 $quote_password
+ * @property string|null                 $url_key
+ * @property string|null                 $template
+ * @property string|null                 $summary
+ * @property string|null                 $terms
+ * @property string|null                 $footer
+ * @property Company                     $company
+ * @property Numbering|null              $numbering
+ * @property Relation                    $relation
+ * @property User                        $user
+ * @property Collection|QuoteItem[]      $quote_items
  * @property Collection|QuoteSignature[] $signatures
  */
 class Quote extends Model
@@ -117,6 +117,7 @@ class Quote extends Model
         return $this->hasMany(QuoteItem::class, 'quote_id');
     }
 
+    /** @return HasMany<QuoteSignature, $this> */
     public function signatures(): HasMany
     {
         return $this->hasMany(QuoteSignature::class, 'quote_id');

--- a/Modules/Quotes/Models/QuoteSignature.php
+++ b/Modules/Quotes/Models/QuoteSignature.php
@@ -12,18 +12,18 @@ use Modules\Core\Traits\BelongsToCompany;
 use Modules\Quotes\Database\Factories\QuoteSignatureFactory;
 
 /**
- * @property int          $id
- * @property int          $company_id
- * @property int          $quote_id
- * @property int|null     $user_id
- * @property string       $signer_name
- * @property string       $signature_disk
- * @property string       $signature_path
- * @property Carbon       $signed_at
- * @property string|null  $ip_address
- * @property string|null  $user_agent
- * @property Quote        $quote
- * @property User|null    $user
+ * @property int         $id
+ * @property int         $company_id
+ * @property int         $quote_id
+ * @property int|null    $user_id
+ * @property string      $signer_name
+ * @property string      $signature_disk
+ * @property string      $signature_path
+ * @property Carbon      $signed_at
+ * @property string|null $ip_address
+ * @property string|null $user_agent
+ * @property Quote       $quote
+ * @property User|null   $user
  */
 class QuoteSignature extends Model
 {

--- a/Modules/Quotes/Services/QuoteService.php
+++ b/Modules/Quotes/Services/QuoteService.php
@@ -353,14 +353,14 @@ class QuoteService extends BaseService
 
         try {
             return $quote->signatures()->create([
-                'company_id'      => $quote->company_id,
-                'user_id'         => $userId,
-                'signer_name'     => $signerName,
-                'signature_disk'  => $disk,
-                'signature_path'  => $path,
-                'signed_at'       => now(),
-                'ip_address'      => $ipAddress,
-                'user_agent'      => $userAgent === null ? null : Str::limit($userAgent, 255, ''),
+                'company_id'     => $quote->company_id,
+                'user_id'        => $userId,
+                'signer_name'    => $signerName,
+                'signature_disk' => $disk,
+                'signature_path' => $path,
+                'signed_at'      => now(),
+                'ip_address'     => $ipAddress,
+                'user_agent'     => $userAgent === null ? null : Str::limit($userAgent, 255, ''),
             ]);
         } catch (Throwable $e) {
             Storage::disk($disk)->delete($path);
@@ -525,11 +525,11 @@ class QuoteService extends BaseService
             ->first();
 
         $placeholders = [
-            'quote.number'                => $quote->quote_number,
-            'quote.total_formatted'       => number_format((float) $quote->quote_total, 2),
-            'quote.expires_at_formatted'  => DateHelpers::formatDate($quote->quote_expires_at),
-            'customer.name'               => $quote->prospect?->company_name,
-            'company.name'                => $quote->company?->name,
+            'quote.number'               => $quote->quote_number,
+            'quote.total_formatted'      => number_format((float) $quote->quote_total, 2),
+            'quote.expires_at_formatted' => DateHelpers::formatDate($quote->quote_expires_at),
+            'customer.name'              => $quote->prospect?->company_name,
+            'company.name'               => $quote->company?->name,
         ];
 
         $defaultSubject = trans('ip.email_quote_default_subject', ['number' => $quote->quote_number]);

--- a/Modules/Quotes/Tests/Feature/EmailQuoteActionTest.php
+++ b/Modules/Quotes/Tests/Feature/EmailQuoteActionTest.php
@@ -238,11 +238,11 @@ class EmailQuoteActionTest extends AbstractCompanyPanelTestCase
 
         /** @var Quote $quote */
         $quote = Quote::factory()->for($this->company)->create(array_merge([
-            'quote_number' => 'QUO-987654',
-            'prospect_id'  => $prospect->id,
-            'user_id'      => $this->user->id,
-            'quote_status' => QuoteStatus::SENT,
-            'quoted_at'    => '2025-05-10',
+            'quote_number'     => 'QUO-987654',
+            'prospect_id'      => $prospect->id,
+            'user_id'          => $this->user->id,
+            'quote_status'     => QuoteStatus::SENT,
+            'quoted_at'        => '2025-05-10',
             'quote_expires_at' => '2025-06-09',
         ], $attributes));
 

--- a/Modules/Quotes/Tests/Feature/GuestQuoteViewTest.php
+++ b/Modules/Quotes/Tests/Feature/GuestQuoteViewTest.php
@@ -229,9 +229,9 @@ class GuestQuoteViewTest extends AbstractTestCase
     public function it_returns_404_for_a_signature_belonging_to_a_different_quote(): void
     {
         /* Arrange */
-        $quote        = Quote::factory()->for($this->company)->create(['quote_password' => null]);
-        $otherQuote   = Quote::factory()->for($this->company)->create(['quote_password' => null]);
-        $signature    = app(QuoteService::class)->captureSignature($otherQuote, self::VALID_PNG_DATA_URL, 'Jane Client');
+        $quote      = Quote::factory()->for($this->company)->create(['quote_password' => null]);
+        $otherQuote = Quote::factory()->for($this->company)->create(['quote_password' => null]);
+        $signature  = app(QuoteService::class)->captureSignature($otherQuote, self::VALID_PNG_DATA_URL, 'Jane Client');
 
         /* Act */
         $response = $this->get(route('quotes.guest.signature', [$quote, $signature]));

--- a/Modules/Quotes/Tests/Feature/QuotePdfSignatureTest.php
+++ b/Modules/Quotes/Tests/Feature/QuotePdfSignatureTest.php
@@ -73,8 +73,8 @@ class QuotePdfSignatureTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         Storage::fake(config('filament.default_filesystem_disk'));
-        $quote   = Quote::factory()->for($this->company)->create();
-        $service = app(QuoteService::class);
+        $quote     = Quote::factory()->for($this->company)->create();
+        $service   = app(QuoteService::class);
         $signature = $service->captureSignature($quote, self::VALID_PNG_DATA_URL, 'Jane Client');
         Storage::disk($signature->signature_disk)->delete($signature->signature_path);
 

--- a/Modules/Quotes/Tests/Feature/QuoteSignatureCaptureTest.php
+++ b/Modules/Quotes/Tests/Feature/QuoteSignatureCaptureTest.php
@@ -128,7 +128,7 @@ class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         Storage::fake(config('filament.default_filesystem_disk'));
-        $quote     = Quote::factory()->for($this->company)->create();
+        $quote      = Quote::factory()->for($this->company)->create();
         $notAnImage = 'data:image/png;base64,' . base64_encode('this is not image bytes');
 
         /* Act & Assert */
@@ -159,8 +159,8 @@ class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
     {
         /* Arrange */
         Storage::fake(config('filament.default_filesystem_disk'));
-        $quote      = Quote::factory()->for($this->company)->create();
-        $userAgent  = str_repeat('a', 500);
+        $quote     = Quote::factory()->for($this->company)->create();
+        $userAgent = str_repeat('a', 500);
 
         /* Act */
         $signature = app(QuoteService::class)->captureSignature(
@@ -171,7 +171,7 @@ class QuoteSignatureCaptureTest extends AbstractCompanyPanelTestCase
         );
 
         /* Assert */
-        $this->assertSame(255, strlen($signature->fresh()->user_agent));
+        $this->assertSame(255, mb_strlen($signature->fresh()->user_agent));
     }
 
     #[Test]

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -25,7 +25,7 @@ class AppServiceProvider extends ServiceProvider
             'invoice' => Invoice::class,
         ]);
 
-        if (! app()->isLocal()) {
+        if ( ! app()->isLocal()) {
             URL::forceScheme('https');
         }
     }


### PR DESCRIPTION
## Summary
- Follow-up to #742 (`phpunit.yml` was missing a `yarn build` step, causing `GuestQuoteViewTest` to fail on a clean checkout with "Unable to locate file in Vite manifest")
- That gap was found reactively, while debugging an unrelated failure — this adds a permanent, whole-codebase check instead of a one-off fix, per "resolve one, resolve all"
- Audited **every** workflow in `.github/workflows/` by hand for the same pattern first (not just the one that surfaced): `quickstart.yml`, `release.yml` already build assets correctly; `smoke.yml` and `composer-update.yml`'s smoke-test step only run `#[Group('smoke')]` tests, verified to exercise `Livewire::test()` component mounts that never render an `@vite`-using layout via a real HTTP request, so they're genuinely exempt; `pint.yml`, `phpstan.yml`, `docker.yml`, `setup.yml`, `claude.yml`, `crowdin-sync.yml`, `yarn-update.yml` don't run PHP tests at all
- New `CiWorkflowAssetBuildAuditTest` parses every `.github/workflows/*.yml` and asserts any job running `php artisan test` / `vendor/bin/phpunit` also builds frontend assets first, unless listed in a `KNOWN_EXEMPT_JOBS` allowlist with a reason — same discipline as `FormDbGapKnownExceptions::KNOWN_GAPS`

## Test plan
- [x] Passes against the current (fixed) workflows
- [x] Confirmed it fails with the expected diagnostic when reverted to `phpunit.yml`'s pre-fix content (temporarily, locally, not committed)
- [x] Full `Modules/Core/Tests/Unit` suite still green (55/55)